### PR TITLE
fix(core): more detailed error message when version cannot be found

### DIFF
--- a/packages/core/src/__tests__/command.spec.ts
+++ b/packages/core/src/__tests__/command.spec.ts
@@ -384,6 +384,36 @@ describe('core-command', () => {
         })
       );
     });
+
+    it('throws ENOVERSION when lerna.json is empty', async () => {
+      const cwd = await initFixture('basic');
+
+      const lernaConfigPath = path.join(cwd, 'lerna.json');
+      await fs.writeJson(lernaConfigPath, {});
+
+      await expect(testFactory({ cwd })).rejects.toThrow(
+        expect.objectContaining({
+          prefix: 'ENOVERSION',
+        })
+      );
+    });
+
+    it('throws ENOVERSION when no version property exists in lerna.json', async () => {
+      const cwd = await initFixture('basic');
+
+      const lernaConfigPath = path.join(cwd, 'lerna.json');
+      const lernaConfig = await fs.readJson(lernaConfigPath);
+      delete lernaConfig.version;
+      await fs.writeJson(lernaConfigPath, {
+        ...lernaConfig,
+      });
+
+      await expect(testFactory({ cwd })).rejects.toThrow(
+        expect.objectContaining({
+          prefix: 'ENOVERSION',
+        })
+      );
+    });
   });
 
   describe('loglevel with verbose option true', () => {

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -285,11 +285,12 @@ export class Command<T extends AvailableCommandOption> {
       );
     }
 
+    if (this.project.configNotFound) {
+      throw new ValidationError('ENOLERNA', '`lerna.json` does not exist, have you run `lerna init`?');
+    }
+
     if (!this.project.version) {
-      throw new ValidationError(
-        'ENOLERNA',
-        'No `lerna.json` file exist, please create one in the root of your project.'
-      );
+      throw new ValidationError('ENOVERSION', 'Required property version does not exist in `lerna.json`');
     }
 
     if ((this.options as InitCommandOption).independent && !this.project.isIndependent()) {

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -22,6 +22,7 @@ import { ProjectConfig, RawManifest } from '../models';
  */
 export class Project {
   config: ProjectConfig;
+  configNotFound: boolean;
   rootConfigLocation: string;
   rootPath: string;
   static PACKAGE_GLOB = 'packages/*';
@@ -40,6 +41,7 @@ export class Project {
             // No need to distinguish between missing and empty,
             // saves a lot of noisy guards elsewhere
             config: {},
+            configNotFound: true,
             // path.resolve(".", ...) starts from process.cwd()
             filepath: path.resolve(cwd || '.', 'lerna.json'),
           };
@@ -66,6 +68,7 @@ export class Project {
     }
 
     this.config = loaded?.config;
+    this.configNotFound = loaded?.configNotFound;
     this.rootConfigLocation = loaded?.filepath ?? '';
     this.rootPath = path.dirname(loaded?.filepath ?? '');
 


### PR DESCRIPTION
## Description

As per Lerna [PR 3424](https://github.com/lerna/lerna/pull/3424)

> When running a lerna command and no version is present in lerna.json configuration following error message is printed:
> 
> ```shell
> lerna ERR! ENOLERNA `lerna.json` does not exist, have you run `lerna init`?
> ```
> 
> As described in (https://github.com/lerna/lerna/issues/3311) this is not completely correct.
> 
> Additional check is added during command validation to prove a version is available in lerna.json file. In addition the check for having a lerna configuration (lerna.json) available is adapted to really check for existance of the config file. This is achieved by setting an additional flag configNotFound in the project object during lerna.json retrival.
> 

## Motivation and Context

> Improve error messages for invalid lerna.json to support user finding configuration problems. The issue is described here (https://github.com/lerna/lerna/issues/3311).

## How Has This Been Tested?

> Added a unit test. Manually built a lerna version.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
