### PR TITLE
feat(version): add `--independent-subpackages` option, closes #491

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "preview:watch:files": "lerna watch --glob=\"src/**/*.ts\" --scope=@lerna-lite/listable --include-dependents -- cross-env-shell echo $LERNA_FILE_CHANGES in package $LERNA_PACKAGE_NAME\"",
     "preview:publish-alpha-dry-run": "lerna publish --dry-run --exact --include-merged-tags --preid alpha --dist-tag next prerelease",
     "preview:publish": "lerna publish from-package --dry-run",
-    "preview:version": "lerna version --dry-run --exclude-subpackages",
+    "preview:version": "lerna version --dry-run --independent-subpackages",
     "preview:roll-new-release": "pnpm build && pnpm new-version --dry-run && pnpm new-publish --dry-run",
     "new-version": "lerna version",
     "new-publish": "lerna publish from-package",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "preview:watch:files": "lerna watch --glob=\"src/**/*.ts\" --scope=@lerna-lite/listable --include-dependents -- cross-env-shell echo $LERNA_FILE_CHANGES in package $LERNA_PACKAGE_NAME\"",
     "preview:publish-alpha-dry-run": "lerna publish --dry-run --exact --include-merged-tags --preid alpha --dist-tag next prerelease",
     "preview:publish": "lerna publish from-package --dry-run",
-    "preview:version": "lerna version --dry-run",
+    "preview:version": "lerna version --dry-run --exclude-subpackages",
     "preview:roll-new-release": "pnpm build && pnpm new-version --dry-run && pnpm new-publish --dry-run",
     "new-version": "lerna version",
     "new-publish": "lerna publish from-package",

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -586,6 +586,9 @@
             "exact": {
               "$ref": "#/$defs/commandOptions/shared/exact"
             },
+            "excludeSubpackages": {
+              "$ref": "#/$defs/commandOptions/shared/excludeSubpackages"
+            },
             "forcePublish": {
               "$ref": "#/$defs/commandOptions/shared/forcePublish"
             },
@@ -1530,6 +1533,10 @@
         "exact": {
           "type": "boolean",
           "description": "During `lerna add`, save the exact version of the newly added package. During `lerna version`, specify cross-dependency version numbers exactly rather than with a caret (^)."
+        },
+        "excludeSubpackages": {
+          "type": "boolean",
+          "description": "Exclude sub-packages when versioning"
         },
         "ignorePrepublish": {
           "type": "boolean",

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -586,8 +586,8 @@
             "exact": {
               "$ref": "#/$defs/commandOptions/shared/exact"
             },
-            "excludeSubpackages": {
-              "$ref": "#/$defs/commandOptions/shared/excludeSubpackages"
+            "independentSubpackages": {
+              "$ref": "#/$defs/commandOptions/shared/independentSubpackages"
             },
             "forcePublish": {
               "$ref": "#/$defs/commandOptions/shared/forcePublish"
@@ -1534,7 +1534,7 @@
           "type": "boolean",
           "description": "During `lerna add`, save the exact version of the newly added package. During `lerna version`, specify cross-dependency version numbers exactly rather than with a caret (^)."
         },
-        "excludeSubpackages": {
+        "independentSubpackages": {
           "type": "boolean",
           "description": "Exclude sub-packages when versioning"
         },

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -111,7 +111,7 @@ export default {
         describe: 'Specify cross-dependency version numbers exactly rather than with a caret (^).',
         type: 'boolean',
       },
-      'exclude-subpackages': {
+      'independent-subpackages': {
         describe: 'Exclude sub-packages when versioning',
         type: 'boolean',
       },

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -111,6 +111,10 @@ export default {
         describe: 'Specify cross-dependency version numbers exactly rather than with a caret (^).',
         type: 'boolean',
       },
+      'exclude-subpackages': {
+        describe: 'Exclude sub-packages when versioning',
+        type: 'boolean',
+      },
       'force-publish': {
         describe: 'Always include targeted packages in versioning operations, skipping default logic.',
         // type must remain ambiguous because it is overloaded (boolean _or_ string _or_ array)

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -246,7 +246,7 @@ export interface VersionCommandOption {
   exact?: boolean;
 
   /** optionally exclude sub-packages when versioning */
-  excludeSubpackages?: boolean;
+  independentSubpackages?: boolean;
 
   /** Always include targeted packages in versioning operations, skipping default logic. */
   forcePublish?: boolean | string;

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -245,6 +245,9 @@ export interface VersionCommandOption {
   /** Specify cross-dependency version numbers exactly rather than with a caret (^). */
   exact?: boolean;
 
+  /** optionally exclude sub-packages when versioning */
+  excludeSubpackages?: boolean;
+
   /** Always include targeted packages in versioning operations, skipping default logic. */
   forcePublish?: boolean | string;
 

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -221,7 +221,7 @@ export interface UpdateCollectorOptions {
   excludeDependents?: boolean;
 
   /** optionally exclude sub-packages when versioning */
-  excludeSubpackages?: boolean;
+  independentSubpackages?: boolean;
 }
 
 export type RemoteClientType = 'gitlab' | 'github';

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -219,6 +219,9 @@ export interface UpdateCollectorOptions {
   conventionalCommits?: boolean;
   conventionalGraduate?: boolean | string;
   excludeDependents?: boolean;
+
+  /** optionally exclude sub-packages when versioning */
+  excludeSubpackages?: boolean;
 }
 
 export type RemoteClientType = 'gitlab' | 'github';

--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -74,7 +74,7 @@ describe('collectUpdates()', () => {
     expect(hasTags).toHaveBeenLastCalledWith(execOpts, '');
     expect(describeRefSync).toHaveBeenLastCalledWith(execOpts, undefined, false);
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
-      excludeSubpackages: undefined,
+      independentSubpackages: undefined,
     });
   });
 
@@ -97,7 +97,7 @@ describe('collectUpdates()', () => {
     expect(hasTags).toHaveBeenLastCalledWith(execOpts, '*@*');
     expect(describeRefSync).toHaveBeenLastCalledWith(execOpts, undefined, false);
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
-      excludeSubpackages: undefined,
+      independentSubpackages: undefined,
     });
   });
 
@@ -369,7 +369,7 @@ describe('collectUpdates()', () => {
       expect.objectContaining({ name: 'package-dag-3' }),
     ]);
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('deadbeef^..deadbeef', execOpts, undefined, {
-      excludeSubpackages: undefined,
+      independentSubpackages: undefined,
     });
   });
 
@@ -383,7 +383,7 @@ describe('collectUpdates()', () => {
     });
 
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('beefcafe', execOpts, undefined, {
-      excludeSubpackages: undefined,
+      independentSubpackages: undefined,
     });
   });
 
