### PR TITLE
fix(version): validate yarn Berry >=2.0 before running yarn sync lock

### DIFF
--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -123,7 +123,7 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('npm', cwd, []);
 
-      expect(execSyncSpy).toHaveBeenCalled();
+      expect(execSyncSpy).toHaveBeenCalledWith('npm', ['--version']);
       expect(execSpy).toHaveBeenCalledWith('npm', ['install', '--package-lock-only'], { cwd });
       expect(lockFileOutput).toBe('package-lock.json');
     });
@@ -136,7 +136,7 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('npm', cwd, []);
 
-      expect(execSyncSpy).toHaveBeenCalled();
+      expect(execSyncSpy).toHaveBeenCalledWith('npm', ['--version']);
       expect(execSpy).toHaveBeenCalledWith('npm', ['shrinkwrap', '--package-lock-only'], { cwd });
       expect(renameSpy).toHaveBeenCalledWith('npm-shrinkwrap.json', 'package-lock.json');
       expect(lockFileOutput).toBe('package-lock.json');
@@ -149,7 +149,7 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('npm', cwd, ['--legacy-peer-deps']);
 
-      expect(execSyncSpy).toHaveBeenCalled();
+      expect(execSyncSpy).toHaveBeenCalledWith('npm', ['--version']);
       expect(execSpy).toHaveBeenCalledWith('npm', ['install', '--package-lock-only', '--legacy-peer-deps'], { cwd });
       expect(lockFileOutput).toBe('package-lock.json');
     });
@@ -161,7 +161,7 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('npm', cwd, ['--legacy-peer-deps,--force']);
 
-      expect(execSyncSpy).toHaveBeenCalled();
+      expect(execSyncSpy).toHaveBeenCalledWith('npm', ['--version']);
       expect(execSpy).toHaveBeenCalledWith('npm', ['install', '--package-lock-only', '--legacy-peer-deps', '--force'], {
         cwd,
       });
@@ -218,7 +218,22 @@ describe('run install lockfile-only', () => {
   });
 
   describe('yarn client', () => {
+    it(`should NOT update project root lockfile when yarn version is 1.0.0 and is below 2.0.0`, async () => {
+      const execSyncSpy = jest.spyOn(core, 'execSync').mockReturnValue('1.0.0');
+      jest.spyOn(nodeFs.promises, 'access').mockResolvedValue(true as any);
+      (nodeFs.renameSync as jest.Mock).mockImplementation(() => true);
+      (core.exec as jest.Mock).mockImplementation(() => true);
+      const execSpy = jest.spyOn(core, 'exec');
+      const cwd = await initFixture('lockfile-version2');
+
+      await runInstallLockFileOnly('yarn', cwd, []);
+
+      expect(execSyncSpy).toHaveBeenCalledWith('yarn', ['--version']);
+      expect(execSpy).not.toHaveBeenCalled();
+    });
+
     it(`should update project root lockfile by calling client script "yarn install --package-lock-only"`, async () => {
+      const execSyncSpy = jest.spyOn(core, 'execSync').mockReturnValue('3.0.0');
       jest.spyOn(nodeFs.promises, 'access').mockResolvedValue(true as any);
       (nodeFs.renameSync as jest.Mock).mockImplementation(() => true);
       (core.exec as jest.Mock).mockImplementation(() => true);
@@ -227,11 +242,13 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('yarn', cwd, []);
 
+      expect(execSyncSpy).toHaveBeenCalledWith('yarn', ['--version']);
       expect(execSpy).toHaveBeenCalledWith('yarn', ['install', '--mode', 'update-lockfile'], { cwd });
       expect(lockFileOutput).toBe('yarn.lock');
     });
 
     it(`should update project root lockfile by calling client script "yarn install --package-lock-only" with extra npm client arguments when provided`, async () => {
+      const execSyncSpy = jest.spyOn(core, 'execSync').mockReturnValue('4.0.0');
       jest.spyOn(nodeFs.promises, 'access').mockResolvedValue(true as any);
       (nodeFs.renameSync as jest.Mock).mockImplementation(() => true);
       (core.exec as jest.Mock).mockImplementation(() => true);
@@ -240,6 +257,7 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('yarn', cwd, ['--check-files']);
 
+      expect(execSyncSpy).toHaveBeenCalledWith('yarn', ['--version']);
       expect(execSpy).toHaveBeenCalledWith('yarn', ['install', '--mode', 'update-lockfile', '--check-files'], { cwd });
       expect(lockFileOutput).toBe('yarn.lock');
     });

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -148,7 +148,8 @@ export async function runInstallLockFileOnly(
       break;
     case 'yarn':
       inputLockfileName = 'yarn.lock';
-      if (await validateFileExists(path.join(cwd, inputLockfileName))) {
+      const yarnVersion = execSync('yarn', ['--version']);
+      if (semver.gte(yarnVersion, '2.0.0') && (await validateFileExists(path.join(cwd, inputLockfileName)))) {
         log.verbose('lock', `updating lock file via "yarn install --mode update-lockfile"`);
         await exec('yarn', ['install', '--mode', 'update-lockfile', ...npmClientArgs], { cwd });
         outputLockfileName = inputLockfileName;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using `--sync-workspace-lock` with Yarn, we should validate that it's Yarn Berry

## Motivation and Context

The `--sync-workspace-lock` option which runs  `yarn install --mode update-lockfile` will only work with Yarn Berry, so we should also make sure that the user does have the minimal Yarn version before trying to execute the command

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
