### PR TITLE
fix(run): only use run-one w/Nx when not passing multiple scripts

### DIFF
--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -231,7 +231,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
     performance.mark('init-local');
     await this.configureNxOutput();
     const { extraOptions, targetDependencies, options } = await this.prepNxOptions();
-    if (this.packagesWithScript.length === 1) {
+    if (this.packagesWithScript.length === 1 && !Array.isArray(this.script)) {
       const { runOne } = await import('nx/src/command-line/run-one');
       const fullQualifiedTarget =
         this.packagesWithScript.map((p) => p.name)[0] + ':' + this.escapeScriptNameQuotes(this.script);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As Lerna PR 3620 for `lerna run` with Nx (only)

> Update the run command to use `runMany` when a single package matches the filter, but multiple targets are provided.

## Motivation and Context

As Lerna PR

> Nx's `runOne` function cannot accept multiple targets. Because of this, Lerna currently errors in the following case:
> 
> ```
> $ lerna run --scope="my-specific-package" script1,script2
> ```
> 
> This fix makes this case use `runMany` instead, which can accept multiple targets.
> 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
