### PR TITLE
fix(watch): watch execution shouldn't skip queued changes

### DIFF
--- a/packages/watch/src/models.ts
+++ b/packages/watch/src/models.ts
@@ -6,5 +6,6 @@ export interface ChangesStructure {
   [pkgName: string]: {
     pkg: Package;
     changeFiles: Set<string>;
+    timestamp: number;
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make sure all file that changed while a command is being processed are being pushed to the queue and not drop/skipped

## Motivation and Context

Changes that were being queued, while an execution was in progress, were being skipped. This PR fixes this problem and makes sure that whichever files are being queued while a command is being processed won't be dropped and be part of the execution

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
