### PR TITLE
chore(watch): add missing process exit and close chokidar watch cleanly

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "preview:watch:build": "lerna watch --no-bail --scope=@lerna-lite/listable --include-dependents -- cross-env-shell lerna run build:incremental --stream --include-dependents --scope=$LERNA_PACKAGE_NAME",
     "preview:watch:build:pnpm": "lerna watch --no-bail --scope=@lerna-lite/listable --include-dependents -- cross-env-shell pnpm run --stream --filter ...$LERNA_PACKAGE_NAME build:incremental",
     "preview:watch:files": "lerna watch --glob=\"src/**/*.ts\" --scope=@lerna-lite/listable --include-dependents -- cross-env-shell echo $LERNA_FILE_CHANGES in package $LERNA_PACKAGE_NAME\"",
-    "preview:watch:all": "lerna watch --watch-all-events --scope {@lerna-lite/watch,@lerna-lite/exec} -- cross-env-shell echo \"Changed files $LERNA_FILE_CHANGES in package $LERNA_PACKAGE_NAME\"",
     "preview:publish-alpha-dry-run": "lerna publish --dry-run --exact --include-merged-tags --preid alpha --dist-tag next prerelease",
     "preview:publish": "lerna publish from-package --dry-run",
     "preview:version": "lerna version --dry-run",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add code to cleanly close the Chokidar watch

## Motivation and Context

It's better to add proper Chokidar watch close and process.exit` for a cleaner exiting of the watch

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
