### PR TITLE
fix(watch): add missing --stream option

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "exec-win": "lerna exec --scope {@lerna-lite/cli,@lerna-lite/core} -- cross-env-shell echo hello from package: $LERNA_PACKAGE_NAME",
     "pack-tarball": "lerna run pack-tarball",
     "pack-tarball:nx": "lerna run pack-tarball --stream --use-nx",
-    "preview:watch:build": "lerna watch --no-bail --ignored=\"**/dist\" --scope {@lerna-lite/exec,@lerna-lite/run} -- cross-env-shell lerna run build --scope=$LERNA_PACKAGE_NAME --stream",
+    "preview:watch:build": "lerna watch --ignored=\"**/dist\" --stream --scope {@lerna-lite/exec,@lerna-lite/run} -- cross-env-shell lerna run build --scope=$LERNA_PACKAGE_NAME",
     "preview:watch:files": "lerna watch --bail --glob=\"src/**.ts\" --scope {@lerna-lite/watch,@lerna-lite/exec} -- cross-env-shell echo $LERNA_FILE_CHANGES $LERNA_FILE_CHANGE_TYPE in package $LERNA_PACKAGE_NAME\"",
     "preview:watch:all": "lerna watch --bail --watch-all-events --scope {@lerna-lite/watch,@lerna-lite/exec} -- cross-env-shell echo \"Changed files $LERNA_FILE_CHANGES $LERNA_FILE_CHANGE_TYPE in package $LERNA_PACKAGE_NAME\"",
     "preview:publish-alpha-dry-run": "lerna publish --dry-run --exact --include-merged-tags --preid alpha --dist-tag next prerelease",

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -717,6 +717,15 @@
           "type": "object",
           "description": "Options for the `watch` command.",
           "properties": {
+            "noPrefix": {
+              "$ref": "#/$defs/commandOptions/shared/noPrefix"
+            },
+            "prefix": {
+              "$ref": "#/$defs/commandOptions/shared/prefix"
+            },
+            "stream": {
+              "$ref": "#/$defs/commandOptions/shared/stream"
+            },
             "glob": {
               "$ref": "#/$defs/commandOptions/watch/glob"
             },
@@ -1654,7 +1663,7 @@
         },
         "stream": {
           "type": "boolean",
-          "description": "During `lerna exec` and `lerna run`, stream output with lines prefixed by originating package name."
+          "description": "During `lerna exec`, `lerna run` and `lerna watch`, stream output with lines prefixed by originating package name."
         },
         "parallel": {
           "type": "boolean",
@@ -1662,19 +1671,19 @@
         },
         "noBail": {
           "type": "boolean",
-          "description": "During `lerna exec` and `lerna run`, when true, do not exit with non-zero status if a command fails."
+          "description": "During `lerna exec`, `lerna run` and `lerna watch`, when true, do not exit with non-zero status if a command fails."
         },
         "bail": {
           "type": "boolean",
-          "description": "During `lerna exec` and `lerna run`, exit with non-zero status if any command fails."
+          "description": "During `lerna exec`, `lerna run` and `lerna watch`, exit with non-zero status if any command fails."
         },
         "noPrefix": {
           "type": "boolean",
-          "description": "During `lerna exec` and `lerna run`, when true, do not prefix output with originating package name."
+          "description": "During `lerna exec`, `lerna run` and `lerna watch`, when true, do not prefix output with originating package name."
         },
         "prefix": {
           "type": "boolean",
-          "description": "During `lerna exec` and `lerna run`, prefix output with originating package name."
+          "description": "During `lerna exec`, `lerna run` and `lerna watch`, prefix output with originating package name."
         },
         "profile": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-watch-commands.ts
+++ b/packages/cli/src/cli-commands/cli-watch-commands.ts
@@ -52,6 +52,23 @@ export default {
             'Glob pattern to define which file pattern to watch, note that this will be appended to the package file path being watched.',
           type: 'string',
         },
