### PR TITLE
fix(publish): ensure zero exit code when EWORKINGTREE warning occurs

### DIFF
--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -393,6 +393,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           // (we tried)
           this.logger.silly('EWORKINGTREE', err.message);
           this.logger.notice('FYI', 'Unable to verify working tree, proceed at your own risk');
+          process.exitCode = 0;
         } else {
           // validation errors should be preserved
           throw err;


### PR DESCRIPTION


## Description

As per Lerna [PR 3327](https://github.com/lerna/lerna/pull/3327)

> when verifyWorkingTreeClean error happend set exitCode to 0

## Motivation and Context

> fixed error when run "lerna publish from-package" in package.json scripts

## How Has This Been Tested?

As per Lerna PR

> 1. add publish:'lerna publish from-package" to package.json->"scripts"
> 2. exec "npm run publish" in terminal
> 3. everything well done

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
