### PR TITLE
fix(watch): lerna watch should ignore git, dist & node_modules folders

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1585,7 +1585,7 @@
           "description": "Defaults to true, when false, only the symlinks themselves will be watched for changes instead of following the link references and bubbling events through the link's path."
         },
         "ignored": {
-          "type": "string",
+          "anyOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }],
           "description": "Defines files/paths to be ignored."
         },
         "ignoreInitial": {

--- a/packages/cli/src/cli-commands/cli-watch-commands.ts
+++ b/packages/cli/src/cli-commands/cli-watch-commands.ts
@@ -111,8 +111,9 @@ export default {
         },
         ignored: {
           group: 'Command Options:',
-          describe: 'Defines files/paths to be ignored',
-          type: 'string',
+          describe:
+            'Defines files/paths to be ignored, it can be a string or an array of string (anymatch-compatible definition)',
+          // type must remain ambiguous because it is overloaded (string _or_ array of string)
         },
         'ignore-initial': {
           group: 'Command Options:',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -480,8 +480,8 @@ export interface WatchCommandOption {
   /** Defaults to true, when false, only the symlinks themselves will be watched for changes instead of following the link references and bubbling events through the link's path. */
   followSymlinks?: boolean;
 
-  /** Defines files/paths to be ignored */
-  ignored?: string;
+  /** Defines files/paths to be ignored, it can be a string or an array of string (anymatch-compatible definition) */
+  ignored?: string | string[];
 
   /** Defaults to true, if set to false then add/addDir events are also emitted for matching paths while instantiating the watching as chokidar discovers these file paths (before the ready event). */
   ignoreInitial?: boolean;

--- a/packages/watch/README.md
+++ b/packages/watch/README.md
@@ -66,10 +66,10 @@ Since you can execute any arbitrary commands, you could use `pnpm run` instead o
 $ lerna watch --glob=\"src/**/*.spec.ts\" -- pnpm -r --filter=\$LERNA_PACKAGE_NAME test
 ```
 
-Watch and stream two packages and run the "build" script on them when a file within it changes (but ignore `dist` folder):
+Watch and stream two packages and run the "build" script on them when a file within it changes:
 
 ```sh
-$ lerna watch --ignored=\"**/dist\", --scope={my-package-1,my-package-2} -- lerna run build --stream --scope=\$LERNA_PACKAGE_NAME
+$ lerna watch --scope={my-package-1,my-package-2} -- lerna run build --stream --scope=\$LERNA_PACKAGE_NAME
 ```
 
 When using `npx`, the `-c` option must be used if also providing variables for substitution:
@@ -119,10 +119,10 @@ $ npx -c 'lerna watch -- echo \$LERNA_PACKAGE_NAME \$LERNA_FILE_CHANGES'
       - [`--awf-poll-interval`](#--awf-poll-interval)
       - [`--awf-stability-threshold`](#--awf-stability-threshold)
 
-> **Note** to limit the number of files being watched, it is recommended to use either [`--ignored`](#--ignored) and/or [`--glob`](#--glob) options. For example you probably want to avoid watching `node_modules` and `dist` folders.
+> **Note** to limit the number of files being watched, you might want to take a look at either [`--ignored`](#--ignored) and/or [`--glob`](#--glob) options. The `lerna watch` command skips `.git/` and `node_modules/` directories by default.
 
 ### `--emit-changes-delay`
-Defaults to `200`, time to wait in milliseconds before collecting all file changes and then emitting them into a single watch event. The reason for this option to exist is basically to provide enough time for the lerna watch to collect all prior file change and merge them into a single watch change event (chokidar has no grouping feature and emits an event for every single file change) and we want to avoid emitting too many events (especially for a watch that triggers a rebuild). This option will come into play when you make a code change that triggers hundred of file changes, you might need to adjust the delay by increasing its value (which is to trigger a large set of changes at the same time, ie variable rename in hundreds of different files).
+Defaults to `200`, time to wait in milliseconds before collecting all file changes and then emitting them into a single watch event. The reason for this option to exist is basically to provide enough time for `lerna watch` to collect all prior file changes and merge them into a single watch change event (chokidar has no grouping feature and emits an event for every single file change) and we want to avoid emitting too many events (especially for a watch that triggers a rebuild). This option will come into play when you make a code change that triggers hundred of file changes, you might need to adjust the delay by increasing its value (similar library like `Nx` have their `Nx Watch` fixed to `500`).
 
 ```sh
 $ lerna watch --emit-changes-delay=500 -- <command>
@@ -138,7 +138,7 @@ $ lerna watch --file-delimiter=\";;\" -- <command>
 
 ### `--glob`
 
-Provide a Glob pattern to target which files to watch, note that this will be appended to the package file path is provided to Chokidar. For example if our package is located under `/home/user/monorepo/packages/pkg-1` and we define `"glob": "/src/**/*.{ts,tsx}"`, then it will use the following watch pattern in Chokidar `/home/user/monorepo/packages/pkg-1/src/**/*.{ts,tsx}`
+Provide a Glob pattern to target which files to watch, note that this will be appended to the package file path is provided to Chokidar. For example if our package is located under `/home/user/monorepo/packages/pkg-1` and we define `"glob": "/src/**/*.{ts,tsx}"`, it will end using the following watch pattern in Chokidar `/home/user/monorepo/packages/pkg-1/src/**/*.{ts,tsx}`
 
 ```sh
 # glob pattern will be appended to package path to Chokidar files to watch
@@ -208,15 +208,17 @@ $ lerna watch --follow-symlinks -- <command>
 
 ### `--ignored`
 
-Defines files/paths to be ignored ([anymatch](https://github.com/micromatch/anymatch)-compatible definition).
+Defines files/paths to be ignored, it can be a string or an array of string ([anymatch](https://github.com/micromatch/anymatch)-compatible definition). Since we use this in a monorepo, we already skips `.git/`, `dist/` and `node_modules/` directories by default
 
 ```sh
-# ignore dist folder
-$ lerna watch --ignored=\"**/dist\" -- <command>
+# ignore bin folder
+$ lerna watch --ignored=\"**/bin\" -- <command>
 
 # or ignore dot file
 $ lerna watch --ignored=\"/(^|[/\\])\../\" -- <command>
 ```
+
+> **Note** the `lerna watch` command skips `.git/` and `node_modules/` directories by default. If you want to watch files inside `node_moduels/`, you can pass a negated glob pattern, that is `lerna watch --ignored=\"!**/node_modules/**\"`
 
 ### `--ignore-initial`
 

--- a/packages/watch/src/__tests__/watch-command.spec.ts
+++ b/packages/watch/src/__tests__/watch-command.spec.ts
@@ -154,7 +154,12 @@ describe('Watch Command', () => {
           path.join(testDir, 'packages/package-1', '/src/**/*.{ts,tsx}'),
           path.join(testDir, 'packages/package-2', '/src/**/*.{ts,tsx}'),
         ],
-        { ignoreInitial: true, ignorePermissionErrors: true, persistent: true }
+        {
+          ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
+          ignoreInitial: true,
+          ignorePermissionErrors: true,
+          persistent: true,
+        }
       );
     });
 
@@ -166,7 +171,12 @@ describe('Watch Command', () => {
           path.join(testDir, 'packages/package-1', '/src/**/*.{ts,tsx}'),
           path.join(testDir, 'packages/package-2', '/src/**/*.{ts,tsx}'),
         ],
-        { ignoreInitial: true, ignorePermissionErrors: true, persistent: true }
+        {
+          ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
+          ignoreInitial: true,
+          ignorePermissionErrors: true,
+          persistent: true,
+        }
       );
     });
 
