### PR TITLE
feat(version): support custom command for git tag

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -620,6 +620,9 @@
             "commitHooks": {
               "$ref": "#/$defs/commandOptions/version/commitHooks"
             },
+            "gitTagCommand": {
+              "$ref": "#/$defs/commandOptions/version/gitTagCommand"
+            },
             "noGitTagVersion": {
               "$ref": "#/$defs/commandOptions/version/noGitTagVersion"
             },
@@ -1395,6 +1398,10 @@
         "commitHooks": {
           "type": "boolean",
           "description": "During `lerna version`, when true, run git commit hooks when committing version changes."
+        },
+        "gitTagCommand": {
+          "type": "string",
+          "description": "During `lerna version`, allows users to specify a custom command to be used when applying git tags."
         },
         "noGitTagVersion": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -165,6 +165,11 @@ export default {
         hidden: true,
         type: 'boolean',
       },
+      'git-tag-command': {
+        describe:
+          'Allows users to specify a custom command to be used when applying git tags. For example, this may be useful for providing a wrapper command in CI/CD pipelines that have no direct write access.',
+        type: 'string',
+      },
       'no-git-tag-version': {
         describe: 'Do not commit or tag version changes.',
         type: 'boolean',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -252,6 +252,12 @@ export interface VersionCommandOption {
   /** @deprecated option was renamed to `--dry-run`, @see dryRun */
   gitDryRun?: boolean;
 
+  /**
+   * Allows users to specify a custom command to be used when applying git tags.
+   * For example, this may be useful for providing a wrapper command in CI/CD pipelines that have no direct write access.
+   */
+  gitTagCommand?: string;
+
   /** Defaults to 'origin', push git changes to the specified remote. */
   gitRemote: string;
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -85,6 +85,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--create-release <type>`](#--create-release-type)
     - [`--exact`](#--exact)
     - [`--force-publish`](#--force-publish)
+    - [`--git-tag-command <cmd>`](#--git-tag-command-cmd) (new)
     - [`--dry-run`](#--dry-run) (new)
     - [`--git-remote <name>`](#--git-remote-name)
     - [`--ignore-changes`](#--ignore-changes)
@@ -438,6 +439,26 @@ Displays the git command that would be performed without actually executing it, 
 
 ```sh
 $ lerna run watch --dry-run
+```
+
+### `--git-tag-command <cmd>`
+
+Allows users to specify a custom command to be used when applying git tags. For example, this may be useful for providing a wrapper command in CI/CD pipelines that have no direct write access.
+
+```sh
+lerna version --git-tag-command "git gh-tag %s -m %s"
+```
+
+This can also be configured in `lerna.json`.
+
+```json
+{
+  "command": {
+    "version": {
+      "gitTagCommand": "git gh-tag %s -m %s"
+    }
+  }
+}
 ```
 
 ### `--git-remote <name>`

--- a/packages/version/src/__tests__/git-tag.spec.ts
+++ b/packages/version/src/__tests__/git-tag.spec.ts
@@ -17,7 +17,7 @@ describe('gitTag', () => {
     const tag = 'v1.2.3';
     const opts = { cwd: 'default' };
 
-    await gitTag(tag, {} as any, opts);
+    await gitTag(tag, {}, opts);
 
     expect(exec).toHaveBeenLastCalledWith('git', ['tag', tag, '-m', tag], opts, false);
   });
@@ -38,5 +38,14 @@ describe('gitTag', () => {
     await gitTag(tag, { forceGitTag: true } as any, opts);
 
     expect(exec).toHaveBeenLastCalledWith('git', ['tag', tag, '-m', tag, '--force'], opts, false);
+  });
+
+  it('creates an annotated git tag using the wrapper arguments', async () => {
+    const tag = 'v1.2.4';
+    const opts = { cwd: 'default' };
+
+    await gitTag(tag, {}, opts, 'git-wrapper gh-tag %s -m %s');
+
+    expect(exec).toHaveBeenLastCalledWith('git-wrapper', ['gh-tag', tag, '-m', tag], opts, false);
   });
 });

--- a/packages/version/src/lib/git-tag.ts
+++ b/packages/version/src/lib/git-tag.ts
@@ -8,19 +8,26 @@ import { GitTagOption } from '../types';
  * @param {{ forceGitTag: boolean; signGitTag: boolean; }} gitOpts
  * @param {import('@lerna/child-process').ExecOpts} opts
  */
-export function gitTag(tag: string, { forceGitTag, signGitTag }: GitTagOption, opts: ExecOpts, dryRun = false) {
-  log.silly('gitTag', tag);
+export function gitTag(
+  tag: string,
+  { forceGitTag, signGitTag }: GitTagOption,
+  opts: ExecOpts,
+  command = 'git tag %s -m %s',
+  dryRun = false
+) {
+  log.silly('gitTag', tag, command);
 
-  const args = ['tag', tag, '-m', tag];
+  const [cmd, ...args] = command.split(' ');
+  const interpolatedArgs = args.map((arg) => arg.replace(/%s/, tag));
 
   if (forceGitTag) {
-    args.push('--force');
+    interpolatedArgs.push('--force');
   }
 
   if (signGitTag) {
-    args.push('--sign');
+    interpolatedArgs.push('--sign');
   }
 
-  log.verbose('git', args.join(' '));
-  return exec('git', args, opts, dryRun);
+  log.verbose(cmd, interpolatedArgs.toString());
+  return exec(cmd, interpolatedArgs, opts, dryRun);
 }

--- a/packages/version/src/types/index.ts
+++ b/packages/version/src/types/index.ts
@@ -6,6 +6,6 @@ export interface GitCommitOption {
 }
 
 export interface GitTagOption {
-  forceGitTag: boolean;
-  signGitTag: boolean;
+  forceGitTag?: boolean;
+  signGitTag?: boolean;
 }

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -806,7 +806,9 @@ export class VersionCommand extends Command<VersionCommandOption> {
     const message = tags.reduce((msg, tag) => `${msg}${os.EOL} - ${tag}`, `${subject}${os.EOL}`);
 
     await gitCommit(message, this.gitOpts, this.execOpts, this.options.dryRun);
-    await Promise.all(tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts, this.options.dryRun)));
+    await Promise.all(
+      tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand, this.options.dryRun))
+    );
 
     return tags;
   }
@@ -817,7 +819,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
     const message = this.options.message ? this.options.message.replace(/%s/g, tag).replace(/%v/g, version) : tag;
 
     await gitCommit(message, this.gitOpts, this.execOpts, this.options.dryRun);
-    await gitTag(tag, this.gitOpts, this.execOpts, this.options.dryRun);
+    await gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand, this.options.dryRun);
 
     return [tag];
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna [PR 2760](https://github.com/lerna/lerna/pull/2760)

> Added support to override the executed command for `git tag` via CLI options and `lerna.json` entry.

## Motivation and Context

As per Lerna PR

> Some CD/CI systems have no direct write access to the repository and are not able to tag the normal way via git. An optional wrapper command/alias might be defined.

## How Has This Been Tested?

> * Added  unit-tests
> * `./core/lerna/cli.js version -h` shows new option

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
