### PR TITLE
docs(exec): add note to wrap lerna exec commands in quotes when run from shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "lerna": "lerna",
     "clean": "rimraf packages/dist",
     "clean:tarball": "rimraf packages/**/*.tgz",
     "build": "pnpm lint && pnpm -r --stream build",
@@ -12,6 +13,7 @@
     "diff-cmd": "lerna diff",
     "list-cmd": "lerna list --all",
     "exec-win": "lerna exec --scope {@lerna-lite/cli,@lerna-lite/core} -- cross-env-shell echo hello from package: $LERNA_PACKAGE_NAME",
+    "exec:preview": "lerna exec -- git log -p -2",
     "pack-tarball": "lerna run pack-tarball",
     "pack-tarball:nx": "lerna run pack-tarball --stream --use-nx",
     "preview:build": "lerna run build --stream --include-dependents --scope=@lerna-lite/listable",

--- a/packages/exec/README.md
+++ b/packages/exec/README.md
@@ -52,6 +52,8 @@ $ lerna exec -- node \$LERNA_ROOT_PATH/scripts/some-script.js
 $ lerna exec --scope my-component -- ls -la
 ```
 
+> **Note** When executing the command in the shell, you will need to surround the command provided to `lerna exec` in quotes (what comes after double-dash ` -- `). Without this, the entire line is interpreted by your shell before lerna ever sees it and causes command flags to be returned as unknown. For example `lerna exec -- 'git log -p -2'`. This is not required when used as an npm script.
+
 - [`@lerna/exec`](#lernaexec)
   - [Usage](#usage)
   - [Options](#options)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When executing the command in the shell, you will need to surround the command provided to `lerna exec` in quotes (what comes after double-dash ` -- `). Without this, the entire line is interpreted by your shell before lerna ever sees it and causes command flags to be returned as unknown. For example `lerna exec -- 'git log -p -2'`. This is not required when used as an npm script.

## Motivation and Context

- closes #493 

Provide necessary documentation to address issue #493, it will still require the command to be wrapped in quotes and we can't do anything to change that since that was mentioned by the original Lerna maintainer in this [comment](https://github.com/lerna/lerna/issues/1965#issuecomment-491431307)

> Yeah, woulda told you to single-quote the whole command after `--` had I seen this earlier, sorry. If you don't, as you discovered, the entire line is interpreted by `bash` before `lerna` ever sees it, and `&&` is not passed into `process.argv`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
