### PR TITLE
feat(publish): recover from network failure

### DIFF
--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -42,6 +42,8 @@ During all publish operations, appropriate [lifecycle scripts](#lifecycle-script
 
 Check out [Per-Package Configuration](#per-package-configuration) for more details about publishing scoped packages, custom registries, and custom dist-tags.
 
+> Note: See the [FAQ](#recovering-from-a-network-error) for information on how to recover from a failed publish.
+
 ## Positionals
 
 ### semver `--bump from-git`
@@ -571,6 +573,14 @@ _you would rarely want to disable the strict match, in fact this option will be 
   }
 }
 ```
+
+## FAQ
+
+### Recovering from a network error
+
+In the case that some packages were successfully published and others were not, `lerna publish` may have left the repository in an inconsistent state with some changed files. To recover from this, reset any extraneous local changes from the failed run to get back to a clean working tree. Then, retry the same `lerna publish` command. Lerna will attempt to publish all of the packages again, but will recognize those that have already been published and skip over them with a warning.
+
+If you used the `lerna publish` command without positional arguments to select a new version for the packages, then you can run `lerna publish from-git` to retry publishing that same already-tagged version instead of having to bump the version again while retrying.
 
 ## Deprecated Options
 

--- a/packages/publish/src/__tests__/npm-publish.spec.ts
+++ b/packages/publish/src/__tests__/npm-publish.spec.ts
@@ -208,44 +208,4 @@ describe('npm-publish', () => {
     expect(runLifecycle).toHaveBeenCalledWith(pkg, 'publish', options);
     expect(runLifecycle).toHaveBeenLastCalledWith(pkg, 'postpublish', options);
   });
-
-  it('catches libnpm errors', async () => {
-    (publish as jest.Mock).mockImplementationOnce(() => {
-      const err = new Error('whoopsy') as Error & { code: string; body: any };
-      err.code = 'E401';
-      err.body = {
-        error: 'doodle',
-      };
-      return Promise.reject(err);
-    });
-
-    const log = {
-      verbose: jest.fn(),
-      silly: jest.fn(),
-      error: jest.fn(),
-    };
-    const opts = { log };
-
-    await expect(npmPublish(pkg, tarFilePath, opts as any)).rejects.toThrow(
-      expect.objectContaining({
-        message: 'whoopsy',
-        name: 'ValidationError',
-      })
-    );
-
-    expect(log.error).toHaveBeenLastCalledWith('E401', 'doodle');
-    expect(process.exitCode).toBe(1);
-
-    (publish as jest.Mock).mockImplementationOnce(() => {
-      const err = new Error('lolwut') as Error & { code: string; errno: any };
-      err.code = 'E404';
-      err.errno = 9001;
-      return Promise.reject(err);
-    });
-
-    await expect(npmPublish(pkg, tarFilePath, opts as any)).rejects.toThrow('lolwut');
-
-    expect(log.error).toHaveBeenLastCalledWith('E404', 'lolwut');
-    expect(process.exitCode).toBe(9001);
-  });
 });

--- a/packages/publish/src/lib/npm-publish.ts
+++ b/packages/publish/src/lib/npm-publish.ts
@@ -83,23 +83,7 @@ export function npmPublish(
         Object.assign(opts, publishConfigToOpts(manifest.publishConfig));
       }
 
-      return otplease(
-        (innerOpts) => publish(manifest, tarData, innerOpts),
-        opts,
-        otpCache as OneTimePasswordCache
-      ).catch((err) => {
-        opts.log.silly('', err);
-        opts.log.error(err.code, err.body?.error ?? err.message);
-
-        // avoid dumping logs, this isn't a lerna-lite problem
-        err.name = 'ValidationError';
-
-        // ensure process exits non-zero
-        process.exitCode = 'errno' in err ? err.errno : 1;
-
-        // re-throw to break chain upstream
-        throw err;
-      });
+      return otplease((innerOpts) => publish(manifest, tarData, innerOpts), opts, otpCache as OneTimePasswordCache);
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna PR 3513

> Catches the EPUBLISHCONFLICT error from npm when a version already exists. In this case, Lerna assumes that you have already published the package.

## Motivation and Context

As per Lerna PR

> This allows `lerna publish from-git` to be idempotent. If one or more packages fail to publish, then you can rerun `lerna publish from-git` to publish the packages that failed.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
