### PR TITLE
fix(watch): add missing Chokidar option awaitWriteFinish as a boolean

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -726,6 +726,9 @@
             "bail": {
               "$ref": "#/$defs/commandOptions/shared/bail"
             },
+            "awaitWriteFinish": {
+              "$ref": "#/$defs/commandOptions/watch/awaitWriteFinish"
+            },
             "awfStabilityThreshold": {
               "$ref": "#/$defs/commandOptions/watch/awfStabilityThreshold"
             },
@@ -1558,6 +1561,10 @@
         "glob": {
           "type": "string",
           "description": "Glob pattern to define which file pattern to watch, note that this will be appended to the package file path being watched."
+        },
+        "awaitWriteFinish": {
+          "type": "boolean",
+          "description": "Defaults to false, by default the add event will fire when a file first appears on disk, before the entire file has been written. Setting awaitWriteFinish to true (or a truthy value) will poll file size, holding its add and change events until the size does not change for a configurable amount of time."
         },
         "awfPollInterval": {
           "type": "number",

--- a/packages/cli/src/cli-commands/cli-watch-commands.ts
+++ b/packages/cli/src/cli-commands/cli-watch-commands.ts
@@ -79,6 +79,11 @@ export default {
         },
 
         // -- Chokidar options
+        'await-write-finish': {
+          group: 'Command Options:',
+          describe: `Defaults to false, by default the add event will fire when a file first appears on disk, before the entire file has been written. Setting awaitWriteFinish to true (or a truthy value) will poll file size, holding its add and change events until the size does not change for a configurable amount of time.`,
+          type: 'boolean',
+        },
         'awf-stability-threshold': {
           group: 'Command Options:',
           describe:

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -456,6 +456,13 @@ export interface WatchCommandOption {
   // -- Chokidar options
   // the options prefixed with "awf" are sub-options of "awaitWriteFinish"
 
+  /**
+   * Defaults to false, by default the add event will fire when a file first appears on disk, before the entire file has been written.
+   * Setting `awaitWriteFinish` to true (or a truthy value) will poll file size,
+   * holding its add and change events until the size does not change for a configurable amount of time.
+   */
+  awaitWriteFinish?: boolean;
+
   /** Default to 100, file size polling interval, in milliseconds. */
   awfPollInterval?: number;
 

--- a/packages/watch/README.md
+++ b/packages/watch/README.md
@@ -293,7 +293,17 @@ $ lerna watch --use-polling -- <command>
 
 ### The `awaitWriteFinish` option
 
-The `awaitWriteFinish` option can be a complex object, this is however difficult to in the CLI. So in order to make them accessible to the CLI, we prefixed them with "awf", the system will internally replace the option(s) with the appropriate Chokidar complex object. For example, `awfPollInterval: 200` will be transformed to `{ awaitWriteFinish: { pollInterval: 200 }}`
+The `awaitWriteFinish` option can be boolean or a complex object
+
+> **Note** Providing a complex object is however difficult to pass to a CLI. So in order to make them accessible to the CLI, we prefixed them with "awf", the system will internally replace the option(s) with the appropriate Chokidar complex object. For example, `awfPollInterval: 200` will be transformed to `{ awaitWriteFinish: { pollInterval: 200 }}`
+
+### `--await-write-finish`
+#### boolean value
+Defaults to `false`, by default the add event will fire when a file first appears on disk, before the entire file has been written. Setting `awaitWriteFinish` to true (or a truthy value) will poll file size, holding its `add` and `change` events until the size does not change for a configurable amount of time.
+
+```sh
+$ lerna watch --await-write-finish -- <command>
+```
 
 ### `--awf-poll-interval`
 

--- a/packages/watch/src/__tests__/watch-command.spec.ts
+++ b/packages/watch/src/__tests__/watch-command.spec.ts
@@ -185,6 +185,15 @@ describe('Watch Command', () => {
       );
     });
 
+    it('should be able to take --await-write-finish options as a boolean', async () => {
+      await lernaWatch(testDir)('--await-write-finish', '--', 'lerna run build');
+
+      expect(watchMock).toHaveBeenCalledWith(
+        [path.join(testDir, 'packages/package-1'), path.join(testDir, 'packages/package-2')],
+        { ignoreInitial: true, ignorePermissionErrors: true, persistent: true, awaitWriteFinish: true }
+      );
+    });
+
     it('should take options prefixed with "awf" (awfPollInterval) and transform them into a valid chokidar "awaitWriteFinish" option', async () => {
       await lernaWatch(testDir)('--awf-poll-interval', '500', '--', 'lerna run build');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Chokidar option [`awaitWriteFinish`](https://github.com/paulmillr/chokidar#performance) can be both a complex object (that we provided in previous PR) and a boolean (this PR)

## Motivation and Context

We should be able to provide `awaitWriteFinish` as both available Chokidar type a boolean and a complex object

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
