### PR TITLE
fix(watch): glob should work without slash prefix

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -17,9 +17,6 @@
       "changelogIncludeCommitsClientLogin": " - by @%l",
       "changelogHeaderMessage": "## Automate your Workspace Versioning, Publishing & Changelogs with [Lerna-Lite](https://github.com/lerna-lite/lerna-lite) 📦🚀",
       "message": "chore(release): publish new version %v"
-    },
-    "watch": {
-      "glob": "/src/**/*.{ts,tsx}"
     }
   },
   "ignoreChanges": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pack-tarball": "lerna run pack-tarball",
     "pack-tarball:nx": "lerna run pack-tarball --stream --use-nx",
     "preview:watch:build": "lerna watch --no-bail --ignored=\"**/dist\" --scope {@lerna-lite/exec,@lerna-lite/run} -- cross-env-shell lerna run build --scope=$LERNA_PACKAGE_NAME --stream",
-    "preview:watch:files": "lerna watch --bail --glob=\"/src\" --scope {@lerna-lite/watch,@lerna-lite/exec} -- cross-env-shell echo $LERNA_FILE_CHANGES $LERNA_FILE_CHANGE_TYPE in package $LERNA_PACKAGE_NAME\"",
+    "preview:watch:files": "lerna watch --bail --glob=\"src/**.ts\" --scope {@lerna-lite/watch,@lerna-lite/exec} -- cross-env-shell echo $LERNA_FILE_CHANGES $LERNA_FILE_CHANGE_TYPE in package $LERNA_PACKAGE_NAME\"",
     "preview:watch:all": "lerna watch --bail --watch-all-events --scope {@lerna-lite/watch,@lerna-lite/exec} -- cross-env-shell echo \"Changed files $LERNA_FILE_CHANGES $LERNA_FILE_CHANGE_TYPE in package $LERNA_PACKAGE_NAME\"",
     "preview:publish-alpha-dry-run": "lerna publish --dry-run --exact --include-merged-tags --preid alpha --dist-tag next prerelease",
     "preview:publish": "lerna publish from-package --dry-run",

--- a/packages/watch/src/__tests__/watch-command.spec.ts
+++ b/packages/watch/src/__tests__/watch-command.spec.ts
@@ -161,7 +161,19 @@ describe('Watch Command', () => {
       expect(process.exitCode).toBe(1);
     });
 
-    it('should take glob input option and expect it to be appeneded to the file path being watch by chokidar', async () => {
+    it('should take glob input option, without slash prefix, and expect it to be appended to the file path being watch by chokidar', async () => {
+      await lernaWatch(testDir)('--glob', 'src/**/*.{ts,tsx}', '--', 'lerna run build');
+
+      expect(watchMock).toHaveBeenCalledWith(
+        [
+          path.join(testDir, 'packages/package-1', '/src/**/*.{ts,tsx}'),
+          path.join(testDir, 'packages/package-2', '/src/**/*.{ts,tsx}'),
+        ],
+        { ignoreInitial: true, ignorePermissionErrors: true, persistent: true }
+      );
+    });
+
+    it('should take glob input option, with slash prefix, and expect same appended to the file path being watch by chokidar', async () => {
       await lernaWatch(testDir)('--glob', '/src/**/*.{ts,tsx}', '--', 'lerna run build');
 
       expect(watchMock).toHaveBeenCalledWith(

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -85,7 +85,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
         // does user have a glob defined, if so append it to the pkg location. Glob example for TS files: /**/*.ts
         let watchingPath = pkg.location;
         if (this.options.glob) {
-          watchingPath = path.join(pkg.location, this.options.glob); // append glob to pkg location
+          watchingPath = path.join(pkg.location, '/', this.options.glob); // append glob to pkg location
         }
         packageLocations.push(watchingPath);
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `--glob` option should work with/without the slash prefix when appended to the package path to watch

## Motivation and Context

Prior to this PR, we had to always remember to include the `/` prefix on the `--glob` option, but we shouldn't have to do that

## How Has This Been Tested?

add and update unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
