### PR TITLE
chore: exclude cosmiconfig from Renovate update for now

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,10 @@
       packageNames: ['glob'],
       allowedVersions: '7.2.3',
     },
+    {
+      packageNames: ['cosmiconfig'],
+      allowedVersions: '8.0.0',
+    },
   ],
   schedule: ['on Thursday'],
   ignoreDeps: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Renovate just ran and latest version from `cosmiconfig` seems to causing issues, let's ignore `cosmiconfig` for now so that we can merge the other deps

## Motivation and Context

ignore `cosmiconfig` which is causing PR #496 to fail, we will reenable it after PR #496 is updated without `cosmiconfig` so that we can merge the update of the other deps

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
