### PR TITLE
feat(version): allow passing multiple npmClientArgs as CSV

### DIFF
--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -98,6 +98,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--no-private`](#--no-private)
     - [`--no-push`](#--no-push)
     - [`--no-manually-update-root-lockfile`](#--no-manually-update-root-lockfile)
+    - [`--npm-client-args`](#--npm-client-args)
     - [`--preid`](#--preid)
     - [`--remote-client <type>`](#--remote-client-type)
     - [`--signoff-git-commit`](#--signoff-git-commit) (new)
@@ -583,6 +584,40 @@ lerna version --no-manually-update-root-lockfile
 ```
 
 A newer and better option is to this use the new flag [--sync-workspace-lock](#--sync-workspace-lock) which will to rely on your package manager client to do the work (via `install lockfile-only`) which is a lot more reliable, future proof and requires a lot less code in Lerna-Lite itself.
+
+### `--npm-client-args`
+
+This option allows arguments to be passed to the `npm install` that `lerna version` performs to update the lockfile (when `--sync-workspace-lock` is enabled).
+
+For example:
+
+```sh
+lerna version 3.3.3 --sync-workspace-lock --npm-client-args=--legacy-peer-deps
+lerna version 3.3.3 --sync-workspace-lock --npm-client-args="--legacy-peer-deps,--force"
+lerna version 3.3.3 --sync-workspace-lock --npm-client-args="--legacy-peer-deps --force"
+```
+
+This can also be set in `lerna.json`:
+
+```json
+{
+  ...
+  "npmClientArgs": ["--legacy-peer-deps", "--production"]
+}
+```
+
+or specifically for the version command:
+
+```json
+{
+  ...
+  "command": {
+    "version": {
+      "npmClientArgs": ["--legacy-peer-deps", "--production"]
+    }
+  }
+}
+```
 
 ### `--preid`
 

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -153,6 +153,20 @@ describe('run install lockfile-only', () => {
       expect(execSpy).toHaveBeenCalledWith('npm', ['install', '--package-lock-only', '--legacy-peer-deps'], { cwd });
       expect(lockFileOutput).toBe('package-lock.json');
     });
+
+    it(`should update project root lockfile by calling npm script "npm install --legacy-peer-deps,--force" with multiple npm client arguments provided as CSV`, async () => {
+      const execSpy = jest.spyOn(core, 'exec');
+      const execSyncSpy = jest.spyOn(core, 'execSync').mockReturnValue('8.5.0');
+      const cwd = await initFixture('lockfile-version2');
+
+      const lockFileOutput = await runInstallLockFileOnly('npm', cwd, ['--legacy-peer-deps,--force']);
+
+      expect(execSyncSpy).toHaveBeenCalled();
+      expect(execSpy).toHaveBeenCalledWith('npm', ['install', '--package-lock-only', '--legacy-peer-deps', '--force'], {
+        cwd,
+      });
+      expect(lockFileOutput).toBe('package-lock.json');
+    });
   });
 
   describe('pnpm client', () => {

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -127,10 +127,15 @@ export function updateNpmLockFileVersion2(obj: any, pkgName: string, newVersion:
 export async function runInstallLockFileOnly(
   npmClient: 'npm' | 'pnpm' | 'yarn',
   cwd: string,
-  npmClientArgs: string[]
+  npmArgs: string[]
 ): Promise<string | undefined> {
   let inputLockfileName = '';
   let outputLockfileName: string | undefined;
+  const npmClientArgsRaw = npmArgs || [];
+  const npmClientArgs: string[] = npmClientArgsRaw.reduce(
+    (args, arg) => args.concat(arg.split(/\s|,/)),
+    [] as string[]
+  );
 
   switch (npmClient) {
     case 'pnpm':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow passing multiple `npmClientArgs` to `lerna version`, for example
```sh
lerna version 3.3.3 --sync-workspace-lock --npm-client-args="--legacy-peer-deps,--force"
```

## Motivation and Context

Keep in sync with Lerna and follow extra commits in Lerna [PR 3434](https://github.com/lerna/lerna/pull/3434)

## How Has This Been Tested?

added necessary unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
