### PR TITLE
fix(watch): remove watch stdin causing problem exiting the watch

### DIFF
--- a/packages/watch/README.md
+++ b/packages/watch/README.md
@@ -25,7 +25,6 @@ lerna watch
 
 ```sh
 $ lerna watch -- <command>
-# you can press "x" to exit the watch mode.
 ```
 
 The values `$LERNA_PACKAGE_NAME` and `$LERNA_FILE_CHANGES` will be replaced with the package name, the file that changed respectively. If multiple file changes are detected, they will all be listed and separated by a whitespace (unless custom file delimiter are provided).

--- a/packages/watch/src/__tests__/watch-command.spec.ts
+++ b/packages/watch/src/__tests__/watch-command.spec.ts
@@ -88,21 +88,6 @@ const createArgv = (cwd: string, ...args: string[]) => {
 };
 
 describe('Watch Command', () => {
-  const stdinIsTTY = process.stdin.isTTY;
-  const stdoutIsTTY = process.stdout.isTTY;
-  const stdin = mockStdin.stdin();
-
-  beforeEach(() => {
-    process.stdin.isTTY = true;
-    process.stdout.isTTY = true;
-  });
-
-  afterEach(() => {
-    process.stdin.isTTY = stdinIsTTY;
-    process.stdout.isTTY = stdoutIsTTY;
-    process.exitCode = undefined;
-  });
-
   describe('in a basic repo', () => {
     // working dir is never mutated
     let testDir;
@@ -498,24 +483,6 @@ describe('Watch Command', () => {
         reject: true,
         shell: true,
       });
-    });
-
-    it('should execute watch add callback and stop the watch process when typing "x" in the shell', async () => {
-      const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
-        throw new Error('process.exit: ' + number);
-      });
-
-      try {
-        // prettier-ignore
-        await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--', 'echo $LERNA_PACKAGE_NAME');
-        const promise = watchAddHandler('add', path.join(testDir, 'packages/package-2/some-file.ts'));
-        stdin.send('x');
-        stdin.end();
-        await promise;
-      } catch (e) {
-        expect(mockExit).toHaveBeenCalled();
-        mockExit.mockRestore();
-      }
     });
   });
 });

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -64,19 +64,6 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
 
     this._count = this._filteredPackages.length;
     this._packagePlural = this._count === 1 ? 'package' : 'packages';
-
-    // optional keystroke to exit the watch cleanly
-    if (process.stdin.isTTY) {
-      this.logger.info('watch', 'Press "x" to exit watch mode.');
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-      process.stdin.on('data', (key) => {
-        if (key.toString().toLowerCase() === 'x') {
-          this.logger.info('watch', 'Exiting the watch...');
-          process.exit(0);
-        }
-      });
-    }
   }
 
   async execute() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Rollback code that implemented stdin to watch for "x" to exit the watch, it seems problematic in some use case. 

## Motivation and Context

The stdin that was added in PR #472 seems to be causing a slight problem in some cases to exit the watch, until I can find a better way to implement this, I think it's just better to simply remove it and go back to a simple Ctrl+C to close the thread/watch

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
