### PR TITLE
chore(deps): add rimraf dist to all packages & stay on older version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,10 @@
       enabled: false,
     },
     {
+      packageNames: ['rimraf'],
+      allowedVersions: '3.0.2',
+    },
+    {
       // npm audit seems to prefer 1.2.6 for some reason
       packageNames: ['tacks'],
       allowedVersions: '1.2.6',

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "clean": "rimraf packages/*/dist",
+    "clean": "rimraf packages/dist",
     "clean:tarball": "rimraf packages/**/*.tgz",
-    "build": "pnpm clean && pnpm lint && pnpm -r --stream build",
+    "build": "pnpm lint && pnpm -r --stream build",
     "info-cmd": "lerna info",
     "init-cmd": "lerna init --independent --exact --use-workspaces",
     "changed-cmd": "lerna changed --all",

--- a/packages/changed/package.json
+++ b/packages/changed/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -36,6 +37,7 @@
     "@lerna-lite/listable": "workspace:*"
   },
   "devDependencies": {
+    "rimraf": "^3.0.2",
     "yargs-parser": "^21.1.1"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@types/load-json-file": "^5.1.0",
+    "rimraf": "^3.0.2",
     "yargs-parser": "^21.1.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "/dist"
   ],
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -96,6 +97,7 @@
     "@types/write-json-file": "^3.2.1",
     "@types/write-pkg": "^4.0.0",
     "npm-registry-fetch": "^14.0.3",
+    "rimraf": "^3.0.2",
     "yargs": "^17.6.2",
     "yargs-parser": "^21.1.1"
   },

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -37,6 +38,7 @@
     "execa": "^5.1.1",
     "fs-extra": "^11.1.0",
     "npmlog": "^7.0.1",
+    "rimraf": "^3.0.2",
     "yargs-parser": "^21.1.1"
   }
 }

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -42,6 +43,7 @@
     "@types/p-map": "^2.0.0",
     "fs-extra": "^11.1.0",
     "globby": "^11.1.0",
+    "rimraf": "^3.0.2",
     "yargs": "^17.6.2",
     "yargs-parser": "^21.1.1"
   }

--- a/packages/info/package.json
+++ b/packages/info/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@types/envinfo": "^7.8.1",
     "path": "^0.12.7",
+    "rimraf": "^3.0.2",
     "yargs": "^17.6.2"
   }
 }

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -41,6 +42,7 @@
     "@types/fs-extra": "^11.0.1",
     "@types/p-map": "^2.0.0",
     "@types/write-json-file": "^3.2.1",
+    "rimraf": "^3.0.2",
     "yargs-parser": "^21.1.1"
   }
 }

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -36,6 +37,7 @@
     "@lerna-lite/optional-cmd-common": "workspace:*"
   },
   "devDependencies": {
+    "rimraf": "^3.0.2",
     "yargs-parser": "^21.1.1"
   }
 }

--- a/packages/listable/package.json
+++ b/packages/listable/package.json
@@ -37,6 +37,6 @@
     "columnify": "^1.6.0"
   },
   "devDependencies": {
-    "rimraf": "^4.1.1"
+    "rimraf": "^3.0.2"
   }
 }

--- a/packages/listable/package.json
+++ b/packages/listable/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -34,5 +35,8 @@
     "@lerna-lite/core": "workspace:*",
     "chalk": "^4.1.2",
     "columnify": "^1.6.0"
+  },
+  "devDependencies": {
+    "rimraf": "^4.1.1"
   }
 }

--- a/packages/optional-cmd-common/package.json
+++ b/packages/optional-cmd-common/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -41,6 +42,7 @@
     "@types/node": "^18.11.18",
     "@types/p-map": "^2.0.0",
     "path": "^0.12.7",
+    "rimraf": "^3.0.2",
     "yargs": "^17.6.2"
   }
 }

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -65,6 +66,7 @@
     "@types/semver": "^7.3.13",
     "@types/write-pkg": "^4.0.0",
     "load-json-file": "^6.2.0",
+    "rimraf": "^3.0.2",
     "write-pkg": "^4.0.0",
     "yargs": "^17.6.2",
     "yargs-parser": "^21.1.1"

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -43,6 +44,7 @@
     "globby": "^11.1.0",
     "jest-circus": "^29.3.1",
     "perf_hooks": "^0.0.1",