@@ -420,22 +420,22 @@ describe('collectUpdates()', () => {
     });
 
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, ['**/README.md'], {
-      excludeSubpackages: undefined,
+      independentSubpackages: undefined,
     });
   });
 
-  it('excludes packages when --exclude-subpackages option is enabled', () => {
+  it('excludes packages when --independent-subpackages option is enabled', () => {
     jest.spyOn(globby, 'sync').mockImplementationOnce(() => ['packages/pkg-2/and-another-thing/package.json']);
     const graph = buildGraph();
     const pkgs = graph.rawPackageList;
     const execOpts = { cwd: '/test' };
 
     collectUpdates(pkgs, graph, execOpts, {
-      excludeSubpackages: true,
+      independentSubpackages: true,
     });
 
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
-      excludeSubpackages: true,
+      independentSubpackages: true,
     });
   });
 });

--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -1,3 +1,4 @@
+import globby from 'globby';
 import { Package } from '../../../package';
 
 jest.mock('../../describe-ref');
@@ -72,7 +73,9 @@ describe('collectUpdates()', () => {
     ]);
     expect(hasTags).toHaveBeenLastCalledWith(execOpts, '');
     expect(describeRefSync).toHaveBeenLastCalledWith(execOpts, undefined, false);
-    expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined);
+    expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
+      excludeSubpackages: undefined,
+    });
   });
 
   it('returns node with changes in independent mode', () => {
@@ -93,7 +96,9 @@ describe('collectUpdates()', () => {
     ]);
     expect(hasTags).toHaveBeenLastCalledWith(execOpts, '*@*');
     expect(describeRefSync).toHaveBeenLastCalledWith(execOpts, undefined, false);
-    expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined);
+    expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
+      excludeSubpackages: undefined,
+    });
   });
 
   it('returns changed node and their dependents', () => {
@@ -363,7 +368,9 @@ describe('collectUpdates()', () => {
       expect.objectContaining({ name: 'package-dag-2a' }),
       expect.objectContaining({ name: 'package-dag-3' }),
     ]);
-    expect(makeDiffPredicate).toHaveBeenLastCalledWith('deadbeef^..deadbeef', execOpts, undefined);
+    expect(makeDiffPredicate).toHaveBeenLastCalledWith('deadbeef^..deadbeef', execOpts, undefined, {
+      excludeSubpackages: undefined,
+    });
   });
 
   it('uses revision provided by --since <ref>', () => {
@@ -375,7 +382,9 @@ describe('collectUpdates()', () => {
       since: 'beefcafe',
     });
 
-    expect(makeDiffPredicate).toHaveBeenLastCalledWith('beefcafe', execOpts, undefined);
+    expect(makeDiffPredicate).toHaveBeenLastCalledWith('beefcafe', execOpts, undefined, {
+      excludeSubpackages: undefined,
+    });
   });
 
   it('does not exit early on tagged release when --since <ref> is passed', () => {
@@ -410,6 +419,23 @@ describe('collectUpdates()', () => {
       ignoreChanges: ['**/README.md'],
     });
 
-    expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, ['**/README.md']);
+    expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, ['**/README.md'], {
+      excludeSubpackages: undefined,
+    });
+  });
+
+  it('excludes packages when --exclude-subpackages option is enabled', () => {
+    jest.spyOn(globby, 'sync').mockImplementationOnce(() => ['packages/pkg-2/and-another-thing/package.json']);
+    const graph = buildGraph();
+    const pkgs = graph.rawPackageList;
+    const execOpts = { cwd: '/test' };
+
+    collectUpdates(pkgs, graph, execOpts, {
+      excludeSubpackages: true,
+    });
+
+    expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
+      excludeSubpackages: true,
+    });
   });
 });

