### PR TITLE
feat(publish): support git "describeTag" configuration in version/publish commands

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts=true
+registry=https://registry.npmjs.org/

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -23,6 +23,11 @@
       "description": "When true, Lerna will delegate the implementation details of `lerna run` to the Nx task runner instead of the default Lerna task runner (which uses `p-map` and `p-queue`).",
       "default": false
     },
+    "describeTag": {
+      "type": "string",
+      "description": "During `lerna publish` (not `from-git` mode) and `lerna version`, the package updated since the last release will be found based on the describeTag.",
+      "default": ""
+    },
     "command": {
       "type": "object",
       "description": "Options for individual Lerna commands.",

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -187,6 +187,9 @@ export interface ProjectConfig extends LernaConfig, QueryGraphConfig {
 
   /** callback to execute when Promise resolved */
   onResolved?: (result: any) => void;
+
+  /** custom tag pattern, default is "*@*" */
+  describeTag?: string;
 }
 
 /** The subset of package.json properties that Lerna-Lite uses */
@@ -214,6 +217,8 @@ export interface UpdateCollectorOptions {
 
   /** are we using Lerna independent mode? */
   isIndependent?: boolean;
+  /** custom describe tag */
+  describeTag?: string;
 
   /** are we using conventional commits? */
   conventionalCommits?: boolean;

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -188,7 +188,7 @@ export interface ProjectConfig extends LernaConfig, QueryGraphConfig {
   /** callback to execute when Promise resolved */
   onResolved?: (result: any) => void;
 
-  /** custom tag pattern, default is "*@*" */
+  /** custom tag pattern, default is `*@*` (independent mode) or `*v*` (non-independent mode) */
   describeTag?: string;
 }
 

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -188,7 +188,7 @@ export interface ProjectConfig extends LernaConfig, QueryGraphConfig {
   /** callback to execute when Promise resolved */
   onResolved?: (result: any) => void;
 
-  /** custom tag pattern, default is `*@*` (independent mode) or `*v*` (non-independent mode) */
+  /** custom tag pattern, default is `*@*` (independent mode) or `""` (non-independent mode) */
   describeTag?: string;
 }
 

--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -474,8 +474,9 @@ describe('collectUpdates()', () => {
       isIndependent: false,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test'}, true, false);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test' }, true, false);
   });
+
   it('use "describeTag" with empty value in independent mode', async () => {
     const graph = buildGraph();
     const pkgs = graph.rawPackageList;

--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -71,8 +71,8 @@ describe('collectUpdates()', () => {
         name: 'package-standalone',
       }),
     ]);
-    expect(hasTags).toHaveBeenLastCalledWith(execOpts, '');
-    expect(describeRefSync).toHaveBeenLastCalledWith(execOpts, undefined, false);
+    expect(hasTags).toHaveBeenLastCalledWith(execOpts, '*v*');
+    expect(describeRefSync).toHaveBeenLastCalledWith({ cwd: '/test', match: '*v*' }, undefined, false);
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
       independentSubpackages: undefined,
     });
@@ -474,7 +474,19 @@ describe('collectUpdates()', () => {
       isIndependent: false,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test' }, true, false);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*custom-tag*' }, true, false);
+  });
+
+  it('no use "describeTag" in non-independent mode', async () => {
+    const graph = buildGraph();
+    const pkgs = graph.rawPackageList;
+    const execOpts = { cwd: '/test' };
+
+    collectUpdates(pkgs, graph, execOpts, {
+      isIndependent: false,
+      includeMergedTags: true,
+    });
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*v*' }, true, false);
   });
 
   it('use "describeTag" with empty value in independent mode', async () => {

--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -438,4 +438,54 @@ describe('collectUpdates()', () => {
       independentSubpackages: true,
     });
   });
