### PR TITLE
fix(core): ignore globby pattern type should be an array not a string

### DIFF
--- a/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
+++ b/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
@@ -83,7 +83,7 @@ function diffSinceIn(
         .sync('**/*/package.json', {
           cwd: formattedLocation,
           nodir: true,
-          ignore: '**/node_modules/**',
+          ignore: ['**/node_modules/**'],
         } as GlobbyOptions)
         .map((file) => `:^${formattedLocation}/${path.dirname(file)}`);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use correct `ignore` pattern type

## Motivation and Context

Globby ignore pattern should be an array of string instead of a simple string

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
