### PR TITLE
fix(version): sign tags sequentially to prevent gpg issues with many tags

### DIFF
--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -814,9 +814,9 @@ export class VersionCommand extends Command<VersionCommandOption> {
     const message = tags.reduce((msg, tag) => `${msg}${os.EOL} - ${tag}`, `${subject}${os.EOL}`);
 
     await gitCommit(message, this.gitOpts, this.execOpts, this.options.dryRun);
-    await Promise.all(
-      tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand, this.options.dryRun))
-    );
+    for (const tag of tags) {
+      await gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand, this.options.dryRun);
+    }
 
     return tags;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tags are signed sequentially 

## Motivation and Context

fixes https://github.com/lerna-lite/lerna-lite/issues/510#issue-1619420415

Simultaneously executing `git tag ... --sign` seems to be an issue. I still have no clue why exactly gpg starts to fail.

On the other hand sequentially signing even with 16 tags has a barely noticeable difference in speed compared to simultanously executing a sign requests.


## How Has This Been Tested?

Unfortunately the issue seems to be a timing issue with gpg, thus i repeated signing 10 times of which non failed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
