### PR TITLE
chore(publish): use `fs.rmdir` instead of rimraf to cleanup publish tmp

### DIFF
--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -123,7 +123,7 @@ it is recommended to customize the [`--preid`](#--preid) and [`--dist-tag <tag>`
 
 ### `--cleanup-temp-files`
 
-Cleanup the packed files & folders from the temp directory once the publish is over, defaults to `false`.
+Cleanup the packed files & folders from the temp directory once the publish process is over, defaults to `false`.
 
 ```sh
 lerna publish --cleanup-temp-files

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -123,13 +123,13 @@ it is recommended to customize the [`--preid`](#--preid) and [`--dist-tag <tag>`
 
 ### `--cleanup-temp-files`
 
-Cleanup the packed files & folders from the temp directory once the publish process is over, defaults to `false`.
+Cleanup the temp folders used by the publish process once the execution is over, defaults to `false`.
 
 ```sh
 lerna publish --cleanup-temp-files
 ```
 
-> **Note** Lerna-Lite is prefixing the temp folders with "lerna-" when packing the tarball folders, we then use a glob pattern to delete all folders starting with this prefix. Also note that it is entirely possible that this cleanup misses some extra temp files created by the publish process.
+> **Note** Lerna-Lite is prefixing the temp folders containing each package tarball with "lerna-", we then use a glob pattern to delete every folders starting with this prefix. Also note that it is entirely possible that this cleanup misses some extra temp files created by the publish process.
 
 ### `--contents <dir>`
 

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -54,7 +54,6 @@
     "path": "^0.12.7",
     "pify": "^5.0.0",
     "read-package-json": "^6.0.0",
-    "rimraf": "^3.0.2",
     "semver": "^7.3.8",
     "ssri": "^10.0.1",
     "tar": "^6.1.13",
@@ -70,6 +69,7 @@
     "@types/semver": "^7.3.13",
     "@types/write-pkg": "^4.0.0",
     "load-json-file": "^6.2.0",
+    "rimraf": "^3.0.2",
     "write-pkg": "^4.0.0",
     "yargs": "^17.6.2",
     "yargs-parser": "^21.1.1"

--- a/packages/publish/src/__tests__/publish-from-git.spec.ts
+++ b/packages/publish/src/__tests__/publish-from-git.spec.ts
@@ -136,7 +136,7 @@ describe('publish from-git', () => {
     const cwd = await initFixture('normal');
 
     await gitTag(cwd, 'v1.0.0');
-    await new PublishCommand(createArgv(cwd, 'from-git', '--no-sort', '--cleanup-temp-files'));
+    await new PublishCommand(createArgv(cwd, 'from-git', '--no-sort'));
 
     // called from chained describeRef()
     expect(throwIfUncommitted).toHaveBeenCalled();
@@ -192,7 +192,7 @@ describe('publish from-git', () => {
     const cwd = await initFixture('independent');
 
     await gitTag(cwd, 'package-3@3.0.0');
-    await new PublishCommand(createArgv(cwd, '--bump', 'from-git', '--cleanup-temp-files'));
+    await new PublishCommand(createArgv(cwd, '--bump', 'from-git'));
 
     expect((logOutput as any).logged()).toMatch('Found 1 package to publish:');
     expect((npmPublish as typeof npmPublishMock).order()).toEqual(['package-3']);
@@ -215,7 +215,7 @@ describe('publish from-git', () => {
     });
 
     const cwd = await initFixture('normal');
-    const command = new PublishCommand(createArgv(cwd, '--bump', 'from-git', '--cleanup-temp-files'));
+    const command = new PublishCommand(createArgv(cwd, '--bump', 'from-git'));
 
     await expect(command).rejects.toThrow('uncommitted');
     // notably different than the actual message, but good enough here

--- a/packages/publish/src/__tests__/publish-from-package.spec.ts
+++ b/packages/publish/src/__tests__/publish-from-package.spec.ts
@@ -158,7 +158,7 @@ describe('publish from-package', () => {
 
     // nuke the git repo first
     await fs.remove(path.join(cwd, '.git'));
-    await new PublishCommand(createArgv(cwd, 'from-package', '--cleanup-temp-files'));
+    await new PublishCommand(createArgv(cwd, 'from-package'));
 
     expect(npmPublish).toHaveBeenCalled();
     expect((writePkg as any).updatedManifest('package-1')).not.toHaveProperty('gitHead');
@@ -176,7 +176,7 @@ describe('publish from-package', () => {
 
     const cwd = await initFixture('independent');
 
-    await new PublishCommand(createArgv(cwd, 'from-package', '--git-head', 'deadbeef', '--cleanup-temp-files'));
+    await new PublishCommand(createArgv(cwd, 'from-package', '--git-head', 'deadbeef'));
 
     expect(npmPublish).toHaveBeenCalled();
     expect((writePkg as any).updatedManifest('package-1').gitHead).toBe('deadbeef');

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -6,7 +6,6 @@ import path from 'path';
 import crypto from 'crypto';
 import pMap from 'p-map';
 import pPipe from 'p-pipe';
-import rimraf from 'rimraf';
 import semver from 'semver';
 import tempDir from 'temp-dir';
 
@@ -332,10 +331,10 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     // optionally cleanup temp packed files after publish, opt-in option
     if (this.options.cleanupTempFiles) {
-      glob(path.join(tempDir, '/lerna-*'), (_err, deleteFiles) => {
+      glob(path.join(tempDir, '/lerna-*'), (_err, deleteFolders) => {
         // delete silently all files/folders that startsWith "lerna-"
-        deleteFiles.forEach((file) => rimraf(file, () => {}));
-        this.logger.verbose('publish', `Found ${deleteFiles.length} temp files/folders to cleanup after publish.`);
+        deleteFolders.forEach((folder) => fs.rmdir(folder, { recursive: true }, () => {}));
+        this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);
       });
     }
 

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import glob from 'glob';
-import fs from 'fs';
+import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import crypto from 'crypto';
@@ -319,7 +319,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
       });
       logOutput(jsonObject);
       try {
-        fs.writeFileSync(filePath, JSON.stringify(jsonObject));
+        fs.outputFileSync(filePath, JSON.stringify(jsonObject));
         logOutput('Publish summary created: ', filePath);
       } catch (error) {
         logOutput('Failed to create the summary report', error);
@@ -333,7 +333,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
     if (this.options.cleanupTempFiles) {
       glob(path.join(tempDir, '/lerna-*'), (_err, deleteFolders) => {
         // delete silently all files/folders that startsWith "lerna-"
-        deleteFolders.forEach((folder) => fs.rmdir(folder, { recursive: true }, () => {}));
+        deleteFolders.forEach((folder) => fs.removeSync(folder));
         this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);
       });
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,7 +490,6 @@ importers:
       path: 0.12.7
       pify: 5.0.0
       read-package-json: 6.0.0
-      rimraf: 3.0.2
       semver: 7.3.8
       ssri: 10.0.1
       tar: 6.1.13
@@ -505,6 +504,7 @@ importers:
       '@types/semver': 7.3.13
       '@types/write-pkg': 4.0.0
       load-json-file: 6.2.0
+      rimraf: 3.0.2
       write-pkg: 4.0.0
       yargs: 17.6.2
       yargs-parser: 21.1.1

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -1,10 +1,10 @@
 import glob from 'glob';
 import path from 'path';
-import rimraf from 'rimraf';
+import fs from 'fs';
 import tempDir from 'temp-dir';
 
-glob(path.join(tempDir, '/lerna-*'), (error, deleteFiles) => {
+glob(path.join(tempDir, '/lerna-*'), (error, deleteFolders) => {
   // delete silently all files/folders that startsWith "lerna-"
-  console.log(`Found ${deleteFiles.length} temp files/folders to cleanup.`);
-  (deleteFiles || []).forEach((file) => rimraf(file, () => {}));
+  console.log(`Found ${deleteFolders.length} temp files/folders to cleanup.`);
+  (deleteFolders || []).forEach((folder) => fs.rmdir(folder, { recursive: true }, () => {}));
 });

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -1,10 +1,10 @@
 import glob from 'glob';
 import path from 'path';
-import fs from 'fs';
+import fs from 'fs-extra';
 import tempDir from 'temp-dir';
 
 glob(path.join(tempDir, '/lerna-*'), (error, deleteFolders) => {
   // delete silently all files/folders that startsWith "lerna-"
   console.log(`Found ${deleteFolders.length} temp files/folders to cleanup.`);
-  (deleteFolders || []).forEach((folder) => fs.rmdir(folder, { recursive: true }, () => {}));
+  (deleteFolders || []).forEach((folder) => fs.removeSync(folder));
 });

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -5,6 +5,6 @@ import tempDir from 'temp-dir';
 
 glob(path.join(tempDir, '/lerna-*'), (error, deleteFolders) => {
   // delete silently all files/folders that startsWith "lerna-"
-  console.log(`Found ${deleteFolders.length} temp files/folders to cleanup.`);
+  console.log(`Found ${deleteFolders.length} temp folders to cleanup.`);
   (deleteFolders || []).forEach((folder) => fs.removeSync(folder));
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use common removeSync from fs-extra to cleanup temp files

## Motivation and Context

No need to use extra libraries like rimraf when we can simply use `fs.removeSync` which we already use to cleanup temp folders after publish execution 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