@@ -175,7 +185,13 @@ describe('Watch Command', () => {
 
       expect(watchMock).toHaveBeenCalledWith(
         [path.join(testDir, 'packages/package-1'), path.join(testDir, 'packages/package-2')],
-        { ignoreInitial: true, ignorePermissionErrors: true, persistent: true, awaitWriteFinish: true }
+        {
+          ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
+          ignoreInitial: true,
+          ignorePermissionErrors: true,
+          persistent: true,
+          awaitWriteFinish: true,
+        }
       );
     });
 
@@ -184,7 +200,13 @@ describe('Watch Command', () => {
 
       expect(watchMock).toHaveBeenCalledWith(
         [path.join(testDir, 'packages/package-1'), path.join(testDir, 'packages/package-2')],
-        { ignoreInitial: true, ignorePermissionErrors: true, persistent: true, awaitWriteFinish: { pollInterval: 500 } }
+        {
+          ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
+          ignoreInitial: true,
+          ignorePermissionErrors: true,
+          persistent: true,
+          awaitWriteFinish: { pollInterval: 500 },
+        }
       );
     });
 
@@ -194,6 +216,7 @@ describe('Watch Command', () => {
       expect(watchMock).toHaveBeenCalledWith(
         [path.join(testDir, 'packages/package-1'), path.join(testDir, 'packages/package-2')],
         {
+          ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
           ignoreInitial: true,
           ignorePermissionErrors: true,
           persistent: true,

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -71,12 +71,16 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
     );
 
     try {
+      const { ignored = [], ...otherOptions } = this.options ?? {};
       const packageLocations: string[] = [];
       const chokidarOptions: chokidar.WatchOptions = {
+        // we should ignore certain folders by default
+        // uses almost same implementation as ViteJS: https://github.com/vitejs/vite/blob/c747a3f289183b3640a6d4a1410acb5eafd11129/packages/vite/src/node/watch.ts
+        ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**', ...(Array.isArray(ignored) ? ignored : [ignored])],
         ignoreInitial: true,
         ignorePermissionErrors: true,
         persistent: true,
-        ...this.options,
+        ...otherOptions,
       };
 
       this._filteredPackages.forEach((pkg) => {


### PR DESCRIPTION
## Description

`lerna watch` should ignore certain folders by default 

## Motivation and Context

in a Lerna-Lite monorepo, there are common folders that should most often be skipped by default: `.git`, `dist` and `node_modules`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
