### PR TITLE
chore: remove more module.exports and require()

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Jest Current Spec File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": ["--runInBand", "${fileBasename}", "--config", "${workspaceFolder}/jest/jest.config.js"],
+      "args": ["--runInBand", "${fileBasename}", "--config", "${workspaceFolder}/jest/jest.config.ts"],
       "console": "internalConsole",
       "internalConsoleOptions": "neverOpen",
       "disableOptimisticBPs": true,

--- a/helpers/cli.ts
+++ b/helpers/cli.ts
@@ -16,9 +16,6 @@ export function commandRunner(commandModule: any) {
   /* eslint-disable import/no-dynamic-require, global-require */
   const cmd = commandModule.command.split(' ')[0];
 
-  // prime the pump so slow-as-molasses CI doesn't fail with delayed require()
-  require(path.resolve((require as any).main.filename, '../..'));
-
   return (cwd: string) => {
     // create a _new_ yargs instance every time cwd changes to avoid singleton pollution
     const cli = lernaCLI([], cwd)

--- a/helpers/cli.ts
+++ b/helpers/cli.ts
@@ -16,6 +16,9 @@ export function commandRunner(commandModule: any) {
   /* eslint-disable import/no-dynamic-require, global-require */
   const cmd = commandModule.command.split(' ')[0];
 
+  // prime the pump so slow-as-molasses CI doesn't fail with delayed require()
+  require(path.resolve((require as any).main.filename, '../..'));
+
   return (cwd: string) => {
     // create a _new_ yargs instance every time cwd changes to avoid singleton pollution
     const cli = lernaCLI([], cwd)

--- a/packages/core/src/__mocks__/collect-updates.ts
+++ b/packages/core/src/__mocks__/collect-updates.ts
@@ -18,6 +18,11 @@ afterEach(() => {
   updated.clear();
 });
 
-export const collectUpdates = mockCollectUpdates;
-collectUpdates.setUpdated = setUpdated;
-export { collectPackages, getPackagesForOption };
+module.exports.collectUpdates = mockCollectUpdates;
+module.exports.collectUpdates.setUpdated = setUpdated;
+module.exports.collectPackages = collectPackages;
+module.exports.getPackagesForOption = getPackagesForOption;
+
+// export const collectUpdates = mockCollectUpdates;
+// collectUpdates.setUpdated = setUpdated;
+// export { collectPackages, getPackagesForOption };

--- a/packages/core/src/__mocks__/collect-updates.ts
+++ b/packages/core/src/__mocks__/collect-updates.ts
@@ -4,7 +4,7 @@ const { collectPackages, getPackagesForOption } = jest.requireActual('../utils/c
 // otherwise, enables everything
 const updated = new Map();
 
-const mockCollectUpdates = jest.fn((filteredPackages, packageGraph, { cwd }) => {
+const mockCollectUpdates: any = jest.fn((filteredPackages, packageGraph, { cwd }) => {
   const targets = updated.get(cwd);
   const updates = targets ? new Map(targets.map((name) => [name, packageGraph.get(name)])) : packageGraph;
 
@@ -18,7 +18,6 @@ afterEach(() => {
   updated.clear();
 });
 
-module.exports.collectUpdates = mockCollectUpdates;
-module.exports.collectUpdates.setUpdated = setUpdated;
-module.exports.collectPackages = collectPackages;
-module.exports.getPackagesForOption = getPackagesForOption;
+export const collectUpdates = mockCollectUpdates;
+collectUpdates.setUpdated = setUpdated;
+export { collectPackages, getPackagesForOption };

--- a/packages/core/src/utils/__tests__/npm-conf.spec.ts
+++ b/packages/core/src/utils/__tests__/npm-conf.spec.ts
@@ -1,4 +1,4 @@
-const npmConfModule = require('../npm-conf');
+import * as npmConfModule from '../npm-conf';
 import { npmConf, toNerfDart, Conf } from '../npm-conf';
 
 describe('@lerna/npm-conf', () => {
@@ -6,12 +6,6 @@ describe('@lerna/npm-conf', () => {
     expect(npmConfModule).toBeDefined();
     expect(Conf).toBeDefined();
     expect(typeof npmConfModule.npmConf).toBe('function');
-  });
-
-  it('exports named defaults', () => {
-    const { defaults } = npmConfModule;
-    expect(defaults).toBeDefined();
-    expect(typeof defaults).toBe('object');
   });
 
   it('exports named Conf', () => {
@@ -30,7 +24,7 @@ describe('@lerna/npm-conf', () => {
   });
 
   it('defaults cli parameter to empty object', () => {
-    const conf = npmConfModule.npmConf();
+    const conf = npmConfModule.npmConf(null);
 
     expect(conf.sources.cli.data).toEqual({});
   });

--- a/packages/core/src/utils/npm-conf.ts
+++ b/packages/core/src/utils/npm-conf.ts
@@ -2,23 +2,22 @@ import path from 'path';
 
 import { Conf } from '../utils/conf';
 import { toNerfDart } from './nerf-dart';
-const defaults = require('./defaults');
+import * as defaults from './defaults';
 
 // https://github.com/npm/npm/blob/latest/lib/config/core.js#L101-L200
 function npmConf(opts: any) {
-  const conf = new Conf(Object.assign({}, defaults.defaults));
+  const conf = new Conf(Object.assign({}, (defaults as any).defaults));
 
   // prevent keys with undefined values from obscuring defaults
   // prettier-ignore
   const cleanOpts = opts
     ? Object.keys(opts).reduce((acc, key) => {
-      if (opts[key] !== undefined) {
-        // eslint-disable-next-line no-param-reassign
-        acc[key] = opts[key];
-      }
-
-      return acc;
-    }, {})
+        if (opts[key] !== undefined) {
+          // eslint-disable-next-line no-param-reassign
+          acc[key] = opts[key];
+        }
+        return acc;
+      }, {})
     : {};
 
   conf.add(cleanOpts, 'cli');
@@ -56,7 +55,5 @@ function npmConf(opts: any) {
 
   return conf;
 }
-
-module.exports.defaults = Object.assign({}, defaults.defaults);
 
 export { Conf, npmConf, toNerfDart };

--- a/packages/exec/src/__tests__/exec-command.spec.ts
+++ b/packages/exec/src/__tests__/exec-command.spec.ts
@@ -30,7 +30,7 @@ import { spawn, spawnStreaming } from '@lerna-lite/core';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import { normalizeRelativeDir } from '@lerna-test/helpers';
-import { factory, ExecCommand } from '../exec-command';
+import { factory, ExecCommand } from '../index';
 import cliExecCommands from '../../../cli/src/cli-commands/cli-exec-commands';
 const lernaExec = commandRunner(cliExecCommands);
 const initFixture = initFixtureFactory(__dirname);

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -25,7 +25,7 @@ import { npmRunScript, npmRunScriptStreaming } from '../lib/npm-run-script';
 import cliRunCommands from '../../../cli/src/cli-commands/cli-run-commands';
 
 // helpers
-import { factory, RunCommand } from '../run-command';
+import { factory, RunCommand } from '../index';
 import { commandRunner, initFixtureFactory, loggingOutput, normalizeRelativeDir } from '@lerna-test/helpers';
 const lernaRun = commandRunner(cliRunCommands);
 const initFixture = initFixtureFactory(__dirname);

--- a/packages/version/src/lib/__mocks__/load-json-file.ts
+++ b/packages/version/src/lib/__mocks__/load-json-file.ts
@@ -15,7 +15,7 @@ function incrementCalled(registry, manifestLocation) {
 }
 
 // by default, act like a spy that counts number of times each location was loaded
-const mockLoadJsonFile = jest.fn((manifestLocation) => {
+const mockLoadJsonFile: any = jest.fn((manifestLocation) => {
   incrementCalled(asyncRegistry, manifestLocation);
 
   return loadJsonFile(manifestLocation);
@@ -33,7 +33,7 @@ afterEach(() => {
   syncRegistry.clear();
 });
 
-module.exports = mockLoadJsonFile;
-module.exports.registry = asyncRegistry;
-module.exports.sync = mockLoadJsonFileSync;
-module.exports.sync.registry = syncRegistry;
+mockLoadJsonFile.registry = asyncRegistry;
+mockLoadJsonFile.sync = mockLoadJsonFileSync;
+mockLoadJsonFile.sync.registry = syncRegistry;
+export default mockLoadJsonFile;

--- a/packages/version/src/lib/__mocks__/load-json-file.ts
+++ b/packages/version/src/lib/__mocks__/load-json-file.ts
@@ -33,7 +33,12 @@ afterEach(() => {
   syncRegistry.clear();
 });
 
-mockLoadJsonFile.registry = asyncRegistry;
-mockLoadJsonFile.sync = mockLoadJsonFileSync;
-mockLoadJsonFile.sync.registry = syncRegistry;
-export default mockLoadJsonFile;
+module.exports = mockLoadJsonFile;
+module.exports.registry = asyncRegistry;
+module.exports.sync = mockLoadJsonFileSync;
+module.exports.sync.registry = syncRegistry;
+
+// mockLoadJsonFile.registry = asyncRegistry;
+// mockLoadJsonFile.sync = mockLoadJsonFileSync;
+// mockLoadJsonFile.sync.registry = syncRegistry;
+// export default mockLoadJsonFile;

--- a/packages/version/src/lib/__mocks__/write-pkg.ts
+++ b/packages/version/src/lib/__mocks__/write-pkg.ts
@@ -2,7 +2,7 @@ const writePkg = jest.requireActual('write-pkg');
 const registry = new Map();
 
 // by default, act like a spy that populates registry
-const mockWritePkg = jest.fn((fp, data) => {
+const mockWritePkg: any = jest.fn((fp, data) => {
   registry.set(data.name, data);
 
   return writePkg(fp, data);
@@ -26,7 +26,7 @@ afterEach(() => {
   registry.clear();
 });
 
-module.exports = mockWritePkg;
-module.exports.registry = registry;
-module.exports.updatedManifest = updatedManifest;
-module.exports.updatedVersions = updatedVersions;
+mockWritePkg.registry = registry;
+mockWritePkg.updatedManifest = updatedManifest;
+mockWritePkg.updatedVersions = updatedVersions;
+export default mockWritePkg;

--- a/packages/version/src/lib/__mocks__/write-pkg.ts
+++ b/packages/version/src/lib/__mocks__/write-pkg.ts
@@ -26,7 +26,12 @@ afterEach(() => {
   registry.clear();
 });
 
-mockWritePkg.registry = registry;
-mockWritePkg.updatedManifest = updatedManifest;
-mockWritePkg.updatedVersions = updatedVersions;
-export default mockWritePkg;
+module.exports = mockWritePkg;
+module.exports.registry = registry;
+module.exports.updatedManifest = updatedManifest;
+module.exports.updatedVersions = updatedVersions;
+
+// mockWritePkg.registry = registry;
+// mockWritePkg.updatedManifest = updatedManifest;
+// mockWritePkg.updatedVersions = updatedVersions;
+// export default mockWritePkg;

--- a/packages/watch/src/__tests__/watch-command.spec.ts
+++ b/packages/watch/src/__tests__/watch-command.spec.ts
@@ -55,7 +55,7 @@ import { spawn, spawnStreaming } from '@lerna-lite/core';
 // helpers
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 import { normalizeRelativeDir } from '@lerna-test/helpers';
-import { factory, WatchCommand } from '../watch-command';
+import { factory, WatchCommand } from '../index';
 import cliWatchCommands from '../../../cli/src/cli-commands/cli-watch-commands';
 const lernaWatch = commandRunner(cliWatchCommands);
 const initFixture = initFixtureFactory(__dirname);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace as much as possible `module.exports` and `require()` by ESM imports

## Motivation and Context

in preparation to be ESM ready

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