+        // This option controls prefix for stream output so that it can be disabled to be friendly
+        // to tools like Visual Studio Code to highlight the raw results
+        'no-prefix': {
+          group: 'Command Options:',
+          describe: 'Do not prefix streaming output.',
+          type: 'boolean',
+        },
+        prefix: {
+          // proxy for --no-prefix
+          hidden: true,
+          type: 'boolean',
+        },
+        stream: {
+          group: 'Command Options:',
+          describe: 'Stream output with lines prefixed by originating package name.',
+          type: 'boolean',
+        },
         'watch-all-events': {
           group: 'Command Options:',
           describe: `When enabled it will trigger from all possible Chokidar events ('add', 'addDir', 'change', 'unlink', 'unlinkDir'), defaults to false`,

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -438,6 +438,17 @@ export interface WatchCommandOption {
   /** Glob pattern to define which file pattern to watch, note that this will be appended to the package file path being watched. */
   glob?: string;
 
+  // This option controls prefix for stream output so that it can be disabled to be friendly
+  // to tools like Visual Studio Code to highlight the raw results
+  /** Do not prefix streaming output. */
+  noPrefix?: boolean;
+
+  /** proxy for `--no-prefix` */
+  prefix?: boolean;
+
+  /** Stream output with lines prefixed by originating package name. */
+  stream?: boolean;
+
   /** Defaults to false, when enabled it will trigger from all possible Chokidar events ('add', 'addDir', 'change', 'unlink', 'unlinkDir'). */
   watchAllEvents?: boolean;
 

--- a/packages/watch/README.md
+++ b/packages/watch/README.md
@@ -66,10 +66,10 @@ Since you can execute any arbitrary commands, you could use `pnpm run` instead o
 $ lerna watch --glob=\"src/**/*.spec.ts\" -- pnpm -r --filter=\$LERNA_PACKAGE_NAME test
 ```
 
-Watch a single package and run the "build" script on it when a file within it changes (but ignore `dist` folder) and also stream the build output:
+Watch and stream two package and run the "build" script on them when a file within it changes (but ignore `dist` folder):
 
 ```sh
-$ lerna watch --ignored=\"**/dist\", --scope="my-package-1" -- lerna run build --scope=\$LERNA_PACKAGE_NAME --stream
+$ lerna watch --stream --ignored=\"**/dist\", --scope={my-package-1,my-package-2} -- lerna run build --scope=\$LERNA_PACKAGE_NAME
 ```
 
 When using `npx`, the `-c` option must be used if also providing variables for substitution:
@@ -102,7 +102,9 @@ $ npx -c 'lerna watch -- echo \$LERNA_PACKAGE_NAME \$LERNA_FILE_CHANGES'
     - [`--emit-changes-delay`](#--emit-changes-delay)
     - [`--file-delimiter`](#--file-delimiter)
     - [`--glob`](#--glob)
+    - [`--stream`](#--stream)
     - [`--no-bail`](#--no-bail)
+    - [`--no-prefix`](#--no-prefix)
     - [Watch Events](#watch-events) (defaults to file `change` only)
       - [`--watch-all-events`](#--watch-all-events)
       - [`--watch-added-file`](#--watch-added-file)
@@ -149,6 +151,15 @@ Provide a Glob pattern to target which files to watch, note that this will be ap
 $ lerna watch --glob=\"src\**\*.ts" -- <command>
 ```
 
+### `--stream`
+
+Stream output from child processes immediately, prefixed with the originating
+package name. This allows output from different packages to be interleaved.
+
+```sh
+$ lerna watch --stream -- <command>
+```
+
 ### `--no-bail`
 
 ```sh
@@ -158,6 +169,11 @@ $ lerna watch --no-bail -- <command>
 
 By default, `lerna watch` will exit with an error if _any_ execution returns a non-zero exit code.
 Pass `--no-bail` to disable this behavior, executing in _all_ packages regardless of exit code.
+
+### `--no-prefix`
+
+Disable package name prefixing when output is streaming (`--stream` _or_ `--parallel`).
+This option can be useful when piping results to other processes, such as editor plugins.
 
 ### Watch Events
 The `lerna watch`, by default, will only execute the watch callback on **file changes only** (via Chokidar `change` event). The reason is simply to have less watches open. If you want to watch for other events, like add/remove file, you can look at the possible flags below or even use `--watch-all-events` for all type of events.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `--stream` option to `lerna watch`

## Motivation and Context

We should add the same `--stream` option as every other commands like `exec` and `run`

## How Has This Been Tested?

add unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