--- a/packages/core/src/utils/collect-updates/__tests__/lib-make-diff-predicate.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/lib-make-diff-predicate.spec.ts
@@ -84,7 +84,7 @@ test('ignore changes (match base)', () => {
   expect(result).toBe(false);
 });
 
-test('exclude subpackages when --exclude-subpackages option is enabled and nested package.json is found', () => {
+test('exclude subpackages when --independent-subpackages option is enabled and nested package.json is found', () => {
   jest.spyOn(globby, 'sync').mockImplementationOnce(() => ['packages/pkg-2/and-another-thing/package.json']);
 
   setup([
@@ -94,7 +94,7 @@ test('exclude subpackages when --exclude-subpackages option is enabled and neste
   ]);
 
   const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, ['**/examples/**', '*.md'], {
-    excludeSubpackages: true,
+    independentSubpackages: true,
   });
   const result = hasDiff({
     location: '/test/packages/pkg-2',
@@ -110,7 +110,7 @@ test('exclude subpackages when --exclude-subpackages option is enabled and neste
   );
 });
 
-test('not exclude any subpackages when --exclude-subpackages option is enabled but no nested package.json are found', () => {
+test('not exclude any subpackages when --independent-subpackages option is enabled but no nested package.json are found', () => {
   jest.spyOn(globby, 'sync').mockImplementationOnce(() => []);
 
   setup([
@@ -120,7 +120,7 @@ test('not exclude any subpackages when --exclude-subpackages option is enabled b
   ]);
 
   const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, ['**/examples/**', '*.md'], {
-    excludeSubpackages: true,
+    independentSubpackages: true,
   });
   const result = hasDiff({
     location: '/test/packages/pkg-2',

--- a/packages/core/src/utils/collect-updates/__tests__/lib-make-diff-predicate.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/lib-make-diff-predicate.spec.ts
@@ -1,5 +1,7 @@
 jest.mock('../../../child-process');
 
+import globby from 'globby';
+
 // mocked modules
 import * as childProcesses from '../../../child-process';
 
@@ -18,7 +20,7 @@ test('git diff call', () => {
     'packages/pkg-1/README.md',
   ]);
 
-  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' });
+  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, undefined, {});
   const result = hasDiff({
     location: '/test/packages/pkg-1',
   });
@@ -34,7 +36,7 @@ test('git diff call', () => {
 test('empty diff', () => {
   setup('');
 
-  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' });
+  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, undefined, {});
   const result = hasDiff({
     location: '/test/packages/pkg-1',
   });
@@ -45,7 +47,7 @@ test('empty diff', () => {
 test('rooted package', () => {
   setup('package.json');
 
-  const hasDiff = makeDiffPredicate('deadbeef', { cwd: '/test' });
+  const hasDiff = makeDiffPredicate('deadbeef', { cwd: '/test' }, undefined, {});
   const result = hasDiff({
     location: '/test',
   });
@@ -63,7 +65,7 @@ test('ignore changes (globstars)', () => {
     'packages/pkg-2/examples/and-another-thing/package.json',
   ]);
 
-  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, ['**/examples/**', '*.md']);
+  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, ['**/examples/**', '*.md'], {});
   const result = hasDiff({
     location: '/test/packages/pkg-2',
   });
@@ -74,10 +76,62 @@ test('ignore changes (globstars)', () => {
 test('ignore changes (match base)', () => {
   setup('packages/pkg-3/README.md');
 
-  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, ['*.md']);
+  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, ['*.md'], {});
   const result = hasDiff({
     location: '/test/packages/pkg-3',
   });
 
   expect(result).toBe(false);
+});
+
+test('exclude subpackages when --exclude-subpackages option is enabled and nested package.json is found', () => {
+  jest.spyOn(globby, 'sync').mockImplementationOnce(() => ['packages/pkg-2/and-another-thing/package.json']);
+
+  setup([
+    'packages/pkg-2/package.json',
+    'packages/pkg-2/do-a-thing/index.js',
+    'packages/pkg-2/and-another-thing/package.json',
+  ]);
+
+  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, ['**/examples/**', '*.md'], {
+    excludeSubpackages: true,
+  });
+  const result = hasDiff({
+    location: '/test/packages/pkg-2',
+  });
+
+  expect(result).toBe(true);
+  expect(childProcesses.execSync).toHaveBeenLastCalledWith(
+    'git',
+    ['diff', '--name-only', 'v1.0.0', '--', 'packages/pkg-2', ':^packages/pkg-2/packages/pkg-2/and-another-thing'],
+    {
+      cwd: '/test',
+    }
+  );
+});
+
+test('not exclude any subpackages when --exclude-subpackages option is enabled but no nested package.json are found', () => {
+  jest.spyOn(globby, 'sync').mockImplementationOnce(() => []);
+
+  setup([
+    'packages/pkg-2/package.json',
+    'packages/pkg-2/do-a-thing/index.js',
+    'packages/pkg-2/and-another-thing/method.js',
+  ]);
+
+  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, ['**/examples/**', '*.md'], {
+    excludeSubpackages: true,
+  });
+  const result = hasDiff({
+    location: '/test/packages/pkg-2',
+  });
+
+  expect(result).toBe(true);
+  expect(childProcesses.execSync).toHaveBeenLastCalledWith(
+    'git',
+    ['diff', '--name-only', 'v1.0.0', '--', 'packages/pkg-2'],
+    {
+      cwd: '/test',
+    }
+  );
 });

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -23,7 +23,14 @@ export function collectUpdates(
   commandOptions: UpdateCollectorOptions,
   dryRun = false
 ) {
-  const { forcePublish, conventionalCommits, conventionalGraduate, excludeDependents, isIndependent } = commandOptions;
+  const {
+    forcePublish,
+    conventionalCommits,
+    conventionalGraduate,
+    excludeDependents,
+    excludeSubpackages,
+    isIndependent,
+  } = commandOptions;
 
   // If --conventional-commits and --conventional-graduate are both set, ignore --force-publish
   const useConventionalGraduate = conventionalCommits && conventionalGraduate;
@@ -96,7 +103,9 @@ export function collectUpdates(
 
   log.info('', `Looking for changed packages since ${committish}`);
 
-  const hasDiff = makeDiffPredicate(committish as string, execOpts, commandOptions.ignoreChanges as string[]);
+  const hasDiff = makeDiffPredicate(committish as string, execOpts, commandOptions.ignoreChanges as string[], {
+    excludeSubpackages,
+  });
   const needsBump =
     !commandOptions.bump || commandOptions.bump.startsWith('pre')
       ? () => false

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -28,7 +28,7 @@ export function collectUpdates(
     conventionalCommits,
     conventionalGraduate,
     excludeDependents,
-    excludeSubpackages,
+    independentSubpackages,
     isIndependent,
   } = commandOptions;
 
@@ -104,7 +104,7 @@ export function collectUpdates(
   log.info('', `Looking for changed packages since ${committish}`);
 
   const hasDiff = makeDiffPredicate(committish as string, execOpts, commandOptions.ignoreChanges as string[], {
-    excludeSubpackages,
+    independentSubpackages,
   });
   const needsBump =
     !commandOptions.bump || commandOptions.bump.startsWith('pre')

--- a/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
+++ b/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
@@ -16,7 +16,7 @@ export function makeDiffPredicate(
   committish: string,
   execOpts: ExecOpts,
   ignorePatterns: string[] = [],
-  diffOpts: { excludeSubpackages?: boolean }
+  diffOpts: { independentSubpackages?: boolean }
 ) {
   const ignoreFilters = new Set(
     ignorePatterns.map((p) =>
@@ -68,18 +68,18 @@ function diffSinceIn(
   committish: string,
   location: string,
   execOpts: ExecOpts,
-  diffOpts: { excludeSubpackages?: boolean }
+  diffOpts: { independentSubpackages?: boolean }
 ) {
   const args = ['diff', '--name-only', committish];
   const formattedLocation = slash(path.relative(execOpts.cwd, location));
 
   if (formattedLocation) {
     // avoid same-directory path.relative() === ""
-    let excludeSubpackages: string[] = [];
+    let independentSubpackages: string[] = [];
 
     // optionally exclude sub-packages
-    if (diffOpts?.excludeSubpackages) {
-      excludeSubpackages = globby
+    if (diffOpts?.independentSubpackages) {
+      independentSubpackages = globby
         .sync('**/*/package.json', {
           cwd: formattedLocation,
           nodir: true,
@@ -89,7 +89,7 @@ function diffSinceIn(
     }
 
     // avoid same-directory path.relative() === ""
-    args.push('--', formattedLocation, ...excludeSubpackages);
+    args.push('--', formattedLocation, ...independentSubpackages);
   }
 
   log.silly('checking diff', formattedLocation);

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -424,7 +424,7 @@ For more information, see the package.json [dependencies](https://docs.npmjs.com
 lerna version --independent-subpackages
 ```
 
-When run with this flag, `lerna version` will exclude versioning of nested subpackages. For example if `package B` is a subpackage of `package A` and we have changes in both packages, calling a new version will lead to a new version in both package. However if we wanted to bump the version of the parent package only, we could simply use `--independent-subpackages`.
+If `package B`, being a child of `package A`, has changes they will normally both get bumped although `package A` itself is eventually unchanged. If this flag is enabled and only `package B` was actually changed, `package A` will not get bumped if it does not have any changes on its own.
 
 ### `--force-publish`
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -83,7 +83,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--changelog-version-message <msg>`](#--changelog-version-message-msg) (new)
     - [`--create-release <type>`](#--create-release-type)
     - [`--exact`](#--exact)
-    - [`----exclude-subpackages`](#----exclude-subpackages)
+    - [`--independent-subpackages`](#--independent-subpackages)
     - [`--force-publish`](#--force-publish)
     - [`--git-tag-command <cmd>`](#--git-tag-command-cmd) (new)
     - [`--dry-run`](#--dry-run) (new)
@@ -418,13 +418,13 @@ When run with this flag, `lerna version` will specify updated dependencies in up
 
 For more information, see the package.json [dependencies](https://docs.npmjs.com/files/package.json#dependencies) documentation.
 
-### `--exclude-subpackages`
+### `--independent-subpackages`
 
 ```sh
-lerna version --exclude-subpackages
+lerna version --independent-subpackages
 ```
 
-When run with this flag, `lerna version` will exclude versioning of nested subpackages. For example if `package B` is a subpackage of `package A` and we have changes in both packages, calling a new version will lead to a new version in both package. However if we wanted to bump the version of the parent package only, we could simply use `--exclude-subpackages`.
+When run with this flag, `lerna version` will exclude versioning of nested subpackages. For example if `package B` is a subpackage of `package A` and we have changes in both packages, calling a new version will lead to a new version in both package. However if we wanted to bump the version of the parent package only, we could simply use `--independent-subpackages`.
 
 ### `--force-publish`
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -83,6 +83,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--changelog-version-message <msg>`](#--changelog-version-message-msg) (new)
     - [`--create-release <type>`](#--create-release-type)
     - [`--exact`](#--exact)
+    - [`----exclude-subpackages`](#----exclude-subpackages)
     - [`--force-publish`](#--force-publish)
     - [`--git-tag-command <cmd>`](#--git-tag-command-cmd) (new)
     - [`--dry-run`](#--dry-run) (new)
@@ -416,6 +417,14 @@ lerna version --exact
 When run with this flag, `lerna version` will specify updated dependencies in updated packages exactly (with no punctuation), instead of as semver compatible (with a `^`).
 
 For more information, see the package.json [dependencies](https://docs.npmjs.com/files/package.json#dependencies) documentation.
+
+### `--exclude-subpackages`
+
+```sh
+lerna version --exclude-subpackages
+```
+
+When run with this flag, `lerna version` will exclude versioning of nested subpackages. For example if `package B` is a subpackage of `package A` and we have changes in both packages, calling a new version will lead to a new version in both package. However if we wanted to bump the version of the parent package only, we could simply use `--exclude-subpackages`.
 
 ### `--force-publish`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new `--independent-subpackages` option to avoid shipping nested 

## Motivation and Context

Closes issue #491 

> As a developer using Lerna-Lite I would love to have the possibility to work with nested packages in a way that changes to a `package B` being a subpackage of `package A` directory-wise do not lead to a version-change of `package A` on `lerna version` purely due to `git diff` but only if `package A` actaully depends on `package B`. This example reflects our current development structure but produces many new, but unnecessary, versions.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