+    "rimraf": "^3.0.2",
     "yargs": "^17.6.2",
     "yargs-parser": "^21.1.1"
   }

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc --project tsconfig.bundle.json --newLine LF",
     "pack-tarball": "npm pack"
   },
@@ -62,6 +63,7 @@
     "execa": "^5.1.1",
     "fs-extra": "^11.1.0",
     "js-yaml": "^4.1.0",
+    "rimraf": "^3.0.2",
     "write-pkg": "^4.0.0",
     "yargs": "^17.6.2",
     "yargs-parser": "^21.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,13 +401,13 @@ importers:
       '@lerna-lite/core': workspace:*
       chalk: ^4.1.2
       columnify: ^1.6.0
-      rimraf: ^4.1.1
+      rimraf: ^3.0.2
     dependencies:
       '@lerna-lite/core': link:../core
       chalk: 4.1.2
       columnify: 1.6.0
     devDependencies:
-      rimraf: 4.1.1
+      rimraf: 3.0.2
 
   packages/optional-cmd-common:
     specifiers:
@@ -6362,12 +6362,6 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
-
-  /rimraf/4.1.1:
-    resolution: {integrity: sha512-Z4Y81w8atcvaJuJuBB88VpADRH66okZAuEm+Jtaufa+s7rZmIz+Hik2G53kGaNytE7lsfXyWktTmfVz0H9xuDg==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
 
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,12 +109,14 @@ importers:
       '@lerna-lite/core': workspace:*
       '@lerna-lite/list': workspace:*
       '@lerna-lite/listable': workspace:*
+      rimraf: ^3.0.2
       yargs-parser: ^21.1.1
     dependencies:
       '@lerna-lite/core': link:../core
       '@lerna-lite/list': link:../list
       '@lerna-lite/listable': link:../listable
     devDependencies:
+      rimraf: 3.0.2
       yargs-parser: 21.1.1
 
   packages/cli:
@@ -132,6 +134,7 @@ importers:
       load-json-file: ^6.2.0
       npmlog: ^7.0.1
       path: ^0.12.7
+      rimraf: ^3.0.2
       yargs: ^17.6.2
       yargs-parser: ^21.1.1
     dependencies:
@@ -150,6 +153,7 @@ importers:
       yargs: 17.6.2
     devDependencies:
       '@types/load-json-file': 5.1.0
+      rimraf: 3.0.2
       yargs-parser: 21.1.1
 
   packages/core:
@@ -209,6 +213,7 @@ importers:
       path: ^0.12.7
       pify: ^5.0.0
       resolve-from: ^5.0.0
+      rimraf: ^3.0.2
       semver: ^7.3.8
       slash: ^3.0.0
       strong-log-transformer: ^2.1.0
@@ -284,6 +289,7 @@ importers:
       '@types/write-json-file': 3.2.1
       '@types/write-pkg': 4.0.0
       npm-registry-fetch: 14.0.3
+      rimraf: 3.0.2
       yargs: 17.6.2
       yargs-parser: 21.1.1
 
@@ -293,6 +299,7 @@ importers:
       execa: ^5.1.1
       fs-extra: ^11.1.0
       npmlog: ^7.0.1
+      rimraf: ^3.0.2
       yargs-parser: ^21.1.1
     dependencies:
       '@lerna-lite/core': link:../core
@@ -300,6 +307,7 @@ importers:
       execa: 5.1.1
       fs-extra: 11.1.0
       npmlog: 7.0.1
+      rimraf: 3.0.2
       yargs-parser: 21.1.1
 
   packages/exec:
@@ -313,6 +321,7 @@ importers:
       globby: ^11.1.0
       npmlog: ^7.0.1
       p-map: ^4.0.0
+      rimraf: ^3.0.2
       yargs: ^17.6.2
       yargs-parser: ^21.1.1
     dependencies:
@@ -326,6 +335,7 @@ importers:
       '@types/p-map': 2.0.0
       fs-extra: 11.1.0
       globby: 11.1.0
+      rimraf: 3.0.2
       yargs: 17.6.2
       yargs-parser: 21.1.1
 
@@ -335,6 +345,7 @@ importers:
       '@types/envinfo': ^7.8.1
       envinfo: ^7.8.1
       path: ^0.12.7
+      rimraf: ^3.0.2
       yargs: ^17.6.2
     dependencies:
       '@lerna-lite/core': link:../core
@@ -342,6 +353,7 @@ importers:
     devDependencies:
       '@types/envinfo': 7.8.1
       path: 0.12.7
+      rimraf: 3.0.2
       yargs: 17.6.2
 
   packages/init:
@@ -353,6 +365,7 @@ importers:
       fs-extra: ^11.1.0
       p-map: ^4.0.0
       path: ^0.12.7
+      rimraf: ^3.0.2
       write-json-file: ^4.3.0
       yargs-parser: ^21.1.1
     dependencies:
@@ -365,6 +378,7 @@ importers:
       '@types/fs-extra': 11.0.1
       '@types/p-map': 2.0.0
       '@types/write-json-file': 3.2.1
+      rimraf: 3.0.2
       yargs-parser: 21.1.1
 
   packages/list:
@@ -372,12 +386,14 @@ importers:
       '@lerna-lite/core': workspace:*
       '@lerna-lite/listable': workspace:*
       '@lerna-lite/optional-cmd-common': workspace:*
+      rimraf: ^3.0.2
       yargs-parser: ^21.1.1
     dependencies:
       '@lerna-lite/core': link:../core
       '@lerna-lite/listable': link:../listable
       '@lerna-lite/optional-cmd-common': link:../optional-cmd-common
     devDependencies:
+      rimraf: 3.0.2
       yargs-parser: 21.1.1
 
   packages/listable:
@@ -385,10 +401,13 @@ importers:
       '@lerna-lite/core': workspace:*
       chalk: ^4.1.2
       columnify: ^1.6.0
+      rimraf: ^4.1.1
     dependencies:
       '@lerna-lite/core': link:../core
       chalk: 4.1.2
       columnify: 1.6.0
+    devDependencies:
+      rimraf: 4.1.1
 
   packages/optional-cmd-common:
     specifiers:
@@ -399,6 +418,7 @@ importers:
       multimatch: ^5.0.0
       npmlog: ^7.0.1
       path: ^0.12.7
+      rimraf: ^3.0.2
       upath: ^2.0.1
       yargs: ^17.6.2
     dependencies:
@@ -411,6 +431,7 @@ importers:
       '@types/node': 18.11.18
       '@types/p-map': 2.0.0
       path: 0.12.7
+      rimraf: 3.0.2
       yargs: 17.6.2
 
   packages/publish:
@@ -444,6 +465,7 @@ importers:
       path: ^0.12.7
       pify: ^5.0.0
       read-package-json: ^6.0.0
+      rimraf: ^3.0.2
       semver: ^7.3.8
       ssri: ^10.0.1
       tar: ^6.1.13
@@ -484,6 +506,7 @@ importers:
       '@types/semver': 7.3.13
       '@types/write-pkg': 4.0.0
       load-json-file: 6.2.0
+      rimraf: 3.0.2
       write-pkg: 4.0.0
       yargs: 17.6.2
       yargs-parser: 21.1.1
@@ -500,6 +523,7 @@ importers:
       npmlog: ^7.0.1
       p-map: ^4.0.0
       perf_hooks: ^0.0.1
+      rimraf: ^3.0.2
       yargs: ^17.6.2
       yargs-parser: ^21.1.1
     dependencies:
@@ -514,6 +538,7 @@ importers:
       globby: 11.1.0
       jest-circus: 29.3.1
       perf_hooks: 0.0.1
+      rimraf: 3.0.2
       yargs: 17.6.2
       yargs-parser: 21.1.1
 
@@ -545,6 +570,7 @@ importers:
       p-pipe: ^3.1.0
       p-reduce: ^2.1.0
       path: ^0.12.7
+      rimraf: ^3.0.2
       semver: ^7.3.8
       slash: ^3.0.0
       write-json-file: ^4.3.0
@@ -582,6 +608,7 @@ importers:
       execa: 5.1.1
       fs-extra: 11.1.0
       js-yaml: 4.1.0
+      rimraf: 3.0.2
       write-pkg: 4.0.0
       yargs: 17.6.2
       yargs-parser: 21.1.1
@@ -6335,6 +6362,12 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+
+  /rimraf/4.1.1:
+    resolution: {integrity: sha512-Z4Y81w8atcvaJuJuBB88VpADRH66okZAuEm+Jtaufa+s7rZmIz+Hik2G53kGaNytE7lsfXyWktTmfVz0H9xuDg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}


### PR DESCRIPTION
## Description

add `rimraf` npm script to all individual packages

## Motivation and Context

the new version of `rimraf` removes support to Glob patterns, let's stick with previous version in Renovate for now since they might bring in it back in future release

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
