### PR TITLE
fix(version): highlight version prop required in `lerna.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ changes and changelogs
 
 #### [Version](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version) and [Publish](https://github.com/lerna-lite/lerna-lite/tree/main/packages/publish) commands (included with the CLI)
 
-- Automate the rolling of new Versions (`independent` or `fixed`) of all your workspace packages.
+- Automate the rolling of new Versions (`independent` or fixed version) of all your workspace packages.
   - it will automatically Commit/Tag your new Version & create new GitHub/GitLab Release (when enabled).
 - Automate, when enabled, the creation of Changelogs for all your packages by reading all [Conventional Commits](https://www.conventionalcommits.org/) and a merged one in the project root.
 - Automate, when enabled, the repository Publishing of your new version for all your packages (NPM or other platforms).
@@ -176,6 +176,8 @@ Note that `package-a` will not be created, it is only shown here to help clarify
 Run the following commands to install Lerna-Lite in your project and/or install it globally by adding the `-g` option.
 
 If you are new to Lerna-Lite, you could also run the [lerna init](https://github.com/lerna-lite/lerna-lite/tree/main/packages/init#readme) command which will create the `lerna.json` for you with a minimal setup. If you are using a different client other than npm, then make sure to update the `npmClient` property in `lerna.json` (for example: `"npmClient": "yarn"` or `"pnpm"`).
+
+> **Note** please make sure that you have a `lerna.json` config file created and a `version` property defined with either a fixed or independent mode. An error will be thrown if you're missing any of them.
 
 ### JSON Schema
 You can add the `$schema` property into your `lerna.json` to take advantage of Lerna-Lite [JSON Schema](https://json-schema.org/) (`lerna init` will automatically configure this for you). This will help with the developer experience, users will be able to see what properties are valid with a brief description of what they do (each description are pulled from their associated lerna command options documentation).

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -288,7 +288,10 @@ export class Command<T extends AvailableCommandOption> {
     }
 
     if (!this.project.version) {
-      throw new ValidationError('ENOVERSION', 'Required property version does not exist in `lerna.json`');
+      throw new ValidationError(
+        'ENOVERSION',
+        'Required property `version` does not exist in `lerna.json`, make sure to provide one of two modes (fixed or independent). For example "version": "independent" OR "version": "1.0.0"'
+      );
     }
 
     if ((this.options as InitCommandOption).independent && !this.project.isIndependent()) {

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -20,6 +20,8 @@ npm install @lerna-lite/cli -D -W
 lerna version
 ```
 
+> **Note** please make sure that you have a `lerna.json` config file and a `version` property defined with either a fixed or independent mode (for example: `"version": "independent"`). An error will be thrown if you're missing any of them.
+
 ## Usage
 
 ```sh


### PR DESCRIPTION

## Description

highlight the fact that `version` is a required property to exist in the `lerna.json` config

## Motivation and Context

We should highlight the fact that `version` property is a required field that needs to be defined in `lerna.json`, there was a previous PR #431 that now throws an error but it wasn't clear enough that the user must really include such field in its `lerna.json` config. Closes #485

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
