### PR TITLE
feat(publish): add --summary-file option

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -443,6 +443,9 @@
             },
             "continueIfNoMatch": {
               "$ref": "#/$defs/filters/continueIfNoMatch"
+            },
+            "summaryFile": {
+              "$ref": "#/$defs/commandOptions/publish/summaryFile"
             }
           }
         },
@@ -1280,6 +1283,10 @@
         "noVerifyAccess": {
           "type": "boolean",
           "description": "During `lerna publish`, when true, do not verify package read-write access for current npm user."
+        },
+        "summaryFile": {
+          "anyOf": [{ "type": "string" }, { "type": "boolean" }],
+          "description": "Generate a json summary report after all packages have been successfully published, you can pass an optional path for where to save the file."
         },
         "verifyAccess": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-publish-commands.ts
+++ b/packages/cli/src/cli-commands/cli-publish-commands.ts
@@ -127,6 +127,12 @@ export default {
         describe: 'Do not verify package read-write access for current npm user.',
         type: 'boolean',
       },
+      'summary-file': {
+        // generate lerna publish json output.
+        describe:
+          'Generate a json summary report after all packages have been successfully published, you can pass an optional path for where to save the file.',
+        type: 'string',
+      },
       'verify-access': {
         describe: 'Verify package read-write access for current npm user.',
         type: 'boolean',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -168,6 +168,9 @@ export interface PublishCommandOption extends VersionCommandOption {
   /** Do not verify package read-write access for current npm user. */
   noVerifyAccess?: boolean;
 
+  /** Generate a json summary report after all packages have been successfully published, you can pass an optional path for where to save the file. */
+  summaryFile?: boolean | string;
+
   /** proxy for `--no-verify-access` */
   verifyAccess?: boolean;
 

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -89,6 +89,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
     - [`--registry <url>`](#--registry-url)
     - [`--tag-version-prefix`](#--tag-version-prefix)
     - [`--temp-tag`](#--temp-tag)
+    - [`--summary-file <dir>`](#--summary-file)
     - [`--verify-access`](#--verify-access)
     - [`--yes`](#--yes)
   - [`publishConfig` Overrides](#publishconfig-overrides)
@@ -348,6 +349,30 @@ new version(s) to the dist-tag configured by [`--dist-tag`](#--dist-tag-tag) (de
 
 This is not generally necessary, as lerna will publish packages in topological
 order (all dependencies before dependents) by default.
+
+### `--summary-file`
+
+```sh
+# Will create a summary file in the root directory, i.e. `./lerna-publish-summary.json`
+lerna publish --canary --yes --summary-file
+# Will create a summary file in the provided directory, i.e. `./some/other/dir/lerna-publish-summary.json`
+lerna publish --canary --yes --summary-file ./some/other/dir
+```
+
+When run with this flag, a json summary report will be generated after all packages have been successfully published (see below for an example).
+
+```json
+[
+  {
+    "packageName": "package1",
+    "version": "v1.0.1-alpha"
+  },
+  {
+    "packageName": "package2",
+    "version": "v2.0.1-alpha"
+  }
+]
+```
 
 ### `--verify-access`
 

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import crypto from 'crypto';
@@ -296,7 +297,29 @@ export class PublishCommand extends Command<PublishCommandOption> {
     const message: string[] = this.packagesToPublish?.map((pkg) => ` - ${pkg.name}@${pkg.version}`) ?? [];
 
     logOutput('Successfully published:');
-    logOutput(message.join(os.EOL));
+
+    if (this.options.summaryFile !== undefined) {
+      // create a json object and output it to a file location.
+      const filePath = this.options.summaryFile
+        ? `${this.options.summaryFile}/lerna-publish-summary.json`
+        : './lerna-publish-summary.json';
+      const jsonObject = this.packagesToPublish.map((pkg) => {
+        return {
+          packageName: pkg.name,
+          version: pkg.version,
+        };
+      });
+      logOutput(jsonObject);
+      try {
+        fs.writeFileSync(filePath, JSON.stringify(jsonObject));
+        logOutput('Publish summary created: ', filePath);
+      } catch (error) {
+        logOutput('Failed to create the summary report', error);
+      }
+    } else {
+      const message = this.packagesToPublish.map((pkg) => ` - ${pkg.name}@${pkg.version}`);
+      logOutput(message.join(os.EOL));
+    }
 
     this.logger.success('published', '%d %s', count, count === 1 ? 'package' : 'packages');
   }


### PR DESCRIPTION
- Outputs the packages and versions from publishing to a JSON file.

## Description

As per Lerna [PR 2653](https://github.com/lerna/lerna/pull/2653)

> When `lerna publish --summary-file <path-to-file>` It'll create a file to easily see what's been published and what version has been. Happy to rename --summary-file to something more meaningful
> 
> ```js
> [
>     {
>         "packageName": "package1",
>         "version": "v1.0.1-alpha"
>     },
>     {
>         "packageName": "package2",
>         "version": "v2.0.1-alpha"
>     }
> ]
> ```

## Motivation and Context
As per Lerna PR

> When creating a release you don't get a definitive and easy way to see whats changed in a nice output especially if its a pre-release(canary), So added the ability to output a JSON object to a file which would look something like this. #2053
> 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