+
+  it('use "describeTag" in independent mode', async () => {
+    const graph = buildGraph();
+    const pkgs = graph.rawPackageList;
+    const execOpts = { cwd: '/test' };
+
+    collectUpdates(pkgs, graph, execOpts, {
+      describeTag: '*custom-tag*',
+      isIndependent: true,
+      includeMergedTags: true,
+    });
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*custom-tag*' }, true, false);
+  });
+
+  it('no use "describeTag" in independent mode', async () => {
+    const graph = buildGraph();
+    const pkgs = graph.rawPackageList;
+    const execOpts = { cwd: '/test' };
+
+    collectUpdates(pkgs, graph, execOpts, {
+      isIndependent: true,
+      includeMergedTags: true,
+    });
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*@*' }, true, false);
+  });
+
+  it('use "describeTag" in non-independent mode', async () => {
+    const graph = buildGraph();
+    const pkgs = graph.rawPackageList;
+    const execOpts = { cwd: '/test' };
+
+    collectUpdates(pkgs, graph, execOpts, {
+      describeTag: '*custom-tag*',
+      isIndependent: false,
+      includeMergedTags: true,
+    });
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test'}, true, false);
+  });
+  it('use "describeTag" with empty value in independent mode', async () => {
+    const graph = buildGraph();
+    const pkgs = graph.rawPackageList;
+    const execOpts = { cwd: '/test' };
+
+    collectUpdates(pkgs, graph, execOpts, {
+      describeTag: '',
+      isIndependent: true,
+      includeMergedTags: true,
+    });
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*@*' }, true, false);
+  });
 });

--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -71,8 +71,8 @@ describe('collectUpdates()', () => {
         name: 'package-standalone',
       }),
     ]);
-    expect(hasTags).toHaveBeenLastCalledWith(execOpts, '*v*');
-    expect(describeRefSync).toHaveBeenLastCalledWith({ cwd: '/test', match: '*v*' }, undefined, false);
+    expect(hasTags).toHaveBeenLastCalledWith(execOpts, '');
+    expect(describeRefSync).toHaveBeenLastCalledWith({ cwd: '/test', match: '' }, undefined, false);
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
       independentSubpackages: undefined,
     });
