### PR TITLE
chore(watch): watch command should watch for chokidar events

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -768,21 +768,6 @@
             "usePolling": {
               "$ref": "#/$defs/commandOptions/watch/usePolling"
             },
-            "watchAllEvents": {
-              "$ref": "#/$defs/commandOptions/watch/watchAllEvents"
-            },
-            "watchAddedFile": {
-              "$ref": "#/$defs/commandOptions/watch/watchAddedFile"
-            },
-            "watchAddedDir": {
-              "$ref": "#/$defs/commandOptions/watch/watchAddedDir"
-            },
-            "watchRemovedFile": {
-              "$ref": "#/$defs/commandOptions/watch/watchRemovedFile"
-            },
-            "watchRemovedDir": {
-              "$ref": "#/$defs/commandOptions/watch/watchRemovedDir"
-            },
 
             "loglevel": {
               "$ref": "#/$defs/globals/loglevel"
@@ -1561,7 +1546,7 @@
       "watch": {
         "emitChangesDelay": {
           "type": "number",
-          "description": "Defaults to 100, time to wait in milliseconds before emitting all the file changes into a single event."
+          "description": "Defaults to 200, time to wait in milliseconds before emitting all the file changes into a single event."
         },
         "fileDelimiter": {
           "type": "string",
@@ -1618,26 +1603,6 @@
         "usePolling": {
           "type": "boolean",
           "description": "Defaults to false, whether to use fs.watchFile (backed by polling), or fs.watch. If polling leads to high CPU utilization, consider setting this to false."
-        },
-        "watchAllEvents": {
-          "type": "boolean",
-          "description": "Defaults to false, when enabled it will trigger from all possible Chokidar events ('add', 'addDir', 'change', 'unlink', 'unlinkDir')."
-        },
-        "watchAddedFile": {
-          "type": "boolean",
-          "description": "Defaults to false, when enabled it will trigger when a file is being added."
-        },
-        "watchAddedDir": {
-          "type": "boolean",
-          "description": "Defaults to false, when enabled it will trigger when a directory is being added."
-        },
-        "watchRemovedFile": {
-          "type": "boolean",
-          "description": "Defaults to false, when enabled it will trigger when a file is being removed."
-        },
-        "watchRemovedDir": {
-          "type": "boolean",
-          "description": "Defaults to false, when enabled it will trigger when a directory is being removed."
         }
       },
       "shared": {

--- a/packages/cli/src/cli-commands/cli-watch-commands.ts
+++ b/packages/cli/src/cli-commands/cli-watch-commands.ts
@@ -37,7 +37,7 @@ export default {
         'emit-changes-delay': {
           group: 'Command Options:',
           describe:
-            'Time to wait in milliseconds before emitting all the file changes into a single event, defaults to 100',
+            'Time to wait in milliseconds before emitting all the file changes into a single event, defaults to 200',
           type: 'number',
         },
         'file-delimiter': {
@@ -67,31 +67,6 @@ export default {
         stream: {
           group: 'Command Options:',
           describe: 'Stream output with lines prefixed by originating package name.',
-          type: 'boolean',
-        },
-        'watch-all-events': {
-          group: 'Command Options:',
-          describe: `When enabled it will trigger from all possible Chokidar events ('add', 'addDir', 'change', 'unlink', 'unlinkDir'), defaults to false`,
-          type: 'boolean',
-        },
-        'watch-added-file': {
-          group: 'Command Options:',
-          describe: 'When enabled it will also watch when a file is being added.',
-          type: 'boolean',
-        },
-        'watch-added-dir': {
-          group: 'Command Options:',
-          describe: 'When enabled it will also watch when a directory is being added.',
-          type: 'boolean',
-        },
-        'watch-removed-file': {
-          group: 'Command Options:',
-          describe: 'When enabled it will also watch when a file is being removed.',
-          type: 'boolean',
-        },
-        'watch-removed-dir': {
-          group: 'Command Options:',
-          describe: 'When enabled it will also watch when a directory is being removed.',
           type: 'boolean',
         },
 

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -426,7 +426,7 @@ export interface WatchCommandOption {
   bail?: boolean;
 
   /**
-   * Defaults to 100, time to wait in milliseconds before emitting all the file changes into a single event.
+   * Defaults to 200, time to wait in milliseconds before emitting all the file changes into a single event.
    * This provide enough time for the system to collect all Chokidar events (1x per file changes)
    * and merge them into a single Lerna watch change event to be emitted (Lerna will join all file paths into a CSV string separated by whitespace by default).
    */
@@ -448,21 +448,6 @@ export interface WatchCommandOption {
 
   /** Stream output with lines prefixed by originating package name. */
   stream?: boolean;
-
-  /** Defaults to false, when enabled it will trigger from all possible Chokidar events ('add', 'addDir', 'change', 'unlink', 'unlinkDir'). */
-  watchAllEvents?: boolean;
-
-  /** Defaults to false, when enabled it will trigger when a file is being added. */
-  watchAddedFile?: boolean;
-
-  /** Defaults to false, when enabled it will trigger when a directory is being added. */
-  watchAddedDir?: boolean;
-
-  /** Defaults to false, when enabled it will trigger when a file is being removed. */
-  watchRemovedFile?: boolean;
-
-  /** Defaults to false, when enabled it will trigger when a directory is being removed. */
-  watchRemovedDir?: boolean;
 
   // -- Chokidar options
   // the options prefixed with "awf" are sub-options of "awaitWriteFinish"

--- a/packages/core/src/utils/query-graph.ts
+++ b/packages/core/src/utils/query-graph.ts
@@ -20,7 +20,7 @@ export class QueryGraph {
    */
   static toposort(packages: Package[], options?: QueryGraphConfig) {
     const graph = new QueryGraph(packages, options);
-    const result = [];
+    const result: Package[] = [];
 
     let batch = graph.getAvailablePackages();
 

--- a/packages/watch/src/constants.ts
+++ b/packages/watch/src/constants.ts
@@ -19,4 +19,4 @@ export const CHOKIDAR_AVAILABLE_OPTIONS = [
 export const FILE_DELIMITER = ' ';
 
 // threshold to hold before firing a single event with merged files
-export const EMIT_CHANGES_DELAY = 100;
+export const EMIT_CHANGES_DELAY = 200;

--- a/packages/watch/src/index.ts
+++ b/packages/watch/src/index.ts
@@ -1,2 +1,2 @@
-export * from './types';
+export * from './models';
 export * from './watch-command';

--- a/packages/watch/src/models.ts
+++ b/packages/watch/src/models.ts
@@ -5,8 +5,6 @@ export type ChokidarEventType = 'add' | 'addDir' | 'change' | 'unlink' | 'unlink
 export interface ChangesStructure {
   [pkgName: string]: {
     pkg: Package;
-    events: {
-      [eventType in ChokidarEventType]: Set<string>;
-    };
+    changeFiles: Set<string>;
   };
 }

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -124,11 +124,8 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
       const pkg = this._filteredPackages.find((p) => filepath.includes(p.location));
       if (pkg) {
         // changes structure sample: { '@lerna-lite/watch': { pkg: Package, events: { change: ['path1', 'path2'], unlink: ['path3'] } } }
-        if (!this._changes[pkg.name]) {
+        if (!this._changes[pkg.name] || !this._changes[pkg.name].changeFiles) {
           this._changes[pkg.name] = { pkg, changeFiles: new Set<string>() }; // use Set to avoid duplicate entires
-        }
-        if (!this._changes[pkg.name].changeFiles) {
-          this._changes[pkg.name].changeFiles = new Set(); // use Set to avoid duplicate entires
         }
         this._changes[pkg.name].changeFiles.add(filepath);
 


### PR DESCRIPTION
## Description

cleanup the `watch` command

## Motivation and Context

- in most cases people would want to watch for not just file update but also file add/remove as well and also for the performance point of view I don't think there will be much difference since they are the same file being watched
- the other problem by watching g chokidar events separately was that it was triggering too many lerna watch events
- this also makes the code a lot smaller and easier to follow and troubleshoot
- I'm doing this now since I doubt many people downloaded it in 2 days and even if they did, the difference is still small and manageable

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