@@ -486,7 +486,7 @@ describe('collectUpdates()', () => {
       isIndependent: false,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*v*' }, true, false);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '' }, true, false);
   });
 
   it('use "describeTag" with empty value in independent mode', async () => {

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -45,19 +45,14 @@ export function collectUpdates(
       : new Map(filteredPackages.map(({ name }) => [name, packageGraph.get(name)]));
 
   let committish = commandOptions.since;
-  let tagPattern = '';
-  if (isIndependent) {
-    tagPattern = describeTag ? describeTag : '*@*';
-  }
+  const tagPattern = describeTag ? describeTag : isIndependent ? '*@*' : '*v*';
 
   if (hasTags(execOpts, tagPattern)) {
     const describeOptions: DescribeRefOptions = {
       ...execOpts,
     };
 
-    if (isIndependent) {
-      describeOptions.match = tagPattern;
-    }
+    describeOptions.match = tagPattern;
 
     // describe the last annotated tag in the current branch
     const { sha, refCount, lastTagName } = describeRefSync(describeOptions, commandOptions.includeMergedTags, dryRun);

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -45,7 +45,7 @@ export function collectUpdates(
       : new Map(filteredPackages.map(({ name }) => [name, packageGraph.get(name)]));
 
   let committish = commandOptions.since;
-  const tagPattern = describeTag ? describeTag : isIndependent ? '*@*' : '*v*';
+  const tagPattern = describeTag ? describeTag : isIndependent ? '*@*' : '';
 
   if (hasTags(execOpts, tagPattern)) {
     const describeOptions: DescribeRefOptions = {

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -30,6 +30,7 @@ export function collectUpdates(
     excludeDependents,
     independentSubpackages,
     isIndependent,
+    describeTag,
   } = commandOptions;
 
   // If --conventional-commits and --conventional-graduate are both set, ignore --force-publish
@@ -44,7 +45,10 @@ export function collectUpdates(
       : new Map(filteredPackages.map(({ name }) => [name, packageGraph.get(name)]));
 
   let committish = commandOptions.since;
-  const tagPattern = isIndependent ? '*@*' : '';
+  let tagPattern = '';
+  if (isIndependent) {
+    tagPattern = describeTag ? describeTag : '*@*';
+  }
 
   if (hasTags(execOpts, tagPattern)) {
     const describeOptions: DescribeRefOptions = {

--- a/packages/listable/package.json
+++ b/packages/listable/package.json
@@ -36,5 +36,8 @@
     "@lerna-lite/core": "workspace:*",
     "chalk": "^4.1.2",
     "columnify": "^1.6.0"
+  },
+  "devDependencies": {
+    "yargs": "^17.7.1"
   }
 }

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -31,8 +31,10 @@ lerna publish from-package  # explicitly publish packages where the latest versi
 When run, this command does one of the following things:
 
 - Publish packages updated since the last release (calling [`lerna version`](https://github.com/lerna-lite/lerna-lite/blob/main/packages/version/README.md) behind the scenes).
-  - This is the legacy behavior of lerna 2.x
+  - This is the legacy behavior of lerna 2.x.
+  - The package updated since the last release will be found based on the `describeTag` pattern (For details, refer to [`lerna version`](https://github.com/lerna-lite/lerna-lite/blob/main/packages/version/README.md#describeTag)).
 - Publish packages tagged in the current commit (`from-git`).
+  - The describe tag pattern is `*@*` (independent mode) or `*v*` (non-independent mode)
 - Publish packages in the latest commit where the version is not present in the registry (`from-package`).
 - Publish an unversioned "canary" release of packages (and their dependents) updated in the previous commit.
 

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -34,7 +34,6 @@ When run, this command does one of the following things:
   - This is the legacy behavior of lerna 2.x.
   - The package updated since the last release will be found based on the `describeTag` pattern (For details, refer to [`lerna version`](https://github.com/lerna-lite/lerna-lite/blob/main/packages/version/README.md#describeTag)).
 - Publish packages tagged in the current commit (`from-git`).
-  - The describe tag pattern is `*@*` (independent mode) or `*v*` (non-independent mode)
 - Publish packages in the latest commit where the version is not present in the registry (`from-package`).
 - Publish an unversioned "canary" release of packages (and their dependents) updated in the previous commit.
 

--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -172,6 +172,7 @@ test("publish --canary --tag-version-prefix='abc'", async () => {
       "package-1": 1.0.1-alpha.0+SHA,
       "package-2": 1.0.1-alpha.0+SHA,
       "package-3": 1.0.1-alpha.0+SHA,
+      "package-4": 1.0.1-alpha.0+SHA,
     }
   `);
 });

--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -172,7 +172,6 @@ test("publish --canary --tag-version-prefix='abc'", async () => {
       "package-1": 1.0.1-alpha.0+SHA,
       "package-2": 1.0.1-alpha.0+SHA,
       "package-3": 1.0.1-alpha.0+SHA,
-      "package-4": 1.0.1-alpha.0+SHA,
     }
   `);
 });

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -735,4 +735,17 @@ describe('PublishCommand', () => {
       await expect(command).rejects.toThrow('Dependency cycles detected, you should fix these!');
     });
   });
+  describe('"describeTag" config', () => {
+    it('set "describeTag" in lerna.json', async () => {
+      const testDir = await initFixture('normal');
+
+      await fs.outputJSON(path.join(testDir, 'lerna.json'), {
+        version: 'independent',
+        describeTag: '*custom-tag*'
+      });
+      await new PublishCommand(createArgv(testDir, '--canary'));
+      expect(collectUpdates.mock.calls[0][3].describeTag).toBe('*custom-tag*');
+      expect(collectUpdates.mock.calls[0][3].isIndependent).toBe(true);
+    });
+  });
 });

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -735,16 +735,19 @@ describe('PublishCommand', () => {
       await expect(command).rejects.toThrow('Dependency cycles detected, you should fix these!');
     });
   });
+
   describe('"describeTag" config', () => {
     it('set "describeTag" in lerna.json', async () => {
       const testDir = await initFixture('normal');
 
       await fs.outputJSON(path.join(testDir, 'lerna.json'), {
         version: 'independent',
-        describeTag: '*custom-tag*'
+        describeTag: '*custom-tag*',
       });
       await new PublishCommand(createArgv(testDir, '--canary'));
+
       expect(collectUpdates.mock.calls[0][3].describeTag).toBe('*custom-tag*');
+
       expect(collectUpdates.mock.calls[0][3].isIndependent).toBe(true);
     });
   });

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -447,6 +447,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
       });
 
     const isIndependent = this.project.isIndependent();
+    const describeTag = this.project.config.describeTag;
 
     // find changed packages since last release, if any
     chain = chain.then(() =>
@@ -461,6 +462,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           forcePublish,
           includeMergedTags,
           isIndependent,
+          describeTag,
           // private packages are never published, don't bother describing their refs.
         } as UpdateCollectorOptions,
         this.options.dryRun

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -854,3 +854,16 @@ Will apply the following updates to your `package.json` (assuming a `minor` vers
 ```
 
 > **Note** semver range with an operator (ie `workspace:>=2.0.0`) are also supported but will never be mutated.
+
+## describeTag
+When `lerna version` is executed, it will identifies packages that have been updated since the previous tagged release. The rules it identifies are based on describe tag pattern (excuted `git describe --match` behind the scenes).
+
+The tag pattern defaults to `*@*` (independent mode) or `*v*` (non-independent mode). You can configure `describeTag` in `lerna.json` to specify the tag pattern.
+
+The `describeTag` will also take effect under `lerna publish`, for example `lerna publish --canary`, but it will not take effect under `lerna publish from-git`.
+
+```
+{
+  describeTag: "*lerna-project*"
+}
+```

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -858,7 +858,7 @@ Will apply the following updates to your `package.json` (assuming a `minor` vers
 ## describeTag
 When `lerna version` is executed, it will identifies packages that have been updated since the previous tagged release. The rules it identifies are based on describe tag pattern (excuted `git describe --match` behind the scenes).
 
-The tag pattern defaults to `*@*` (independent mode) or `*v*` (non-independent mode). You can configure `describeTag` in `lerna.json` to specify the tag pattern.
+The tag pattern defaults to `*@*` (independent mode) or `""` (non-independent mode). You can configure `describeTag` in `lerna.json` to specify the tag pattern.
 
 The `describeTag` will also take effect under `lerna publish`, for example `lerna publish --canary`, but it will not take effect under `lerna publish from-git`.
 

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -1087,12 +1087,13 @@ describe('VersionCommand', () => {
 
       await fs.outputJSON(path.join(testDir, 'lerna.json'), {
         version: 'independent',
-        describeTag: '*custom-tag*'
+        describeTag: '*custom-tag*',
       });
       await new VersionCommand(createArgv(testDir));
+
       expect(collectUpdates.mock.calls[0][3].describeTag).toBe('*custom-tag*');
+
       expect(collectUpdates.mock.calls[0][3].isIndependent).toBe(true);
     });
   });
-
 });

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -1080,4 +1080,19 @@ describe('VersionCommand', () => {
       expect(logMessages).toContain('Arguments after -- are no longer passed to subprocess executions.');
     });
   });
+
+  describe('"describeTag" config', () => {
+    it('set "describeTag" in lerna.json', async () => {
+      const testDir = await initFixture('normal');
+
+      await fs.outputJSON(path.join(testDir, 'lerna.json'), {
+        version: 'independent',
+        describeTag: '*custom-tag*'
+      });
+      await new VersionCommand(createArgv(testDir));
+      expect(collectUpdates.mock.calls[0][3].describeTag).toBe('*custom-tag*');
+      expect(collectUpdates.mock.calls[0][3].isIndependent).toBe(true);
+    });
+  });
+
 });

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -164,6 +164,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
 
   async initialize() {
     const isIndependent = this.project.isIndependent();
+    const describeTag = this.project.config.describeTag;
+
     if (!isIndependent) {
       this.logger.info('current project version', this.project.version ?? '');
     }
@@ -299,6 +301,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
     this.updates = collectUpdates(this.packageGraph.rawPackageList, this.packageGraph, this.execOpts, {
       ...this.options,
       isIndependent,
+      describeTag,
     } as UpdateCollectorOptions).filter((node) => {
       // --no-private completely removes private packages from consideration
       if (node.pkg.private && this.options.private === false) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,10 +362,13 @@ importers:
       '@lerna-lite/core': workspace:*
       chalk: ^4.1.2
       columnify: ^1.6.0
+      yargs: ^17.7.1
     dependencies:
       '@lerna-lite/core': link:../core
       chalk: 4.1.2
       columnify: 1.6.0
+    devDependencies:
+      yargs: 17.7.1
 
   packages/profiler:
     specifiers:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `descripteTag` in the `lerna.json` configuration to allow users to customize the tag pattern. If `descripteTag` is not configured, the tag pattern defaults to`*@*`.

However, it is not supported in `lerna publish from-git`, only in `version`, `publish -- canary`


## Motivation and Context

Add feature to fix #507 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
