### PR TITLE
chore: use `node:` imports and `fs-extra/esm` import

### DIFF
--- a/__fixtures__/pack-directory/packages/a/prepare.ts
+++ b/__fixtures__/pack-directory/packages/a/prepare.ts
@@ -1,13 +1,13 @@
-import fs from 'fs';
-import path from 'path';
+import { createReadStream, createWriteStream, mkdirSync } from 'node:fs';
+import { dirname, resolve as pathResolve } from 'node:path';
 
-const sourceIndex = path.resolve('./src/index.js');
-const targetIndex = path.resolve('./dist/index.js');
+const sourceIndex = pathResolve('./src/index.js');
+const targetIndex = pathResolve('./dist/index.js');
 
-fs.mkdirSync(path.dirname(targetIndex));
+mkdirSync(dirname(targetIndex));
 
-const reader = fs.createReadStream(sourceIndex);
-const writer = fs.createWriteStream(targetIndex);
+const reader = createReadStream(sourceIndex);
+const writer = createWriteStream(targetIndex);
 
 // fs.copyFileSync is node >=8.5.0
 reader.pipe(writer);

--- a/__fixtures__/pack-directory/packages/b/prepack.ts
+++ b/__fixtures__/pack-directory/packages/b/prepack.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
-import path from 'path';
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve as pathResolve } from 'node:path';
 
-const distDir = path.resolve('dist');
-const pkg = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8'));
+const distDir = pathResolve('dist');
+const pkg = JSON.parse(readFileSync(pathResolve('package.json'), 'utf8'));
 
 delete pkg.private;
 delete pkg.scripts;
@@ -11,6 +11,6 @@ delete pkg.publishConfig;
 pkg.description = 'big important things to do';
 pkg.main = 'prepacked.js';
 
-fs.mkdirSync(distDir);
-fs.writeFileSync(path.join(distDir, 'package.json'), JSON.stringify(pkg, null, 2));
-fs.writeFileSync(path.join(distDir, 'prepacked.js'), "export default 'B';");
+mkdirSync(distDir);
+writeFileSync(join(distDir, 'package.json'), JSON.stringify(pkg, null, 2));
+writeFileSync(join(distDir, 'prepacked.js'), "export default 'B';");

--- a/__fixtures__/pack-directory/packages/c/prepublishOnly.ts
+++ b/__fixtures__/pack-directory/packages/c/prepublishOnly.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
-import path from 'path';
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-fs.writeFileSync(path.resolve('index.js'), "export default 'C';");
+writeFileSync(resolve('index.js'), "export default 'C';");

--- a/helpers/cli.ts
+++ b/helpers/cli.ts
@@ -1,12 +1,12 @@
 import { execa } from 'execa';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import lernaCLI from '../packages/cli/src/lerna-cli.js';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const LERNA_BIN = path.resolve(__dirname, '../packages/cli/src/cli.ts');
+const __dirname = dirname(__filename);
+const LERNA_BIN = pathResolve(__dirname, '../packages/cli/src/cli.ts');
 
 /**
  * A higher-order function to help with passing _actual_ yargs-parsed argv

--- a/helpers/fixtures.ts
+++ b/helpers/fixtures.ts
@@ -1,9 +1,9 @@
 import { execa } from 'execa';
 import fileUrl from 'file-url';
 import { temporaryDirectory } from 'tempy';
-import fs from 'fs-extra';
+import { copy, ensureDir } from 'fs-extra/esm';
 import { findUp } from 'find-up';
-import path from 'path';
+import { join } from 'node:path';
 
 import { gitAdd, gitCommit, gitInit } from './git/index.js';
 
@@ -28,7 +28,7 @@ export function cloneFixtureFactory(startDir: string) {
 }
 
 export function findFixture(cwd: string, fixtureName: string) {
-  return findUp(path.join('__fixtures__', fixtureName), { cwd, type: 'directory' }).then((fixturePath) => {
+  return findUp(join('__fixtures__', fixtureName), { cwd, type: 'directory' }).then((fixturePath) => {
     if (fixturePath === undefined) {
       throw new Error(`Could not find fixture with name "${fixtureName}"`);
     }
@@ -38,7 +38,7 @@ export function findFixture(cwd: string, fixtureName: string) {
 }
 
 export function copyFixture(targetDir: string, fixtureName: string, cwd: string) {
-  return findFixture(cwd, fixtureName).then((fp) => fs.copy(fp, targetDir));
+  return findFixture(cwd, fixtureName).then((fp) => copy(fp, targetDir));
 }
 
 export function initFixtureFactory(startDir: string) {
@@ -61,10 +61,10 @@ export function initFixtureFactory(startDir: string) {
 
 export function initNamedFixtureFactory(startDir: string) {
   return (dirName: string, fixtureName: string, commitMessage: boolean | string = 'Init commit') => {
-    const cwd = path.join(temporaryDirectory(), dirName);
+    const cwd = join(temporaryDirectory(), dirName);
     let chain: Promise<any> = Promise.resolve();
 
-    chain = chain.then(() => fs.ensureDir(cwd));
+    chain = chain.then(() => ensureDir(cwd));
     chain = chain.then(() => process.chdir(cwd));
     chain = chain.then(() => copyFixture(cwd, fixtureName, startDir));
     chain = chain.then(() => gitInit(cwd, '.'));

--- a/helpers/git/index.ts
+++ b/helpers/git/index.ts
@@ -1,18 +1,18 @@
 import { execa } from 'execa';
-import os from 'node:os';
-import path from 'path';
+import { EOL } from 'node:os';
+import { dirname, join, resolve as pathResolve } from 'node:path';
 import cp from 'child_process';
 import { loadJsonFile } from 'load-json-file';
 import { writeJsonFile } from 'write-json-file';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 import { tempWrite } from '../../packages/version/src/utils/temp-write.js';
 import gitSHA from '../serializers/serialize-git-sha.js';
 
 // Contains all relevant git config (user, commit.gpgSign, etc)
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const TEMPLATE = path.resolve(__dirname, 'template');
+const __dirname = dirname(__filename);
+const TEMPLATE = pathResolve(__dirname, 'template');
 
 export function getCommitMessage(cwd, format = '%B') {
   return execa('git', ['log', '-1', `--pretty=format:${format}`], { cwd }).then((result) => result.stdout);
@@ -27,7 +27,7 @@ export function gitCheckout(cwd, args) {
 }
 
 export function gitCommit(cwd, message) {
-  if (message.indexOf(os.EOL) > -1) {
+  if (message.indexOf(EOL) > -1) {
     // Use tempfile to allow multi\nline strings.
     return tempWrite(message).then((fp) => execa('git', ['commit', '-F', fp], { cwd }));
   }
@@ -72,7 +72,7 @@ export function showCommit(cwd, ...args) {
 }
 
 export function commitChangeToPackage(cwd, packageName, commitMsg, data) {
-  const packageJSONPath = path.join(cwd, 'packages', packageName, 'package.json');
+  const packageJSONPath = join(cwd, 'packages', packageName, 'package.json');
 
   // QQ no async/await yet...
   let chain: Promise<any> = Promise.resolve();

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -1,6 +1,6 @@
 import normalizeNewline from 'normalize-newline';
 import normalizePath from 'normalize-path';
-import path from 'path';
+import { relative } from 'node:path';
 
 import { Project } from '../packages/core/src/project/index.js';
 
@@ -26,7 +26,7 @@ export function multiLineTrimRight(str) {
 }
 
 export function normalizeRelativeDir(testDir, filePath) {
-  return normalizePath(path.relative(testDir, filePath));
+  return normalizePath(relative(testDir, filePath));
 }
 
 export * from './git/index.js';

--- a/helpers/npm/set-npm-userconfig.ts
+++ b/helpers/npm/set-npm-userconfig.ts
@@ -1,12 +1,12 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 
 // Overwrite npm userconfig to avoid test pollution
 // https://docs.npmjs.com/misc/config#npmrc-files
-process.env.npm_config_userconfig = path.resolve(__dirname, 'test-user.ini');
+process.env.npm_config_userconfig = pathResolve(__dirname, 'test-user.ini');
 
 // use consistent locale for all tests
 process.env.LC_ALL = 'en_US.UTF-8';

--- a/helpers/pkg-matchers.ts
+++ b/helpers/pkg-matchers.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
-import path from 'path';
+import { accessSync, constants, readdirSync } from 'node:fs';
+import { join as pathJoin } from 'node:path';
 import semver from 'semver';
 
 import { Package } from '../packages/core/src/package.js';
@@ -109,7 +109,7 @@ export function toHaveBinaryLinks(received, ...inputs) {
   let found;
 
   try {
-    found = fs.readdirSync(pkg.binLocation);
+    found = readdirSync(pkg.binLocation);
   } catch (err) {
     if (links.length === 0 && err.code === 'ENOENT') {
       return {
@@ -153,10 +153,10 @@ export function toHaveExecutables(received, ...files) {
   const expectation = `${expectedFiles} ${expectedAction}`;
 
   // eslint-disable-next-line prefer-destructuring
-  const X_OK = fs.constants.X_OK;
+  const X_OK = constants.X_OK;
   const failed = files.filter((file) => {
     try {
-      return fs.accessSync(path.join(pkg.location, file), X_OK);
+      return accessSync(pathJoin(pkg.location, file), X_OK);
     } catch (_) {
       return true;
     }

--- a/helpers/serializers/serialize-placeholders.ts
+++ b/helpers/serializers/serialize-placeholders.ts
@@ -1,14 +1,14 @@
 import { loadJsonFileSync } from 'load-json-file';
 import normalizeNewline from 'normalize-newline';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import serializeTempdir from './serialize-tempdir.js';
 import serializeWindowsPaths from './serialize-windows-paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const pkgJson = loadJsonFileSync(path.join(__dirname, '../../core/lerna/', 'package.json')) as any;
+const __dirname = dirname(__filename);
+const pkgJson = loadJsonFileSync(join(__dirname, '../../core/lerna/', 'package.json')) as any;
 const LERNA_VERSION = pkgJson.version as string;
 
 const VERSION_REGEX = new RegExp(`^((?:.*?notice cli )|\\^?)v?${LERNA_VERSION}`, 'g');

--- a/helpers/serializers/serialize-tempdir.ts
+++ b/helpers/serializers/serialize-tempdir.ts
@@ -1,5 +1,5 @@
 import normalizePath from 'normalize-path';
-import path from 'path';
+import { join } from 'node:path';
 
 // tempy creates subdirectories with hexadecimal names that are 32 characters long
 const TEMP_DIR_REGEXP = /([^\s"]*[\\/][0-9a-f]{32})([^\s"]*)/g;
@@ -18,7 +18,7 @@ const serializeTempdir = {
 };
 
 function serializeProjectRoot(match, cwd, subPath) {
-  return normalizePath(path.join('__TEST_ROOTDIR__', subPath));
+  return normalizePath(join('__TEST_ROOTDIR__', subPath));
 }
 
 export default serializeTempdir;

--- a/helpers/serializers/serialize-windows-paths.ts
+++ b/helpers/serializers/serialize-windows-paths.ts
@@ -1,5 +1,5 @@
 import normalizePath from 'normalize-path';
-import path from 'path';
+import { join } from 'node:path';
 
 const WHACK_WACK = /(\\)([\S]*)/g;
 
@@ -16,7 +16,7 @@ const serializeWindowsPaths = {
 };
 
 function serializeWindowsPath(match, wack, wackPath) {
-  return normalizePath(path.join(wack, wackPath));
+  return normalizePath(join(wack, wackPath));
 }
 
 export default serializeWindowsPaths;

--- a/packages/changed/src/__tests__/changed-command.spec.ts
+++ b/packages/changed/src/__tests__/changed-command.spec.ts
@@ -18,13 +18,13 @@ import { ChangedCommandOption, collectUpdates, logOutput } from '@lerna-lite/cor
 import cliChangedCommands from '../../../cli/src/cli-commands/cli-changed-commands.js';
 
 // helpers
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import { updateLernaConfig } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // file under test

--- a/packages/cli/src/__tests__/core-cli.spec.ts
+++ b/packages/cli/src/__tests__/core-cli.spec.ts
@@ -1,11 +1,11 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Package, ValidationError } from '@lerna-lite/core';
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import lernaCLI from '../lerna-cli';
 import { initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 function prepare(cwd: string) {

--- a/packages/cli/src/global-options.ts
+++ b/packages/cli/src/global-options.ts
@@ -1,4 +1,4 @@
-import os from 'node:os';
+import { cpus } from 'node:os';
 import { Argv } from 'yargs';
 
 export function globalOptions(yargs: Argv<any>) {
@@ -10,7 +10,7 @@ export function globalOptions(yargs: Argv<any>) {
       type: 'string',
     },
     concurrency: {
-      defaultDescription: os.cpus().length,
+      defaultDescription: cpus().length,
       describe: 'How many processes to use when lerna parallelizes tasks.',
       type: 'number',
       requiresArg: true,

--- a/packages/cli/src/lerna-entry.ts
+++ b/packages/cli/src/lerna-entry.ts
@@ -1,7 +1,7 @@
 import { loadJsonFileSync } from 'load-json-file';
-import path from 'path';
+import { dirname, join } from 'node:path';
 import { JsonValue } from '@lerna-lite/core';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 import changedCmd from './cli-commands/cli-changed-commands.js';
 import diffCmd from './cli-commands/cli-diff-commands.js';
@@ -16,8 +16,8 @@ import cli from './lerna-cli.js';
 
 export function lerna(argv: any[]) {
   const __filename = fileURLToPath(import.meta.url);
-  const __dirname = path.dirname(__filename);
-  const cliPkg = loadJsonFileSync<{ [dep: string]: JsonValue }>(path.join(__dirname, '../', 'package.json'));
+  const __dirname = dirname(__filename);
+  const cliPkg = loadJsonFileSync<{ [dep: string]: JsonValue }>(join(__dirname, '../', 'package.json'));
   const context = {
     lernaVersion: (cliPkg?.version ?? '') as string,
   };

--- a/packages/core/src/__tests__/cyclic-package-graph-node.spec.ts
+++ b/packages/core/src/__tests__/cyclic-package-graph-node.spec.ts
@@ -1,5 +1,5 @@
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 
 import { Project } from '../project';
 import { initFixtureFactory } from '@lerna-test/helpers';
@@ -7,7 +7,7 @@ import { CyclicPackageGraphNode } from '../package-graph/lib/cyclic-package-grap
 import { PackageGraphNode } from '../package-graph';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 describe('CyclicPackageGraphNode class', () => {

--- a/packages/core/src/child-process.ts
+++ b/packages/core/src/child-process.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { execa, execaSync } from 'execa';
 import type { Options as ExecaOptions, SyncOptions as ExacaSyncOptions, ExecaChildProcess } from 'execa';
 import log from 'npmlog';
-import os from 'node:os';
+import { constants } from 'node:os';
 import logTransformer from 'strong-log-transformer';
 
 import { Package } from './package.js';
@@ -114,7 +114,7 @@ export function getExitCode(result: any) {
   // https://nodejs.org/docs/latest-v6.x/api/errors.html#errors_error_code
   // istanbul ignore else
   if (typeof result.code === 'string' || typeof result.exitCode === 'string') {
-    return os.constants.errno[result.code ?? result.exitCode];
+    return constants.errno[result.code ?? result.exitCode];
   }
 
   // istanbul ignore next: extremely weird

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -3,7 +3,7 @@ import dedent from 'dedent';
 import { execaSync, SyncOptions as ExacaSyncOptions } from 'execa';
 import isCI from 'is-ci';
 import log, { Logger } from 'npmlog';
-import os from 'node:os';
+import { cpus } from 'node:os';
 
 import { cleanStack } from './utils/clean-stack.js';
 import { logExecCommand } from './child-process.js';
@@ -28,7 +28,7 @@ import {
 import { PackageGraph } from './package-graph/package-graph.js';
 
 // maxBuffer value for running exec
-const DEFAULT_CONCURRENCY = os.cpus().length;
+const DEFAULT_CONCURRENCY = cpus().length;
 
 type AvailableCommandOption =
   | ChangedCommandOption

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -1,7 +1,7 @@
 import { loadJsonFile, loadJsonFileSync } from 'load-json-file';
 import npa from 'npm-package-arg';
 import npmlog from 'npmlog';
-import path from 'path';
+import { basename, dirname, join, resolve as pathResolve, relative } from 'node:path';
 import { writePackage } from 'write-pkg';
 
 import { CommandType, NpaResolveResult, RawManifest } from './models/index.js';
@@ -59,8 +59,8 @@ export class Package {
    */
   static lazy(ref: string | Package | RawManifest, dir = '.'): Package {
     if (typeof ref === 'string') {
-      const location = path.resolve(path.basename(ref) === 'package.json' ? path.dirname(ref) : ref);
-      const manifest = loadJsonFileSync<RawManifest>(path.join(location, 'package.json'));
+      const location = pathResolve(basename(ref) === 'package.json' ? dirname(ref) : ref);
+      const manifest = loadJsonFileSync<RawManifest>(join(location, 'package.json'));
 
       return new Package(manifest, location);
     }
@@ -81,7 +81,7 @@ export class Package {
    */
   constructor(pkg: RawManifest, location: string, rootPath = location) {
     // npa will throw an error if the name is invalid
-    const resolved = npa.resolve(pkg?.name ?? '', `file:${path.relative(rootPath, location)}`, rootPath);
+    const resolved = npa.resolve(pkg?.name ?? '', `file:${relative(rootPath, location)}`, rootPath);
 
     this.name = pkg?.name ?? '';
     this[PKG] = pkg;
@@ -124,7 +124,7 @@ export class Package {
   }
 
   get binLocation(): string {
-    return path.join(this.location, 'node_modules', '.bin');
+    return join(this.location, 'node_modules', '.bin');
   }
 
   /** alias to pkg getter (to avoid calling duplicate prop like `node.pkg.pkg` in which node is PackageGraphNode) */
@@ -133,11 +133,11 @@ export class Package {
   }
 
   get manifestLocation(): string {
-    return path.join(this.location, 'package.json');
+    return join(this.location, 'package.json');
   }
 
   get nodeModulesLocation(): string {
-    return path.join(this.location, 'node_modules');
+    return join(this.location, 'node_modules');
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -171,7 +171,7 @@ export class Package {
 
     // if provided by pkg.publishConfig.directory value
     if (this[PKG].publishConfig && this[PKG].publishConfig.directory) {
-      return path.join(this.location, this[PKG].publishConfig.directory);
+      return join(this.location, this[PKG].publishConfig.directory);
     }
 
     // default to package root
@@ -179,7 +179,7 @@ export class Package {
   }
 
   set contents(subDirectory: string) {
-    this[_contents] = path.join(this.location, subDirectory);
+    this[_contents] = join(this.location, subDirectory);
   }
 
   // 'live' collections

--- a/packages/core/src/project/__tests__/project.spec.ts
+++ b/packages/core/src/project/__tests__/project.spec.ts
@@ -1,11 +1,11 @@
-import { outputFile, remove, writeJSON } from 'fs-extra/esm';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { outputFile, remove, writeJson } from 'fs-extra/esm';
+import { basename, dirname, join, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // helpers
 import { initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // file under test
@@ -121,7 +121,7 @@ describe('Project', () => {
     it.skip('extends local shared config subpath', async () => {
       const cwd = await initFixture('extends');
 
-      await writeJSON(path.resolve(cwd, 'lerna.json'), {
+      await writeJson(pathResolve(cwd, 'lerna.json'), {
         extends: 'local-package/subpath',
         version: '1.0.0',
       });
@@ -210,7 +210,7 @@ describe('Project', () => {
     it('returns a list of package parent directories', () => {
       const project = new Project(testDir);
       project.config.packages = ['.', 'packages/*', 'dir/nested/*', 'globstar/**'];
-      expect(project.packageParentDirs).toEqual([testDir, path.join(testDir, 'packages'), path.join(testDir, 'dir/nested'), path.join(testDir, 'globstar')]);
+      expect(project.packageParentDirs).toEqual([testDir, join(testDir, 'packages'), join(testDir, 'dir/nested'), join(testDir, 'globstar')]);
     });
   });
 
@@ -281,24 +281,24 @@ describe('Project', () => {
 
     it('defaults package.json name field when absent', async () => {
       const cwd = await initFixture('basic');
-      const manifestLocation = path.join(cwd, 'package.json');
+      const manifestLocation = join(cwd, 'package.json');
 
-      await writeJSON(manifestLocation, { private: true }, { spaces: 2 });
+      await writeJson(manifestLocation, { private: true }, { spaces: 2 });
 
       const project = new Project(cwd);
-      expect(project.manifest).toHaveProperty('name', path.basename(cwd));
+      expect(project.manifest).toHaveProperty('name', basename(cwd));
     });
 
     it('does not cache failures', async () => {
       const cwd = await initFixture('basic');
-      const manifestLocation = path.join(cwd, 'package.json');
+      const manifestLocation = join(cwd, 'package.json');
 
       await remove(manifestLocation);
 
       const project = new Project(cwd);
       expect(project.manifest).toBe(undefined);
 
-      await writeJSON(manifestLocation, { name: 'test' }, { spaces: 2 });
+      await writeJson(manifestLocation, { name: 'test' }, { spaces: 2 });
       expect(project.manifest).toHaveProperty('name', 'test');
     });
 
@@ -326,7 +326,7 @@ describe('Project', () => {
       const cwd = await initFixture('licenses-missing');
       const project = new Project(cwd);
 
-      await outputFile(path.join(cwd, 'LICENSE.md'), 'copyright, yo', 'utf8');
+      await outputFile(join(cwd, 'LICENSE.md'), 'copyright, yo', 'utf8');
 
       expect(project.licensePath).toMatch(/LICENSE\.md$/);
     });
@@ -335,7 +335,7 @@ describe('Project', () => {
       const cwd = await initFixture('licenses-missing');
       const project = new Project(cwd);
 
-      await outputFile(path.join(cwd, 'licence.txt'), 'copyright, yo', 'utf8');
+      await outputFile(join(cwd, 'licence.txt'), 'copyright, yo', 'utf8');
 
       expect(project.licensePath).toMatch(/licence\.txt$/);
     });
@@ -353,7 +353,7 @@ describe('Project', () => {
 
       expect(project.licensePath).toBeUndefined();
 
-      await outputFile(path.join(cwd, 'LiCeNsE'), 'copyright, yo', 'utf8');
+      await outputFile(join(cwd, 'LiCeNsE'), 'copyright, yo', 'utf8');
 
       const foundPath = project.licensePath;
       expect(foundPath).toMatch(/LiCeNsE$/);
@@ -371,12 +371,12 @@ describe('Project', () => {
       const licensePaths = await project.getPackageLicensePaths();
 
       expect(licensePaths).toEqual([
-        path.join(cwd, 'packages', 'package-1', 'LICENSE'),
-        path.join(cwd, 'packages', 'package-2', 'licence'),
-        path.join(cwd, 'packages', 'package-3', 'LiCeNSe'),
-        path.join(cwd, 'packages', 'package-5', 'LICENCE'),
+        join(cwd, 'packages', 'package-1', 'LICENSE'),
+        join(cwd, 'packages', 'package-2', 'licence'),
+        join(cwd, 'packages', 'package-3', 'LiCeNSe'),
+        join(cwd, 'packages', 'package-5', 'LICENCE'),
         // We do not care about duplicates, they are weeded out elsewhere
-        path.join(cwd, 'packages', 'package-5', 'license'),
+        join(cwd, 'packages', 'package-5', 'license'),
       ]);
     });
   });

--- a/packages/core/src/project/lib/apply-extends.ts
+++ b/packages/core/src/project/lib/apply-extends.ts
@@ -1,5 +1,5 @@
 import { readJsonSync } from 'fs-extra/esm';
-import path from 'path';
+import { dirname } from 'node:path';
 import resolveFrom from 'resolve-from';
 
 import { shallowExtend } from './shallow-extend.js';
@@ -33,7 +33,7 @@ export function applyExtends(config: { [key: string]: any }, cwd: string, seen =
 
     // deprecateConfig(defaultConfig, pathToDefault);
 
-    defaultConfig = applyExtends(defaultConfig, path.dirname(pathToDefault), seen);
+    defaultConfig = applyExtends(defaultConfig, dirname(pathToDefault), seen);
   }
 
   return shallowExtend(config, defaultConfig);

--- a/packages/core/src/project/lib/make-file-finder.ts
+++ b/packages/core/src/project/lib/make-file-finder.ts
@@ -1,5 +1,5 @@
 import { globby, globbySync, Options as GlobbyOptions } from 'globby';
-import path from 'path';
+import { normalize as pathNormalize, posix } from 'node:path';
 import pMap from 'p-map';
 
 import { ValidationError } from '../../validation-error.js';
@@ -8,7 +8,7 @@ import { ValidationError } from '../../validation-error.js';
  * @param {string[]} results
  */
 function normalize(results: string[]) {
-  return results.map((fp) => path.normalize(fp));
+  return results.map((fp) => pathNormalize(fp));
 }
 
 function getGlobOpts(rootPath: string, packageConfigs: string[]) {
@@ -42,7 +42,7 @@ export function makeFileFinder(rootPath: string, packageConfigs: string[]) {
     const promise = pMap(
       Array.from(packageConfigs).sort(),
       (globPath: string) => {
-        let chain: Promise<any> = globby(path.posix.join(globPath, fileName), options);
+        let chain: Promise<any> = globby(posix.join(globPath, fileName), options);
 
         // fast-glob does not respect pattern order, so we re-sort by absolute path
         chain = chain.then((results) => results.sort());
@@ -73,7 +73,7 @@ export function makeSyncFileFinder(rootPath: string, packageConfigs: string[]) {
     customGlobOpts?: GlobbyOptions
   ) => {
     const options: GlobbyOptions = Object.assign({}, customGlobOpts, globOpts);
-    const patterns = packageConfigs.map((globPath) => path.posix.join(globPath, fileName)).sort();
+    const patterns = packageConfigs.map((globPath) => posix.join(globPath, fileName)).sort();
 
     let results: string[] = globbySync(patterns, options);
 

--- a/packages/core/src/utils/__tests__/collect-uncommitted.spec.ts
+++ b/packages/core/src/utils/__tests__/collect-uncommitted.spec.ts
@@ -1,14 +1,14 @@
-import fs from 'fs-extra';
-import path from 'path';
+import { outputFile, remove } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
 import chalk from 'chalk';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 // helpers
 import { Project } from '../../project';
 import { gitAdd } from '@lerna-test/helpers';
 import { initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // file under test
@@ -47,23 +47,23 @@ const setupChanges = async (cwd) => {
   const [pkg1, pkg2, pkg3, pkg4] = await Project.getPackages(cwd);
 
   // 'AD': (added to index, deleted in working tree)
-  const file1 = path.join(pkg1.location, 'file-1.ts');
-  await fs.outputFile(file1, 'yay');
+  const file1 = join(pkg1.location, 'file-1.ts');
+  await outputFile(file1, 'yay');
   await gitAdd(cwd, file1);
-  await fs.remove(file1);
+  await remove(file1);
 
   // ' D': (deleted in working tree)
-  await fs.remove(pkg1.manifestLocation);
+  await remove(pkg1.manifestLocation);
 
   // ' M': (modified in working tree)
   pkg2.set('modified', true);
   await pkg2.serialize();
 
   // 'AM': (added to index, modified in working tree)
-  const file2 = path.join(pkg2.location, 'file-2.ts');
-  await fs.outputFile(file2, 'woo');
+  const file2 = join(pkg2.location, 'file-2.ts');
+  await outputFile(file2, 'woo');
   await gitAdd(cwd, file2);
-  await fs.outputFile(file2, 'hoo');
+  await outputFile(file2, 'hoo');
 
   // 'MM': (updated in index, modified in working tree)
   pkg3.set('updated', true);
@@ -78,13 +78,13 @@ const setupChanges = async (cwd) => {
   await gitAdd(cwd, pkg4.manifestLocation);
 
   // 'D ': (deleted in index)
-  const rootManifest = path.join(cwd, 'package.json');
-  await fs.remove(rootManifest);
+  const rootManifest = join(cwd, 'package.json');
+  await remove(rootManifest);
   await gitAdd(cwd, rootManifest);
 
   // '??': (untracked)
-  const poopy = path.join(cwd, 'poopy.txt');
-  await fs.outputFile(poopy, 'pants');
+  const poopy = join(cwd, 'poopy.txt');
+  await outputFile(poopy, 'pants');
 };
 
 describe('collectUncommitted()', () => {

--- a/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
+++ b/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
@@ -1,7 +1,7 @@
 import { globbySync } from 'globby';
 import log from 'npmlog';
 import minimatch from 'minimatch';
-import path from 'path';
+import { dirname, relative } from 'node:path';
 import slash from 'slash';
 
 import { execSync } from '../../../child-process.js';
@@ -66,7 +66,7 @@ export function makeDiffPredicate(
  */
 function diffSinceIn(committish: string, location: string, execOpts: ExecOpts, diffOpts: { independentSubpackages?: boolean }) {
   const args = ['diff', '--name-only', committish];
-  const formattedLocation = slash(path.relative(execOpts.cwd, location));
+  const formattedLocation = slash(relative(execOpts.cwd, location));
 
   if (formattedLocation) {
     // avoid same-directory path.relative() === ""
@@ -78,7 +78,7 @@ function diffSinceIn(committish: string, location: string, execOpts: ExecOpts, d
         cwd: formattedLocation,
         nodir: true,
         ignore: '**/node_modules/**',
-      }).map((file) => `:^${formattedLocation}/${path.dirname(file)}`);
+      }).map((file) => `:^${formattedLocation}/${dirname(file)}`);
     }
 
     // avoid same-directory path.relative() === ""

--- a/packages/core/src/utils/conf.ts
+++ b/packages/core/src/utils/conf.ts
@@ -1,6 +1,6 @@
-import assert from 'assert';
-import fs from 'fs';
-import path from 'path';
+import assert from 'node:assert';
+import { readFileSync, statSync } from 'node:fs';
+import { resolve as pathResolve } from 'node:path';
 // @ts-ignore
 import { ConfigChain } from 'config-chain';
 
@@ -57,7 +57,7 @@ export class Conf extends ConfigChain {
     this._await();
 
     try {
-      const contents = fs.readFileSync(file, 'utf8');
+      const contents = readFileSync(file, 'utf8');
       this.addString(contents, file, 'ini', marker);
     } catch (err: any) {
       this.add({}, marker);
@@ -111,7 +111,7 @@ export class Conf extends ConfigChain {
       set: (prefix) => {
         this.set('prefix', prefix);
       },
-      get: () => path.resolve(this.get('prefix')),
+      get: () => pathResolve(this.get('prefix')),
     });
 
     let p;
@@ -125,7 +125,7 @@ export class Conf extends ConfigChain {
     });
 
     if (Object.prototype.hasOwnProperty.call(cli, 'prefix')) {
-      p = path.resolve(cli.prefix);
+      p = pathResolve(cli.prefix);
     } else {
       try {
         p = findPrefix(process.cwd());
@@ -144,7 +144,7 @@ export class Conf extends ConfigChain {
     }
 
     try {
-      const contents = fs.readFileSync(file, 'utf8');
+      const contents = readFileSync(file, 'utf8');
       const delim = '-----END CERTIFICATE-----';
       const output = contents
         .split(delim)
@@ -174,10 +174,10 @@ export class Conf extends ConfigChain {
       return;
     }
 
-    const prefix = path.resolve(this.get('prefix'));
+    const prefix = pathResolve(this.get('prefix'));
 
     try {
-      const stats = fs.statSync(prefix);
+      const stats = statSync(prefix);
       defConf.user = stats.uid;
     } catch (err: any) {
       if (err.code === 'ENOENT') {

--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -1,7 +1,7 @@
-import os from 'node:os';
-import path from 'path';
+import { homedir, tmpdir, type as osType } from 'node:os';
+import { dirname, join, resolve as pathResolve } from 'node:path';
 
-const temp = os.tmpdir();
+const temp = tmpdir();
 const uidOrPid = process.getuid ? process.getuid() : process.pid;
 const hasUnicode = () => true;
 const isWindows = process.platform === 'win32';
@@ -16,17 +16,17 @@ const umask = {
   fromString: (inputStr?: string) => process.umask(),
 };
 
-let home = os.homedir();
+let home = homedir();
 
 if (home) {
   process.env.HOME = home;
 } else {
-  home = path.resolve(temp, `npm-${uidOrPid}`);
+  home = pathResolve(temp, `npm-${uidOrPid}`);
 }
 
 const cacheExtra = process.platform === 'win32' ? 'npm-cache' : '.npm';
 const cacheRoot = (process.platform === 'win32' && process.env.APPDATA) || home;
-const cache = path.resolve(cacheRoot, cacheExtra);
+const cache = pathResolve(cacheRoot, cacheExtra);
 
 let defaults;
 let globalPrefix;
@@ -41,13 +41,13 @@ export class Defaults {
       globalPrefix = process.env.PREFIX;
     } else if (process.platform === 'win32') {
       // c:\node\node.exe --> prefix=c:\node\
-      globalPrefix = path.dirname(process.execPath);
+      globalPrefix = dirname(process.execPath);
     } else {
       // /usr/local/bin/node --> prefix=/usr/local
-      globalPrefix = path.dirname(path.dirname(process.execPath)); // destdir only is respected on Unix
+      globalPrefix = dirname(dirname(process.execPath)); // destdir only is respected on Unix
 
       if (process.env.DESTDIR) {
-        globalPrefix = path.join(process.env.DESTDIR, globalPrefix);
+        globalPrefix = join(process.env.DESTDIR, globalPrefix);
       }
     }
 
@@ -88,7 +88,7 @@ export class Defaults {
       'git-tag-version': true,
       'commit-hooks': true,
       global: false,
-      globalconfig: path.resolve(globalPrefix, 'etc', 'npmrc'),
+      globalconfig: pathResolve(globalPrefix, 'etc', 'npmrc'),
       'global-style': false,
       group: process.platform === 'win32' ? 0 : process.env.SUDO_GID || (process.getgid && process.getgid()),
       'ham-it-up': false,
@@ -96,7 +96,7 @@ export class Defaults {
       'if-present': false,
       'ignore-prepublish': false,
       'ignore-scripts': false,
-      'init-module': path.resolve(home, '.npm-init.js'),
+      'init-module': pathResolve(home, '.npm-init.js'),
       'init-author-name': '',
       'init-author-email': '',
       'init-author-url': '',
@@ -173,8 +173,8 @@ export class Defaults {
         process.getuid() !== 0,
       'update-notifier': true,
       usage: false,
-      user: process.platform === 'win32' || os.type() === 'OS400' ? 0 : 'nobody',
-      userconfig: path.resolve(home, '.npmrc'),
+      user: process.platform === 'win32' || osType() === 'OS400' ? 0 : 'nobody',
+      userconfig: pathResolve(home, '.npmrc'),
       umask: process.umask ? process.umask() : umask.fromString('022'),
       version: false,
       versions: false,

--- a/packages/core/src/utils/find-prefix.ts
+++ b/packages/core/src/utils/find-prefix.ts
@@ -1,13 +1,13 @@
-import fs from 'fs';
-import path from 'path';
+import { readdirSync } from 'node:fs';
+import { basename, dirname as pathDirname, resolve as pathResolve } from 'node:path';
 
 // https://github.com/npm/npm/blob/876f0c8/lib/config/find-prefix.js
 export function findPrefix(start: string) {
-  let dir = path.resolve(start);
+  let dir = pathResolve(start);
   let walkedUp = false;
 
-  while (path.basename(dir) === 'node_modules') {
-    dir = path.dirname(dir);
+  while (basename(dir) === 'node_modules') {
+    dir = pathDirname(dir);
     walkedUp = true;
   }
 
@@ -24,13 +24,13 @@ export function find(name: string, original: string) {
   }
 
   try {
-    const files = fs.readdirSync(name);
+    const files = readdirSync(name);
 
     if (files.indexOf('node_modules') !== -1 || files.indexOf('package.json') !== -1) {
       return name;
     }
 
-    const dirname = path.dirname(name);
+    const dirname = pathDirname(name);
 
     if (dirname === name) {
       return original;

--- a/packages/core/src/utils/nerf-dart.ts
+++ b/packages/core/src/utils/nerf-dart.ts
@@ -1,4 +1,4 @@
-import url from 'url';
+import url from 'node:url';
 
 // https://github.com/npm/npm/blob/0cc9d89/lib/config/nerf-dart.js
 export function toNerfDart(uri) {

--- a/packages/core/src/utils/npm-conf.ts
+++ b/packages/core/src/utils/npm-conf.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { resolve as pathResolve } from 'node:path';
 
 import { Conf } from '../utils/conf.js';
 import { toNerfDart } from './nerf-dart.js';
@@ -24,7 +24,7 @@ function npmConf(opts: any) {
   conf.addEnv();
   conf.loadPrefix();
 
-  const projectConf = path.resolve(conf.localPrefix, '.npmrc');
+  const projectConf = pathResolve(conf.localPrefix, '.npmrc');
   const userConf = conf.get('userconfig');
 
   /* istanbul ignore else */
@@ -38,9 +38,9 @@ function npmConf(opts: any) {
 
   /* istanbul ignore else */
   if (conf.get('prefix')) {
-    const etc = path.resolve(conf.get('prefix'), 'etc');
-    conf.root.globalconfig = path.resolve(etc, 'npmrc');
-    conf.root.globalignorefile = path.resolve(etc, 'npmignore');
+    const etc = pathResolve(conf.get('prefix'), 'etc');
+    conf.root.globalconfig = pathResolve(etc, 'npmrc');
+    conf.root.globalignorefile = pathResolve(etc, 'npmignore');
   }
 
   conf.addFile(conf.get('globalconfig'), 'global');

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -1,6 +1,6 @@
-import path from 'path';
-import { Stream } from 'stream';
-import url from 'url';
+import path from 'node:path';
+import { Stream } from 'node:stream';
+import url from 'node:url';
 
 const Umask = () => {};
 const getLocalAddresses = () => [];

--- a/packages/core/src/utils/write-log-file.ts
+++ b/packages/core/src/utils/write-log-file.ts
@@ -1,6 +1,6 @@
 import log from 'npmlog';
-import path from 'path';
-import os from 'node:os';
+import { join } from 'node:path';
+import { EOL } from 'node:os';
 import writeFileAtomic from 'write-file-atomic';
 
 export function writeLogFile(cwd: string) {
@@ -18,12 +18,12 @@ export function writeLogFile(cwd: string) {
       .split(/\r?\n/)
       .map((line) => `${pref} ${line}`.trim())
       .forEach((line) => {
-        logOutput += line + os.EOL;
+        logOutput += line + EOL;
       });
   });
 
   // this must be synchronous because it is called before process exit
-  writeFileAtomic.sync(path.join(cwd, 'lerna-debug.log'), logOutput);
+  writeFileAtomic.sync(join(cwd, 'lerna-debug.log'), logOutput);
 
   // truncate log after writing
   log.record.length = 0;

--- a/packages/diff/src/__tests__/diff-command.spec.ts
+++ b/packages/diff/src/__tests__/diff-command.spec.ts
@@ -8,9 +8,9 @@ vi.mock('@lerna-lite/core', async () => ({
 }));
 
 import { execa } from 'execa';
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { outputFile, remove } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Mock } from 'vitest';
 import yargParser from 'yargs-parser';
 
@@ -21,7 +21,7 @@ import { spawn } from '@lerna-lite/core';
 // helpers
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 import { Project } from '@lerna-lite/core';
 import { gitAdd } from '@lerna-test/helpers';
@@ -79,10 +79,10 @@ describe('Diff Command', () => {
   it('should diff packages from the first commit from DiffCommand class', async () => {
     const cwd = await initFixture('basic');
     const [pkg1] = await Project.getPackages(cwd);
-    const rootReadme = path.join(cwd, 'README.md');
+    const rootReadme = join(cwd, 'README.md');
 
     await pkg1.set('changed', 1).serialize();
-    await fs.outputFile(rootReadme, 'change outside packages glob');
+    await outputFile(rootReadme, 'change outside packages glob');
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'changed');
 
@@ -94,10 +94,10 @@ describe('Diff Command', () => {
   it('should diff packages from the first commit from factory', async () => {
     const cwd = await initFixture('basic');
     const [pkg1] = await Project.getPackages(cwd);
-    const rootReadme = path.join(cwd, 'README.md');
+    const rootReadme = join(cwd, 'README.md');
 
     await pkg1.set('changed', 1).serialize();
-    await fs.outputFile(rootReadme, 'change outside packages glob');
+    await outputFile(rootReadme, 'change outside packages glob');
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'changed');
 
@@ -109,10 +109,10 @@ describe('Diff Command', () => {
   it('should diff packages from the first commit', async () => {
     const cwd = await initFixture('basic');
     const [pkg1] = await Project.getPackages(cwd);
-    const rootReadme = path.join(cwd, 'README.md');
+    const rootReadme = join(cwd, 'README.md');
 
     await pkg1.set('changed', 1).serialize();
-    await fs.outputFile(rootReadme, 'change outside packages glob');
+    await outputFile(rootReadme, 'change outside packages glob');
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'changed');
 
@@ -158,7 +158,7 @@ describe('Diff Command', () => {
     const [pkg1] = await Project.getPackages(cwd);
 
     await pkg1.set('changed', 1).serialize();
-    await fs.outputFile(path.join(pkg1.location, 'README.md'), 'ignored change');
+    await outputFile(join(pkg1.location, 'README.md'), 'ignored change');
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'changed');
 
@@ -184,7 +184,7 @@ describe('Diff Command', () => {
   it('should error when running in a repository without commits', async () => {
     const cwd = await initFixture('basic');
 
-    await fs.remove(path.join(cwd, '.git'));
+    await remove(join(cwd, '.git'));
     await gitInit(cwd);
 
     const command = new DiffCommand(createArgv(cwd, 'package-1'));

--- a/packages/filter-packages/src/__tests__/get-filtered-packages.spec.ts
+++ b/packages/filter-packages/src/__tests__/get-filtered-packages.spec.ts
@@ -18,8 +18,8 @@ vi.mock('@lerna-lite/core', async () => ({
   getPackages: (await vi.importActual<any>('../../../core/src/project')).getPackages,
 }));
 
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yargs from 'yargs/yargs';
 
 // mocked modules
@@ -28,8 +28,8 @@ import { collectUpdates } from '@lerna-lite/core';
 // helpers
 import { initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../'));
+const __dirname = dirname(__filename);
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../'));
 
 import { Project, PackageGraph } from '@lerna-lite/core';
 

--- a/packages/filter-packages/src/filter-packages.ts
+++ b/packages/filter-packages/src/filter-packages.ts
@@ -1,5 +1,5 @@
 import multimatch from 'multimatch';
-import util from 'util';
+import util from 'node:util';
 import log from 'npmlog';
 
 import { Package, ValidationError } from '@lerna-lite/core';

--- a/packages/init/src/init-command.ts
+++ b/packages/init/src/init-command.ts
@@ -1,6 +1,6 @@
 import { Command, CommandType, exec, InitCommandOption, ProjectConfig } from '@lerna-lite/core';
 import { mkdirp } from 'fs-extra/esm';
-import path from 'path';
+import { join } from 'node:path';
 import pMap from 'p-map';
 import { writeJsonFile } from 'write-json-file';
 
@@ -54,7 +54,7 @@ export class InitCommand extends Command<InitCommandOption> {
       this.logger.info('', 'Creating package.json');
 
       // initialize with default indentation so write-pkg doesn't screw it up with tabs
-      await writeJsonFile(path.join(this.project.rootPath, 'package.json'), { name: 'root', private: true }, { indent: 2 });
+      await writeJsonFile(join(this.project.rootPath, 'package.json'), { name: 'root', private: true }, { indent: 2 });
     } else {
       this.logger.info('', 'Updating package.json');
     }

--- a/packages/list/src/__tests__/list-command.spec.ts
+++ b/packages/list/src/__tests__/list-command.spec.ts
@@ -19,11 +19,11 @@ vi.mock('@lerna-lite/filter-packages', async () => await vi.importActual<any>('.
 import { collectUpdates, ListCommandOption, logOutput } from '@lerna-lite/core';
 
 // helpers
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // file under test

--- a/packages/listable/src/lib/listable-format.ts
+++ b/packages/listable/src/lib/listable-format.ts
@@ -1,7 +1,7 @@
 import { Package, QueryGraph } from '@lerna-lite/core';
 import chalk from 'chalk';
 import columnify from 'columnify';
-import path from 'path';
+import { relative } from 'node:path';
 
 import { ListableOptions } from '../models/index.js';
 
@@ -218,7 +218,7 @@ function formatColumns(resultList: ReturnType<typeof filterResultList>, viewOpti
       formatted.private = `(${chalk.red('PRIVATE')})`;
     }
 
-    formatted.location = chalk.grey(path.relative('.', result.location));
+    formatted.location = chalk.grey(relative('.', result.location));
 
     return formatted;
   }) as unknown as Package[];

--- a/packages/publish/src/__tests__/create-temp-licenses.spec.ts
+++ b/packages/publish/src/__tests__/create-temp-licenses.spec.ts
@@ -1,11 +1,11 @@
-import fs from 'fs-extra';
-import path from 'path';
+import { move, pathExists } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
 import { Project } from '@lerna-lite/core';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 import { initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 import { createTempLicenses } from '../lib/create-temp-licenses';
 
@@ -17,7 +17,7 @@ describe('createTempLicenses', () => {
 
     await createTempLicenses(project.licensePath, [pkg]);
 
-    const licenseWritten = await fs.pathExists(path.join(pkg.location, 'LICENSE'));
+    const licenseWritten = await pathExists(join(pkg.location, 'LICENSE'));
     expect(licenseWritten).toBe(true);
   });
 
@@ -31,7 +31,7 @@ describe('createTempLicenses', () => {
 
     await createTempLicenses(project.licensePath, [pkg]);
 
-    const licenseWritten = await fs.pathExists(path.join(pkg.contents, 'LICENSE'));
+    const licenseWritten = await pathExists(join(pkg.contents, 'LICENSE'));
     expect(licenseWritten).toBe(true);
   });
 
@@ -45,7 +45,7 @@ describe('createTempLicenses', () => {
 
     await createTempLicenses(project.licensePath, [pkg]);
 
-    const licenseWritten = await fs.pathExists(path.join(pkg.contents, 'LICENSE'));
+    const licenseWritten = await pathExists(join(pkg.contents, 'LICENSE'));
     expect(licenseWritten).toBe(true);
   });
 
@@ -54,10 +54,10 @@ describe('createTempLicenses', () => {
     const project = new Project(cwd);
     const [pkg] = await project.getPackages();
 
-    await fs.move(path.join(cwd, 'LICENSE'), path.join(cwd, 'LICENSE.md'));
+    await move(join(cwd, 'LICENSE'), join(cwd, 'LICENSE.md'));
     await createTempLicenses(project.licensePath, [pkg]);
 
-    const licenseWritten = await fs.pathExists(path.join(pkg.location, 'LICENSE.md'));
+    const licenseWritten = await pathExists(join(pkg.location, 'LICENSE.md'));
     expect(licenseWritten).toBe(true);
   });
 
@@ -68,7 +68,7 @@ describe('createTempLicenses', () => {
 
     await createTempLicenses(undefined as any, [pkg]);
 
-    const licenseWritten = await fs.pathExists(path.join(pkg.location, 'LICENSE'));
+    const licenseWritten = await pathExists(join(pkg.location, 'LICENSE'));
     expect(licenseWritten).toBe(false);
   });
 
@@ -79,7 +79,7 @@ describe('createTempLicenses', () => {
 
     await createTempLicenses(project.licensePath, []);
 
-    const licenseWritten = await fs.pathExists(path.join(pkg.location, 'LICENSE'));
+    const licenseWritten = await pathExists(join(pkg.location, 'LICENSE'));
     expect(licenseWritten).toBe(false);
   });
 });

--- a/packages/publish/src/__tests__/get-current-sha.spec.ts
+++ b/packages/publish/src/__tests__/get-current-sha.spec.ts
@@ -1,9 +1,10 @@
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { getCurrentSHA } from '../lib/get-current-sha';
 import { initFixtureFactory } from '@lerna-test/helpers';
-import path from 'path';
+import { dirname } from 'node:path';
+
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 test('getCurrentSHA', async () => {

--- a/packages/publish/src/__tests__/get-packages-without-license.spec.ts
+++ b/packages/publish/src/__tests__/get-packages-without-license.spec.ts
@@ -1,10 +1,11 @@
 import { Project } from '@lerna-lite/core';
 import { getPackagesWithoutLicense } from '../lib/get-packages-without-license';
 import { initFixtureFactory } from '@lerna-test/helpers';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 test('getPackagesWithoutLicense', async () => {

--- a/packages/publish/src/__tests__/get-unpublished-packages.spec.ts
+++ b/packages/publish/src/__tests__/get-unpublished-packages.spec.ts
@@ -4,12 +4,13 @@ vi.mock('pacote');
 import pacote from 'pacote';
 
 // helpers
-import { fileURLToPath } from 'url';
-import path from 'path';
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { Project, PackageGraph, FetchConfig } from '@lerna-lite/core';
 import { initFixtureFactory } from '@lerna-test/helpers';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // file under test

--- a/packages/publish/src/__tests__/git-checkout.spec.ts
+++ b/packages/publish/src/__tests__/git-checkout.spec.ts
@@ -1,20 +1,20 @@
 import { execa } from 'execa';
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { outputFile, outputJson, writeJson } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { initFixtureFactory } from '@lerna-test/helpers';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 import { gitCheckout } from '../lib/git-checkout';
 
 test('gitCheckout files', async () => {
   const cwd = await initFixture('no-interdependencies');
-  const files = ['package-1', 'package-2'].map((name) => path.join('packages', name, 'package.json'));
+  const files = ['package-1', 'package-2'].map((name) => join('packages', name, 'package.json'));
 
-  await Promise.all(files.map((fp) => fs.writeJSON(path.join(cwd, fp), { foo: 'bar' })));
+  await Promise.all(files.map((fp) => writeJson(join(cwd, fp), { foo: 'bar' })));
   await gitCheckout(files, { granularPathspec: true }, { cwd });
 
   const { stdout: modified } = await execa('git', ['ls-files', '--modified'], { cwd });
@@ -23,12 +23,12 @@ test('gitCheckout files', async () => {
 
 test('gitCheckout files with .gitignored files', async () => {
   const cwd = await initFixture('no-interdependencies');
-  const files = ['package-1', 'package-2', 'package-3'].map((name) => path.join('packages', name, 'package.json'));
+  const files = ['package-1', 'package-2', 'package-3'].map((name) => join('packages', name, 'package.json'));
 
   // simulate a "dynamic", intentionally unversioned package by gitignoring it
-  await fs.writeFile(path.join(cwd, '.gitignore'), 'packages/package-3/*', 'utf8');
+  await outputFile(join(cwd, '.gitignore'), 'packages/package-3/*', 'utf8');
 
-  await Promise.all(files.map((fp) => fs.outputJSON(path.join(cwd, fp), { foo: 'bar' })));
+  await Promise.all(files.map((fp) => outputJson(join(cwd, fp), { foo: 'bar' })));
   await gitCheckout(files, { granularPathspec: false }, { cwd });
 
   const { stdout: modified } = await execa('git', ['ls-files', '--others'], { cwd });

--- a/packages/publish/src/__tests__/npm-publish.spec.ts
+++ b/packages/publish/src/__tests__/npm-publish.spec.ts
@@ -15,7 +15,7 @@ import readJSON from 'read-package-json';
 import { runLifecycle, Package, RawManifest } from '@lerna-lite/core';
 
 // helpers
-import path from 'path';
+import { join, normalize } from 'node:path';
 import { Mock } from 'vitest';
 
 // file under test
@@ -32,8 +32,8 @@ describe('npm-publish', () => {
   (runLifecycle as Mock).mockName('@lerna-lite/core').mockResolvedValue(null);
 
   const tarFilePath = '/tmp/test-1.10.100.tgz';
-  const rootPath = path.normalize('/test');
-  const pkg = new Package({ name: '@scope/test', version: '1.10.100' } as RawManifest, path.join(rootPath, 'npmPublish/test'), rootPath);
+  const rootPath = normalize('/test');
+  const pkg = new Package({ name: '@scope/test', version: '1.10.100' } as RawManifest, join(rootPath, 'npmPublish/test'), rootPath);
 
   it('calls external libraries with correct arguments', async () => {
     const opts = { tag: 'published-tag' };
@@ -122,7 +122,7 @@ describe('npm-publish', () => {
           directory: 'dist',
         },
       } as RawManifest,
-      path.join(rootPath, 'npmPublish/fancy'),
+      join(rootPath, 'npmPublish/fancy'),
       rootPath
     );
 
@@ -135,7 +135,7 @@ describe('npm-publish', () => {
 
     await npmPublish(fancyPkg, tarFilePath);
 
-    expect(readJSON).toHaveBeenCalledWith(path.join(fancyPkg.location, 'dist/package.json'), expect.any(Function));
+    expect(readJSON).toHaveBeenCalledWith(join(fancyPkg.location, 'dist/package.json'), expect.any(Function));
     expect(publish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'fancy-fancy',

--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -20,9 +20,9 @@ vi.mock('../lib/verify-npm-package-access', async () => await vi.importActual('.
 vi.mock('../lib/get-npm-username', async () => await vi.importActual('../lib/__mocks__/get-npm-username'));
 vi.mock('../lib/get-two-factor-auth-required', async () => await vi.importActual('../lib/__mocks__/get-two-factor-auth-required'));
 vi.mock('../lib/npm-publish', async () => await vi.importActual('../lib/__mocks__/npm-publish'));
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { outputFile } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Mock } from 'vitest';
 import yargParser from 'yargs-parser';
 
@@ -35,7 +35,7 @@ import { promptConfirmation, PublishCommandOption, describeRef, throwIfUncommitt
 // helpers
 import { commandRunner, gitAdd, gitTag, gitCommit, initFixtureFactory, loggingOutput } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // test command
@@ -86,7 +86,7 @@ async function initTaggedFixture(fixtureName, tagVersionPrefix = 'v') {
  * @param {Array[String]..} tuples Any number of [filePath, fileContent] configs
  */
 async function setupChanges(cwd, ...tuples) {
-  await Promise.all(tuples.map(([filePath, content]) => fs.outputFile(path.join(cwd, filePath), content, 'utf8')));
+  await Promise.all(tuples.map(([filePath, content]) => outputFile(join(cwd, filePath), content, 'utf8')));
   await gitAdd(cwd, '.');
   await gitCommit(cwd, 'setup');
 }

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -40,13 +40,13 @@ vi.mock('fs-extra/esm', async () => ({
   outputFileSync: vi.fn(),
 }));
 
-import { outputFileSync, outputJSON } from 'fs-extra/esm';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { outputFileSync, outputJson } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import { commitChangeToPackage } from '@lerna-test/helpers';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
@@ -663,8 +663,8 @@ describe('PublishCommand', () => {
       expect(dirOne).toBe(pkgOne.location);
       expect(dirTwo).toBe(pkgTwo.location);
 
-      expect(pkgOne.contents).toBe(path.join(pkgOne.location, 'dist'));
-      expect(pkgTwo.contents).toBe(path.join(pkgTwo.location, 'dist'));
+      expect(pkgOne.contents).toBe(join(pkgOne.location, 'dist'));
+      expect(pkgTwo.contents).toBe(join(pkgTwo.location, 'dist'));
 
       // opts is a snapshot of npm-conf instance
       expect(packDirectory).toHaveBeenCalledWith(pkgOne, dirOne, opts);
@@ -687,17 +687,17 @@ describe('PublishCommand', () => {
       expect(packDirectory).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'package-1',
-          contents: path.join(cwd, 'packages/package-1/dist'),
+          contents: join(cwd, 'packages/package-1/dist'),
         }),
-        path.join(cwd, 'packages/package-1'),
+        join(cwd, 'packages/package-1'),
         expect.any(Object)
       );
       expect(packDirectory).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'package-2',
-          contents: path.join(cwd, 'packages/package-2'),
+          contents: join(cwd, 'packages/package-2'),
         }),
-        path.join(cwd, 'packages/package-2'),
+        join(cwd, 'packages/package-2'),
         expect.any(Object)
       );
     });
@@ -716,7 +716,7 @@ describe('PublishCommand', () => {
     it('set "describeTag" in lerna.json', async () => {
       const testDir = await initFixture('normal');
 
-      await outputJSON(path.join(testDir, 'lerna.json'), {
+      await outputJson(join(testDir, 'lerna.json'), {
         version: 'independent',
         describeTag: '*custom-tag*',
       });

--- a/packages/publish/src/__tests__/publish-config-overrides.spec.ts
+++ b/packages/publish/src/__tests__/publish-config-overrides.spec.ts
@@ -33,15 +33,15 @@ vi.mock('../lib/pack-directory', async () => await vi.importActual<any>('../lib/
 vi.mock('../lib/npm-publish', async () => await vi.importActual<any>('../lib/__mocks__/npm-publish'));
 
 import { outputFile } from 'fs-extra/esm';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // mocked modules
 import writePkg from 'write-pkg';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { gitAdd } from '@lerna-test/helpers';
 import { gitTag } from '@lerna-test/helpers';
 import { gitCommit } from '@lerna-test/helpers';
@@ -67,7 +67,7 @@ const createArgv = (cwd, ...args) => {
 
 describe('publishConfig overrides', () => {
   const setupChanges = async (cwd, pkgRoot = 'packages') => {
-    await outputFile(path.join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
+    await outputFile(join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
     await gitAdd(cwd, '.');
     await gitCommit(cwd, 'setup');
   };

--- a/packages/publish/src/__tests__/publish-from-git.spec.ts
+++ b/packages/publish/src/__tests__/publish-from-git.spec.ts
@@ -33,14 +33,14 @@ import { npmPublish as npmPublishMock } from '../lib/__mocks__/npm-publish';
 import { logOutput, promptConfirmation, PublishCommandOption, throwIfUncommitted } from '@lerna-lite/core';
 
 // helpers
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { gitTag } from '@lerna-test/helpers';
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import { initFixtureFactory } from '@lerna-test/helpers';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // test command

--- a/packages/publish/src/__tests__/publish-from-package.spec.ts
+++ b/packages/publish/src/__tests__/publish-from-package.spec.ts
@@ -28,9 +28,9 @@ vi.mock('../lib/get-unpublished-packages', async () => await vi.importActual('..
 vi.mock('../lib/pack-directory', async () => await vi.importActual('../lib/__mocks__/pack-directory'));
 vi.mock('../lib/npm-publish', async () => await vi.importActual('../lib/__mocks__/npm-publish'));
 
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { remove } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Mock } from 'vitest';
 import yargParser from 'yargs-parser';
 
@@ -43,7 +43,7 @@ import { getUnpublishedPackages } from '../lib/get-unpublished-packages';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import { initFixtureFactory } from '@lerna-test/helpers';
 const initFixture = initFixtureFactory(__dirname);
@@ -154,7 +154,7 @@ describe('publish from-package', () => {
     const cwd = await initFixture('independent');
 
     // nuke the git repo first
-    await fs.remove(path.join(cwd, '.git'));
+    await remove(join(cwd, '.git'));
     await new PublishCommand(createArgv(cwd, 'from-package'));
 
     expect(npmPublish).toHaveBeenCalled();

--- a/packages/publish/src/__tests__/publish-licenses.spec.ts
+++ b/packages/publish/src/__tests__/publish-licenses.spec.ts
@@ -31,9 +31,9 @@ vi.mock('../lib/remove-temp-licenses', () => ({ removeTempLicenses: vi.fn(() => 
 vi.mock('../lib/pack-directory', async () => await vi.importActual('../lib/__mocks__/pack-directory'));
 vi.mock('../lib/npm-publish', async () => await vi.importActual('../lib/__mocks__/npm-publish'));
 
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { remove } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // mocked modules
 import { packDirectory } from '../lib/pack-directory';
@@ -42,7 +42,7 @@ import { removeTempLicenses } from '../lib/remove-temp-licenses';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 const initFixture = initFixtureFactory(__dirname);
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
@@ -75,7 +75,7 @@ describe('licenses', () => {
 
     await new PublishCommand(createArgv(cwd));
 
-    expect(createTempLicenses).toHaveBeenLastCalledWith(path.join(cwd, 'LICENSE'), packagesToBeLicensed);
+    expect(createTempLicenses).toHaveBeenLastCalledWith(join(cwd, 'LICENSE'), packagesToBeLicensed);
     expect(removeTempLicenses).toHaveBeenLastCalledWith(packagesToBeLicensed);
   });
 
@@ -122,7 +122,7 @@ describe('licenses', () => {
     const cwd = await initFixture('licenses');
 
     // remove root license so warning is triggered
-    await fs.remove(path.join(cwd, 'LICENSE'));
+    await remove(join(cwd, 'LICENSE'));
 
     await lernaPublish(cwd)();
 
@@ -134,7 +134,7 @@ describe('licenses', () => {
     const cwd = await initFixture('licenses-missing');
 
     // simulate _all_ packages missing a license
-    await fs.remove(path.join(cwd, 'packages/package-2/LICENSE'));
+    await remove(join(cwd, 'packages/package-2/LICENSE'));
 
     await lernaPublish(cwd)();
 

--- a/packages/publish/src/__tests__/publish-lifecycle-scripts.spec.ts
+++ b/packages/publish/src/__tests__/publish-lifecycle-scripts.spec.ts
@@ -40,13 +40,13 @@ import { packDirectory } from '../lib/pack-directory';
 import { runLifecycle } from '@lerna-lite/core';
 
 // helpers
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // test command
@@ -73,7 +73,7 @@ describe('lifecycle scripts', () => {
     // package-2 only has prepublish lifecycle
     expect(packDirectory).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'package-2' }),
-      path.join(cwd, 'packages/package-2'),
+      join(cwd, 'packages/package-2'),
       expect.objectContaining({
         'ignore-prepublish': false,
         'ignore-scripts': false,
@@ -148,7 +148,7 @@ describe('lifecycle scripts', () => {
 
     expect(packDirectory).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'package-2' }),
-      path.join(cwd, 'packages/package-2'),
+      join(cwd, 'packages/package-2'),
       expect.objectContaining({
         'ignore-prepublish': true,
       })
@@ -174,7 +174,7 @@ describe('lifecycle scripts', () => {
     );
     expect(packDirectory).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'package-2' }),
-      path.join(cwd, 'packages/package-2'),
+      join(cwd, 'packages/package-2'),
       expect.objectContaining({
         'ignore-scripts': true,
       })

--- a/packages/publish/src/__tests__/publish-relative-file-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-relative-file-specifiers.spec.ts
@@ -32,16 +32,16 @@ vi.mock('../lib/get-two-factor-auth-required', async () => await vi.importActual
 vi.mock('../lib/pack-directory', async () => await vi.importActual('../lib/__mocks__/pack-directory'));
 vi.mock('../lib/npm-publish', async () => await vi.importActual('../lib/__mocks__/npm-publish'));
 
-import fs from 'fs-extra';
-import path from 'path';
+import { outputFile } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
 
 // mocked modules
 import writePkg from 'write-pkg';
 
 // helpers
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { commandRunner, gitAdd, gitCommit, gitTag, initFixtureFactory } from '@lerna-test/helpers';
 const initFixture = initFixtureFactory(__dirname);
 
@@ -66,7 +66,7 @@ const createArgv = (cwd, ...args) => {
 
 describe("relative 'file:' specifiers", () => {
   const setupChanges = async (cwd, pkgRoot = 'packages') => {
-    await fs.outputFile(path.join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
+    await outputFile(join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
     await gitAdd(cwd, '.');
     await gitCommit(cwd, 'setup');
   };

--- a/packages/publish/src/__tests__/publish-remove-package-fields.spec.ts
+++ b/packages/publish/src/__tests__/publish-remove-package-fields.spec.ts
@@ -31,20 +31,20 @@ vi.mock('../lib/get-two-factor-auth-required', async () => await vi.importActual
 vi.mock('../lib/pack-directory', async () => await vi.importActual('../lib/__mocks__/pack-directory'));
 vi.mock('../lib/npm-publish', async () => await vi.importActual('../lib/__mocks__/npm-publish'));
 
-import fs from 'fs-extra';
-import path from 'path';
+import { outputFile } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
 
 // mocked modules
 import writePkg from 'write-pkg';
 
 // helpers
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { gitAdd } from '@lerna-test/helpers';
 import { gitTag } from '@lerna-test/helpers';
 import { gitCommit } from '@lerna-test/helpers';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // test command
@@ -54,7 +54,7 @@ const lernaPublish = commandRunner(cliCommands);
 
 describe('publish --remove-package-fields', () => {
   const setupChanges = async (cwd, pkgRoot = 'packages') => {
-    await fs.outputFile(path.join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
+    await outputFile(join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
     await gitAdd(cwd, '.');
     await gitCommit(cwd, 'setup');
   };

--- a/packages/publish/src/__tests__/publish-tagging.spec.ts
+++ b/packages/publish/src/__tests__/publish-tagging.spec.ts
@@ -39,10 +39,10 @@ import { npmPublish } from '../lib/npm-publish';
 import { add, remove } from '../lib/npm-dist-tag';
 
 // helpers
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 const initFixture = initFixtureFactory(__dirname);
 

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -32,17 +32,17 @@ vi.mock('../lib/get-two-factor-auth-required', async () => await vi.importActual
 vi.mock('../lib/pack-directory', async () => await vi.importActual<any>('../lib/__mocks__/pack-directory'));
 vi.mock('../lib/npm-publish', async () => await vi.importActual<any>('../lib/__mocks__/npm-publish'));
 
-import fs from 'fs-extra';
-import path from 'path';
+import { outputFile } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
 import npmlog from 'npmlog';
 
 // mocked modules
 import writePkg from 'write-pkg';
 
 // helpers
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { gitAdd } from '@lerna-test/helpers';
 import { gitTag } from '@lerna-test/helpers';
 import { gitCommit } from '@lerna-test/helpers';
@@ -68,7 +68,7 @@ const createArgv = (cwd, ...args) => {
 
 describe("workspace protocol 'workspace:' specifiers", () => {
   const setupChanges = async (cwd, pkgRoot = 'packages') => {
-    await fs.outputFile(path.join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
+    await outputFile(join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
     await gitAdd(cwd, '.');
     await gitCommit(cwd, 'setup');
   };

--- a/packages/publish/src/__tests__/remove-temp-licenses.spec.ts
+++ b/packages/publish/src/__tests__/remove-temp-licenses.spec.ts
@@ -1,11 +1,11 @@
-import fs from 'fs-extra';
-import path from 'path';
+import { pathExists } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
 import { Project } from '@lerna-lite/core';
 import { removeTempLicenses } from '../lib/remove-temp-licenses';
 import { initFixtureFactory } from '@lerna-test/helpers';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 describe('removeTempLicenses', () => {
@@ -15,11 +15,11 @@ describe('removeTempLicenses', () => {
     const [pkg] = await project.getPackages();
 
     // mimic decoration in createTempLicenses()
-    pkg.licensePath = path.join(pkg.location, 'LICENSE');
+    pkg.licensePath = join(pkg.location, 'LICENSE');
 
     await removeTempLicenses([pkg]);
 
-    const tempLicensePresent = await fs.pathExists(pkg.licensePath);
+    const tempLicensePresent = await pathExists(pkg.licensePath);
     expect(tempLicensePresent).toBe(false);
   });
 
@@ -29,11 +29,11 @@ describe('removeTempLicenses', () => {
     const [pkg] = await project.getPackages();
 
     // mimic decoration in createTempLicenses()
-    pkg.licensePath = path.join(pkg.location, 'LICENSE');
+    pkg.licensePath = join(pkg.location, 'LICENSE');
 
     await removeTempLicenses([]);
 
-    const licensePresent = await fs.pathExists(pkg.licensePath);
+    const licensePresent = await pathExists(pkg.licensePath);
     expect(licensePresent).toBe(true);
   });
 });

--- a/packages/publish/src/__tests__/verify-npm-package-access.spec.ts
+++ b/packages/publish/src/__tests__/verify-npm-package-access.spec.ts
@@ -4,14 +4,14 @@ import { FetchConfig, Project } from '@lerna-lite/core';
 import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import { initFixtureFactory } from '@lerna-test/helpers';
 import access from 'libnpmaccess';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { Mock } from 'vitest';
 
 import { verifyNpmPackageAccess } from '../lib/verify-npm-package-access';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 (access.getPackages as unknown as Mock).mockImplementation(() =>

--- a/packages/publish/src/lib/create-temp-licenses.ts
+++ b/packages/publish/src/lib/create-temp-licenses.ts
@@ -1,5 +1,5 @@
 import { copy } from 'fs-extra/esm';
-import path from 'path';
+import { basename, join } from 'node:path';
 import pMap from 'p-map';
 
 import { Package } from '@lerna-lite/core';
@@ -15,7 +15,7 @@ export function createTempLicenses(srcLicensePath: string, packagesToBeLicensed:
   }
 
   // license file might have an extension, so let's allow it
-  const licenseFileName = path.basename(srcLicensePath);
+  const licenseFileName = basename(srcLicensePath);
   const options = {
     // make an effort to keep package contents stable over time
     preserveTimestamps: process.arch !== 'ia32',
@@ -24,7 +24,7 @@ export function createTempLicenses(srcLicensePath: string, packagesToBeLicensed:
 
   // store target path for removal later
   packagesToBeLicensed.forEach((pkg) => {
-    pkg.licensePath = path.join(pkg.contents, licenseFileName);
+    pkg.licensePath = join(pkg.contents, licenseFileName);
   });
 
   return pMap(packagesToBeLicensed, (pkg) => copy(srcLicensePath, pkg.licensePath, options));

--- a/packages/publish/src/lib/get-packages-without-license.ts
+++ b/packages/publish/src/lib/get-packages-without-license.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { dirname } from 'node:path';
 import { Package, Project } from '@lerna-lite/core';
 
 /**
@@ -11,7 +11,7 @@ export function getPackagesWithoutLicense(project: Project, packagesToPublish: P
   return project.getPackageLicensePaths().then((licensePaths: string[]) => {
     // this assumes any existing license is a sibling of package.json, which is pretty safe
     // it also dedupes package locations, since we don't care about duplicate license files
-    const licensed = new Set(licensePaths.map((lp: string) => path.dirname(lp)));
+    const licensed = new Set(licensePaths.map((lp: string) => dirname(lp)));
 
     return packagesToPublish.filter((pkg) => !licensed.has(pkg.location));
   });

--- a/packages/publish/src/lib/get-packed.ts
+++ b/packages/publish/src/lib/get-packed.ts
@@ -1,6 +1,6 @@
-import { createReadStream } from 'fs';
+import { createReadStream } from 'node:fs';
 import { stat } from 'fs/promises';
-import path from 'path';
+import { basename } from 'node:path';
 import ssri from 'ssri';
 import tar from 'tar';
 import { Package } from '@lerna-lite/core';
@@ -60,7 +60,7 @@ export function getPacked(pkg: Package, tarFilePath: string): Promise<Tarball> {
         unpackedSize: totalEntrySize,
         shasum,
         integrity: ssri.parse(sha512[0]),
-        filename: path.basename(tarFilePath),
+        filename: basename(tarFilePath),
         files,
         entryCount: totalEntries,
         bundled: Array.from(bundled),

--- a/packages/publish/src/lib/get-tagged-packages.ts
+++ b/packages/publish/src/lib/get-tagged-packages.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { basename, dirname, join } from 'node:path';
 import log from 'npmlog';
 import { exec, ExecOpts, PackageGraph } from '@lerna-lite/core';
 
@@ -16,8 +16,8 @@ export function getTaggedPackages(packageGraph: PackageGraph, rootPath: string, 
   // FIXME: --root is only necessary for tests :P
   return exec('git', ['diff-tree', '--name-only', '--no-commit-id', '--root', '-r', '-c', 'HEAD'], execOpts, dryRun).then(
     ({ stdout }) => {
-      const manifests = stdout.split('\n').filter((fp) => path.basename(fp) === 'package.json');
-      const locations = new Set<string>(manifests.map((fp) => path.join(rootPath, path.dirname(fp))));
+      const manifests = stdout.split('\n').filter((fp) => basename(fp) === 'package.json');
+      const locations = new Set<string>(manifests.map((fp) => join(rootPath, dirname(fp))));
 
       // @ts-ignore
       return Array.from(packageGraph.values()).filter((node: { location: string }) => locations.has(node.location));

--- a/packages/publish/src/lib/npm-publish.ts
+++ b/packages/publish/src/lib/npm-publish.ts
@@ -3,7 +3,7 @@ import { OneTimePasswordCache, otplease } from '@lerna-lite/version';
 import { readFile } from 'fs/promises';
 import log from 'npmlog';
 import npa from 'npm-package-arg';
-import path from 'path';
+import { join } from 'node:path';
 import pify from 'pify';
 import { publish } from 'libnpmpublish';
 import readJSON from 'read-package-json';
@@ -60,7 +60,7 @@ export function npmPublish(
 
       if (pkg.contents !== pkg.location) {
         // 'rebase' manifest used to generated directory
-        manifestLocation = path.join(pkg.contents, 'package.json');
+        manifestLocation = join(pkg.contents, 'package.json');
       }
 
       return Promise.all([readFile(tarFilePath), readJSONAsync(manifestLocation) as RawManifest]);

--- a/packages/publish/src/lib/pack-directory.ts
+++ b/packages/publish/src/lib/pack-directory.ts
@@ -1,10 +1,10 @@
 import { LifecycleConfig, Package, PackConfig, runLifecycle } from '@lerna-lite/core';
 import { tempWrite } from '@lerna-lite/version';
 import Arborist from '@npmcli/arborist';
-import path from 'path';
 import packlist from 'npm-packlist';
 import log from 'npmlog';
-import { Readable } from 'stream';
+import { relative } from 'node:path';
+import { Readable } from 'node:stream';
 import tar from 'tar';
 
 import { getPacked } from './get-packed.js';
@@ -24,7 +24,7 @@ export async function packDirectory(_pkg: Package, dir: string, options: PackCon
     ...options,
   };
 
-  opts.log.verbose('pack-directory', path.relative('.', pkg.contents));
+  opts.log.verbose('pack-directory', relative('.', pkg.contents));
 
   if (opts.ignorePrepublish !== true) {
     await runLifecycle(pkg, 'prepublish', opts);

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import { glob } from 'glob';
 import { outputFileSync, removeSync } from 'fs-extra/esm';
-import os from 'node:os';
-import path from 'path';
+import { EOL } from 'node:os';
+import { join, relative } from 'node:path';
 import crypto from 'crypto';
 import { createRequire } from 'node:module';
 import normalizePath from 'normalize-path';
@@ -331,12 +331,12 @@ export class PublishCommand extends Command<PublishCommandOption> {
       }
     } else {
       const message = publishedPackagesSorted.map((pkg) => ` - ${pkg.name}@${pkg.version}`);
-      logOutput(message.join(os.EOL));
+      logOutput(message.join(EOL));
     }
 
     // optionally cleanup temp packed files after publish, opt-in option
     if (this.options.cleanupTempFiles) {
-      glob(normalizePath(path.join(tempDir, '/lerna-*'))).then((deleteFolders) => {
+      glob(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
         // delete silently all files/folders that startsWith "lerna-"
         deleteFolders.forEach((folder) => removeSync(folder));
         this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);
@@ -537,7 +537,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     logOutput('');
     logOutput(`Found ${count} ${count === 1 ? 'package' : 'packages'} to publish:`);
-    logOutput(message.join(os.EOL));
+    logOutput(message.join(EOL));
     logOutput('');
 
     if (this.options.yes) {
@@ -743,7 +743,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
     // prettier-ignore
     const dirtyManifests = [this.project.manifest]
       .concat(this.packagesToPublish)
-      .map((pkg) => path.relative(cwd, pkg.manifestLocation));
+      .map((pkg) => relative(cwd, pkg.manifestLocation));
 
     return gitCheckout(dirtyManifests, gitOpts, this.execOpts, this.options.dryRun).catch((err) => {
       this.logger.silly('EGITCHECKOUT', err.message);
@@ -753,7 +753,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
   // @deprecated, see Lerna PR https://github.com/lerna/lerna/pull/1862/files
   execScript(pkg: Package, script: string) {
-    const scriptLocation = path.join(pkg.location, 'scripts', script);
+    const scriptLocation = join(pkg.location, 'scripts', script);
 
     try {
       const require = createRequire(import.meta.url);
@@ -857,7 +857,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
           (pkg: Package & { packed: Tarball }) =>
             pulseTillDone(packDirectory(pkg, pkg.location, opts)).then((packed: Tarball) => {
-              tracker.verbose('packed', path.relative(this.project.rootPath ?? '', pkg.contents));
+              tracker.verbose('packed', relative(this.project.rootPath ?? '', pkg.contents));
               tracker.completeWork(1);
 
               // store metadata for use in this.publishPacked()

--- a/packages/run/src/__tests__/run-command-with-nx-no-target-defaults.spec.ts
+++ b/packages/run/src/__tests__/run-command-with-nx-no-target-defaults.spec.ts
@@ -15,13 +15,13 @@ import { npmRunScript, npmRunScriptStreaming } from '../lib/npm-run-script';
 import cliRunCommands from '../../../cli/src/cli-commands/cli-run-commands';
 
 // helpers
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { Mock } from 'vitest';
 
 import { commandRunner, initFixtureFactory, loggingOutput } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 
 const lernaRun = commandRunner(cliRunCommands);
 const initFixture = initFixtureFactory(__dirname);

--- a/packages/run/src/__tests__/run-command-with-nx-not-loaded.spec.ts
+++ b/packages/run/src/__tests__/run-command-with-nx-not-loaded.spec.ts
@@ -9,12 +9,12 @@ import { npmRunScript } from '../lib/npm-run-script';
 import cliRunCommands from '../../../cli/src/cli-commands/cli-run-commands';
 
 // helpers
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { Mock } from 'vitest';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 
 const lernaRun = commandRunner(cliRunCommands);

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -13,7 +13,7 @@ vi.mock('@lerna-lite/core', async () => ({
 // also point to the local run command so that all mocks are properly used even by the command-runner
 vi.mock('@lerna-lite/run', () => vi.importActual<any>('../run-command'));
 
-import fs from 'fs-extra';
+import { pathExists, readJson } from 'fs-extra/esm';
 import { globby } from 'globby';
 import { Mock } from 'vitest';
 import yargParser from 'yargs-parser';
@@ -22,10 +22,10 @@ import yargParser from 'yargs-parser';
 import { logOutput, RunCommandOption } from '@lerna-lite/core';
 
 // mocked modules
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { npmRunScript, npmRunScriptStreaming } from '../lib/npm-run-script';
 import cliRunCommands from '../../../cli/src/cli-commands/cli-run-commands';
 
@@ -247,7 +247,7 @@ describe('RunCommand', () => {
       await lernaRun(cwd)('my-script', '--profile');
 
       const [profileLocation] = await globby('Lerna-Profile-*.json', { cwd, absolute: true });
-      const json = await fs.readJson(profileLocation);
+      const json = await readJson(profileLocation);
 
       expect(json).toMatchObject([
         {
@@ -270,9 +270,9 @@ describe('RunCommand', () => {
       await new RunCommand(createArgv(cwd, 'my-script', '--profile', '--profile-location', 'foo/bar'));
 
       const [profileLocation] = await globby('foo/bar/Lerna-Profile-*.json', { cwd, absolute: true });
-      const exists = await fs.exists(profileLocation, null as any);
+      const isExists = await pathExists(profileLocation, null as any);
 
-      expect(exists).toBe(true);
+      expect(isExists).toBe(true);
     });
   });
 

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -13,7 +13,7 @@ import { generateProfileOutputPath, Profiler } from '@lerna-lite/profiler';
 import chalk from 'chalk';
 import { pathExistsSync } from 'fs-extra/esm';
 import pMap from 'p-map';
-import path from 'path';
+import { join, relative } from 'node:path';
 import { performance } from 'perf_hooks';
 
 import { npmRunScript, npmRunScriptStreaming, timer } from './lib/index.js';
@@ -225,7 +225,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
     if (this.options.profile) {
       const absolutePath = generateProfileOutputPath(this.options.profileLocation);
       // Nx requires a workspace relative path for this
-      process.env.NX_PROFILE = path.relative(this.project.rootPath, absolutePath);
+      process.env.NX_PROFILE = relative(this.project.rootPath, absolutePath);
     }
 
     performance.mark('init-local');
@@ -258,7 +258,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
   }
 
   async prepNxOptions() {
-    const nxJsonExists = pathExistsSync(path.join(this.project.rootPath, 'nx.json'));
+    const nxJsonExists = pathExistsSync(join(this.project.rootPath, 'nx.json'));
     const { readNxJson } = await import('nx/src/config/configuration.js');
     const nxJson = readNxJson();
     const targetDependenciesAreDefined = Object.keys(nxJson.targetDependencies || nxJson.targetDefaults || {}).length > 0;

--- a/packages/version/src/__mocks__/conventional-commits.ts
+++ b/packages/version/src/__mocks__/conventional-commits.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { join } from 'node:path';
 import semver from 'semver';
 const { outputFile } = await vi.importActual<any>('fs-extra/esm');
 
@@ -16,7 +16,7 @@ mockApplyBuildMetadata.mockImplementation((version, buildMetadata) => {
 mockRecommendVersion.mockImplementation((node) => semver.inc(node.version, 'patch'));
 
 mockUpdateChangelog.mockImplementation((pkg) => {
-  const filePath = path.join(pkg.location, 'CHANGELOG.md');
+  const filePath = join(pkg.location, 'CHANGELOG.md');
 
   // grumble grumble re-implementing the implementation
   return outputFile(filePath, 'changelog', 'utf8').then(() => ({

--- a/packages/version/src/__tests__/get-current-branch.spec.ts
+++ b/packages/version/src/__tests__/get-current-branch.spec.ts
@@ -1,10 +1,11 @@
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { getCurrentBranch } from '../lib/get-current-branch';
 
 import { initFixtureFactory } from '@lerna-test/helpers';
-import path from 'path';
+import { dirname } from 'node:path';
+
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 test('getCurrentBranch', async () => {

--- a/packages/version/src/__tests__/git-add.spec.ts
+++ b/packages/version/src/__tests__/git-add.spec.ts
@@ -1,22 +1,22 @@
 import { execa } from 'execa';
-import fs from 'fs-extra';
-import path from 'path';
+import { outputFile, outputJson } from 'fs-extra/esm';
+import { dirname, join } from 'node:path';
 import slash from 'slash';
 import { gitAdd } from '../lib/git-add';
 
 import { initFixtureFactory } from '@lerna-test/helpers';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 const getStagedFile = async (cwd) => execa('git', ['diff', '--cached', '--name-only'], { cwd }).then((result) => slash(result.stdout));
 
 test('relative files', async () => {
   const cwd = await initFixture('root-manifest-only');
-  const file = path.join('packages', 'pkg-1', 'index.js');
+  const file = join('packages', 'pkg-1', 'index.js');
 
-  await fs.outputFile(path.join(cwd, file), 'hello');
+  await outputFile(join(cwd, file), 'hello');
   await gitAdd([file], { granularPathspec: true }, { cwd });
 
   await expect(getStagedFile(cwd)).resolves.toBe('packages/pkg-1/index.js');
@@ -24,9 +24,9 @@ test('relative files', async () => {
 
 test('absolute files', async () => {
   const cwd = await initFixture('root-manifest-only');
-  const file = path.join(cwd, 'packages', 'pkg-2', 'index.js');
+  const file = join(cwd, 'packages', 'pkg-2', 'index.js');
 
-  await fs.outputFile(file, 'hello');
+  await outputFile(file, 'hello');
   await gitAdd([file], { granularPathspec: true }, { cwd });
 
   await expect(getStagedFile(cwd)).resolves.toBe('packages/pkg-2/index.js');
@@ -34,13 +34,13 @@ test('absolute files', async () => {
 
 test('.gitignore', async () => {
   const cwd = await initFixture('root-manifest-only');
-  const file3 = path.join(cwd, 'packages/version-3/package.json');
-  const file4 = path.join(cwd, 'packages/dynamic-4/package.json');
+  const file3 = join(cwd, 'packages/version-3/package.json');
+  const file4 = join(cwd, 'packages/dynamic-4/package.json');
 
   await Promise.all([
     // a 'dynamic' package is intentionally unversioned, yet still published
-    fs.outputJSON(file3, { three: true }),
-    fs.outputJSON(file4, { four: true }),
+    outputJson(file3, { three: true }),
+    outputJson(file4, { four: true }),
   ]);
 
   await gitAdd([file3, file4], { granularPathspec: false }, { cwd });
@@ -50,13 +50,13 @@ test('.gitignore', async () => {
 
 test('.gitignore without naming files', async () => {
   const cwd = await initFixture('root-manifest-only');
-  const file5 = path.join(cwd, 'packages/version-5/package.json');
-  const file6 = path.join(cwd, 'packages/dynamic-6/package.json');
+  const file5 = join(cwd, 'packages/version-5/package.json');
+  const file6 = join(cwd, 'packages/dynamic-6/package.json');
 
   await Promise.all([
     // a 'dynamic' package is intentionally unversioned, yet still published
-    fs.outputJSON(file5, { five: true }),
-    fs.outputJSON(file6, { six: true }),
+    outputJson(file5, { five: true }),
+    outputJson(file6, { six: true }),
   ]);
 
   await gitAdd([], { granularPathspec: false }, { cwd });

--- a/packages/version/src/__tests__/git-push.spec.ts
+++ b/packages/version/src/__tests__/git-push.spec.ts
@@ -1,9 +1,9 @@
 import { execa } from 'execa';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { gitPush } from '../lib/git-push';
 import { cloneFixtureFactory } from '@lerna-test/helpers';
 const cloneFixture = cloneFixtureFactory(__dirname);

--- a/packages/version/src/__tests__/is-anything-committed.spec.ts
+++ b/packages/version/src/__tests__/is-anything-committed.spec.ts
@@ -1,11 +1,11 @@
 import { execa } from 'execa';
 import { execSync } from '@lerna-lite/core';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { isAnythingCommitted } from '../lib/is-anything-committed';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { initFixtureFactory } from '@lerna-test/helpers';
 
 const initFixture = initFixtureFactory(__dirname);

--- a/packages/version/src/__tests__/is-behind-upstream.spec.ts
+++ b/packages/version/src/__tests__/is-behind-upstream.spec.ts
@@ -1,11 +1,11 @@
 import { execa } from 'execa';
 import { isBehindUpstream } from '../lib/is-behind-upstream';
 import { cloneFixtureFactory } from '@lerna-test/helpers';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const cloneFixture = cloneFixtureFactory(__dirname);
 
 test('isBehindUpstream', async () => {

--- a/packages/version/src/__tests__/remote-branch-exists.spec.ts
+++ b/packages/version/src/__tests__/remote-branch-exists.spec.ts
@@ -2,11 +2,11 @@ import { execa } from 'execa';
 
 import { remoteBranchExists } from '../lib/remote-branch-exists';
 import { cloneFixtureFactory } from '@lerna-test/helpers';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const cloneFixture = cloneFixtureFactory(__dirname);
 
 test('remoteBranchExists', async () => {

--- a/packages/version/src/__tests__/version-allow-branch.spec.ts
+++ b/packages/version/src/__tests__/version-allow-branch.spec.ts
@@ -16,16 +16,16 @@ vi.mock('@lerna-lite/core', async () => ({
   throwIfUncommitted: (await vi.importActual<any>('../../../core/src/__mocks__/check-working-tree')).throwIfUncommitted,
 }));
 
-import path from 'path';
+import { dirname, resolve as pathResolve } from 'node:path';
 import { execa } from 'execa';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import yargParser from 'yargs-parser';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { initFixtureFactory } from '@lerna-test/helpers';
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../../../publish/src/__tests__'));
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../../../publish/src/__tests__'));
 
 // test command
 import { VersionCommand } from '../index';

--- a/packages/version/src/__tests__/version-build-metadata.spec.ts
+++ b/packages/version/src/__tests__/version-build-metadata.spec.ts
@@ -22,7 +22,7 @@ vi.mock('@lerna-lite/version', async () => vi.importActual('../version-command')
 import { PackageGraphNode, promptSelectOne, promptTextInput, VersionCommandOption } from '@lerna-lite/core';
 import { makePromptVersion } from '../lib/prompt-version';
 
-import path from 'path';
+import { dirname, resolve as pathResolve } from 'node:path';
 import { Mock } from 'vitest';
 import yargParser from 'yargs-parser';
 
@@ -30,11 +30,11 @@ const resolvePrereleaseId = vi.fn(() => 'alpha');
 const versionPrompt = (buildMetadata) => makePromptVersion(resolvePrereleaseId, buildMetadata);
 
 // helpers
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../../../publish/src/__tests__'));
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../../../publish/src/__tests__'));
 import { showCommit } from '@lerna-test/helpers';
 
 // test command

--- a/packages/version/src/__tests__/version-bump-prerelease.spec.ts
+++ b/packages/version/src/__tests__/version-bump-prerelease.spec.ts
@@ -19,9 +19,9 @@ vi.mock('@lerna-lite/core', async () => ({
 // also point to the local version command so that all mocks are properly used even by the command-runner
 vi.mock('@lerna-lite/version', async () => await vi.importActual('../version-command'));
 
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { outputFile } from 'fs-extra/esm';
+import { dirname, join, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yargParser from 'yargs-parser';
 // mocked modules
 import { promptTextInput, promptSelectOne, VersionCommandOption } from '@lerna-lite/core';
@@ -29,8 +29,8 @@ import { promptTextInput, promptSelectOne, VersionCommandOption } from '@lerna-l
 // helpers
 import { commandRunner, gitAdd, gitCommit, gitInit, gitTag, getCommitMessage, initFixtureFactory, showCommit } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../../../publish/src/__tests__'));
+const __dirname = dirname(__filename);
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../../../publish/src/__tests__'));
 
 import Tacks from 'tacks';
 import { temporaryDirectory } from 'tempy';
@@ -71,7 +71,7 @@ const createArgv = (cwd, ...args) => {
 
 const setupChanges = async (cwd) => {
   await gitTag(cwd, 'v1.0.1-beta.3');
-  await fs.outputFile(path.join(cwd, 'packages/package-3/hello.js'), 'world');
+  await outputFile(join(cwd, 'packages/package-3/hello.js'), 'world');
   await gitAdd(cwd, '.');
   await gitCommit(cwd, 'feat: setup');
 };
@@ -192,7 +192,7 @@ chore: Publish new release
  - pkg-b@1.0.0-bumps.2
 `);
 
-  await fs.outputFile(path.join(cwd, 'packages/pkg-a/hello.js'), 'world');
+  await outputFile(join(cwd, 'packages/pkg-a/hello.js'), 'world');
   await gitAdd(cwd, '.');
   await gitCommit(cwd, 'feat: hello world');
 

--- a/packages/version/src/__tests__/version-bump.spec.ts
+++ b/packages/version/src/__tests__/version-bump.spec.ts
@@ -1,4 +1,4 @@
-import nodeFs from 'fs';
+import nodeFs from 'node:fs';
 vi.spyOn(nodeFs, 'renameSync');
 
 // local modules _must_ be explicitly mocked
@@ -21,8 +21,8 @@ vi.mock('@lerna-lite/core', async () => ({
 // also point to the local version command so that all mocks are properly used even by the command-runner
 vi.mock('@lerna-lite/version', async () => await vi.importActual('../version-command'));
 
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yargParser from 'yargs-parser';
 
 // mocked modules
@@ -30,9 +30,9 @@ import { promptSelectOne, VersionCommandOption } from '@lerna-lite/core';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../../../publish/src/__tests__'));
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../../../publish/src/__tests__'));
 import { getCommitMessage } from '@lerna-test/helpers';
 
 // test command

--- a/packages/version/src/__tests__/version-conventional-commits.spec.ts
+++ b/packages/version/src/__tests__/version-conventional-commits.spec.ts
@@ -21,21 +21,21 @@ vi.mock('@lerna-lite/core', async () => ({
   throwIfUncommitted: (await vi.importActual<any>('../../../core/src/__mocks__/check-working-tree')).throwIfUncommitted,
 }));
 
-import path from 'path';
+import { dirname, join, resolve as pathResolve } from 'node:path';
 import semver from 'semver';
 import { Mock } from 'vitest';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 // mocked modules
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import writePkg from 'write-pkg';
 import { collectUpdates, VersionCommandOption } from '@lerna-lite/core';
 import { recommendVersion, updateChangelog } from '../conventional-commits';
 
 // helpers
 import { initFixtureFactory, showCommit } from '@lerna-test/helpers';
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../../../publish/src/__tests__'));
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../../../publish/src/__tests__'));
 
 // test command
 import { VersionCommand } from '../version-command';
@@ -245,7 +245,7 @@ describe('--conventional-commits', () => {
       expect(changedFiles).toMatchSnapshot();
 
       ['package-1', 'package-2', 'package-3', 'package-4', 'package-5'].forEach((name) => {
-        const location = path.join(cwd, 'packages', name);
+        const location = join(cwd, 'packages', name);
 
         expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name, location }), 'fixed', {
           changelogPreset: undefined,
@@ -295,7 +295,7 @@ describe('--conventional-commits', () => {
       expect(changedFiles).toMatchSnapshot();
 
       ['package-1', 'package-2', 'package-3', 'package-4', 'package-5'].forEach((name) => {
-        const location = path.join(cwd, 'packages', name);
+        const location = join(cwd, 'packages', name);
 
         expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name, location }), 'fixed', {
           changelogPreset: undefined,

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -25,10 +25,10 @@ vi.mock('@lerna-lite/core', async () => ({
 vi.mock('@lerna-lite/version', async () => await vi.importActual('../version-command'));
 
 // mocked modules
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { logOutput, VersionCommandOption } from '@lerna-lite/core';
 import { recommendVersion } from '../conventional-commits';
 import { createGitHubClient, createGitLabClient } from '../git-clients';

--- a/packages/version/src/__tests__/version-git-hosted-siblings.spec.ts
+++ b/packages/version/src/__tests__/version-git-hosted-siblings.spec.ts
@@ -18,8 +18,8 @@ vi.mock('@lerna-lite/core', async () => ({
 }));
 vi.mock('write-pkg', async () => await vi.importActual('../lib/__mocks__/write-pkg'));
 
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yargParser from 'yargs-parser';
 
 // mocked module(s)
@@ -27,9 +27,9 @@ import writePkg from 'write-pkg';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { initFixtureFactory } from '@lerna-test/helpers';
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../../../publish/src/__tests__'));
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../../../publish/src/__tests__'));
 
 // test command
 import { VersionCommand } from '../version-command';

--- a/packages/version/src/__tests__/version-ignore-changes.spec.ts
+++ b/packages/version/src/__tests__/version-ignore-changes.spec.ts
@@ -1,4 +1,4 @@
-import nodeFs from 'fs';
+import nodeFs from 'node:fs';
 vi.spyOn(nodeFs, 'renameSync');
 
 // local modules _must_ be explicitly mocked
@@ -19,20 +19,20 @@ vi.mock('@lerna-lite/core', async () => ({
   throwIfUncommitted: (await vi.importActual<any>('../../../core/src/__mocks__/check-working-tree')).throwIfUncommitted,
 }));
 
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { outputFile } from 'fs-extra/esm';
+import { dirname, join, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yargParser from 'yargs-parser';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { gitAdd } from '@lerna-test/helpers';
 import { gitCommit } from '@lerna-test/helpers';
 import { gitTag } from '@lerna-test/helpers';
 import { showCommit } from '@lerna-test/helpers';
 import { initFixtureFactory } from '@lerna-test/helpers';
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../../../publish/src/__tests__'));
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../../../publish/src/__tests__'));
 
 // test command
 import { VersionCommand } from '../version-command';
@@ -56,7 +56,7 @@ const createArgv = (cwd, ...args) => {
 describe('version --ignore-changes', () => {
   const setupChanges = async (cwd, tuples) => {
     await gitTag(cwd, 'v1.0.0');
-    await Promise.all(tuples.map(([filePath, content]) => fs.outputFile(path.join(cwd, filePath), content, 'utf8')));
+    await Promise.all(tuples.map(([filePath, content]) => outputFile(join(cwd, filePath), content, 'utf8')));
     await gitAdd(cwd, '.');
     await gitCommit(cwd, 'setup');
   };

--- a/packages/version/src/__tests__/version-include-merged-tags.spec.ts
+++ b/packages/version/src/__tests__/version-include-merged-tags.spec.ts
@@ -10,9 +10,9 @@ vi.mock('@lerna-lite/core', async () => ({
   throwIfUncommitted: (await vi.importActual<any>('../../../core/src/__mocks__/check-working-tree')).throwIfUncommitted,
 }));
 
-import path from 'path';
-import fs from 'fs';
-import { fileURLToPath } from 'url';
+import { dirname as pathDirname, join } from 'node:path';
+import { appendFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import yargParser from 'yargs-parser';
 
 // mocked modules
@@ -20,7 +20,7 @@ import { logOutput, VersionCommandOption } from '@lerna-lite/core';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = pathDirname(__filename);
 import { gitCheckout } from '@lerna-test/helpers';
 import { gitCommit } from '@lerna-test/helpers';
 import { gitMerge } from '@lerna-test/helpers';
@@ -63,20 +63,20 @@ const createArgv = (cwd, ...args) => {
 describe('version --include-merged-tags', () => {
   const setupGitChangesWithBranch = async (cwd, mainPaths, branchPaths) => {
     await gitTag(cwd, 'v1.0.0');
-    await Promise.all(mainPaths.map((fp) => fs.appendFileSync(path.join(cwd, fp), '1')));
+    await Promise.all(mainPaths.map((fp) => appendFileSync(join(cwd, fp), '1')));
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'Commit');
     // Create release branch
     await gitCheckout(cwd, ['-b', 'release/v1.0.1']);
     // Switch into release branch
-    await Promise.all(branchPaths.map((fp) => fs.appendFileSync(path.join(cwd, fp), '1')));
+    await Promise.all(branchPaths.map((fp) => appendFileSync(join(cwd, fp), '1')));
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'Bump');
     await gitTag(cwd, 'v1.0.1');
     await gitCheckout(cwd, ['main']);
     await gitMerge(cwd, ['--no-ff', 'release/v1.0.1']);
     // Commit after merge
-    await Promise.all(mainPaths.map((fp) => fs.appendFileSync(path.join(cwd, fp), '1')));
+    await Promise.all(mainPaths.map((fp) => appendFileSync(join(cwd, fp), '1')));
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'Commit2');
   };

--- a/packages/version/src/__tests__/version-lifecycle-scripts.spec.ts
+++ b/packages/version/src/__tests__/version-lifecycle-scripts.spec.ts
@@ -20,13 +20,13 @@ vi.mock('@lerna-lite/core', async () => ({
 }));
 import { runLifecycle, VersionCommandOption } from '@lerna-lite/core';
 import { loadJsonFile } from 'load-json-file';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import yargParser from 'yargs-parser';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { initFixtureFactory } from '@lerna-test/helpers';
 const initFixture = initFixtureFactory(__dirname);
 

--- a/packages/version/src/__tests__/version-message.spec.ts
+++ b/packages/version/src/__tests__/version-message.spec.ts
@@ -15,15 +15,15 @@ vi.mock('@lerna-lite/core', async () => ({
   throwIfUncommitted: (await vi.importActual<any>('../../../core/src/__mocks__/check-working-tree')).throwIfUncommitted,
 }));
 
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yargParser from 'yargs-parser';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { getCommitMessage, initFixtureFactory } from '@lerna-test/helpers';
-const initFixture = initFixtureFactory(path.resolve(__dirname, '../../../publish/src/__tests__'));
+const initFixture = initFixtureFactory(pathResolve(__dirname, '../../../publish/src/__tests__'));
 
 // test command
 import { VersionCommand } from '../version-command';

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -1,12 +1,12 @@
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { readFile } from 'fs/promises';
+import { dirname, join, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Project } from '@lerna-lite/core';
 
 // helpers
 import { gitAdd, gitCommit, gitTag, initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 const initFixture = initFixtureFactory(__dirname);
 
 // file under test
@@ -206,7 +206,7 @@ describe('conventional-commits', () => {
       const [pkg1, pkg2] = await Project.getPackages(cwd);
       const opts = {
         // sometimes presets return null for the level, with no actual releaseType...
-        changelogPreset: path.resolve(__dirname, '__fixtures__/fixed/scripts/null-preset.ts'),
+        changelogPreset: pathResolve(__dirname, '__fixtures__/fixed/scripts/null-preset.ts'),
       };
 
       // make a change in package-1 and package-2
@@ -391,7 +391,7 @@ describe('conventional-commits', () => {
   });
 
   describe('updateChangelog()', () => {
-    const getFileContent = ({ logPath }) => fs.readFile(logPath, 'utf8');
+    const getFileContent = ({ logPath }) => readFile(logPath, 'utf8');
 
     it('creates files if they do not exist', async () => {
       const cwd = (await initFixture('changelog-missing')) as string;
@@ -415,8 +415,8 @@ describe('conventional-commits', () => {
         updateChangelog(rootPkg as Package, 'root', { version: '1.1.0' }),
       ]);
 
-      expect(leafChangelog.logPath).toBe(path.join(pkg1.location, 'CHANGELOG.md'));
-      expect(rootChangelog.logPath).toBe(path.join(rootPkg.location, 'CHANGELOG.md'));
+      expect(leafChangelog.logPath).toBe(join(pkg1.location, 'CHANGELOG.md'));
+      expect(rootChangelog.logPath).toBe(join(rootPkg.location, 'CHANGELOG.md'));
 
       const [leafChangelogContent, rootChangelogContent] = await Promise.all([getFileContent(leafChangelog), getFileContent(rootChangelog)]);
 

--- a/packages/version/src/conventional-commits/read-existing-changelog.ts
+++ b/packages/version/src/conventional-commits/read-existing-changelog.ts
@@ -1,6 +1,6 @@
 import { Package } from '@lerna-lite/core';
 import { readFile } from 'fs/promises';
-import path from 'path';
+import { join } from 'node:path';
 
 import { BLANK_LINE, COMMIT_GUIDELINE } from './constants.js';
 
@@ -10,7 +10,7 @@ import { BLANK_LINE, COMMIT_GUIDELINE } from './constants.js';
  * @returns {Promise<[string, string]>} A tuple of changelog location and contents
  */
 export async function readExistingChangelog(pkg: Package) {
-  const changelogFileLoc = path.join(pkg.location, 'CHANGELOG.md');
+  const changelogFileLoc = join(pkg.location, 'CHANGELOG.md');
 
   let chain: Promise<any> = Promise.resolve();
 

--- a/packages/version/src/git-clients/GitLabClient.ts
+++ b/packages/version/src/git-clients/GitLabClient.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch';
 import log from 'npmlog';
-import path from 'path';
+import { join } from 'node:path';
 
 import { GitClient, GitClientReleaseOption } from '../models/index.js';
 
@@ -35,8 +35,6 @@ export class GitLabClient implements GitClient {
   }
 
   releasesUrl(namespace: string, project: string, releaseType = 'releases'): string {
-    return new URL(
-      `${this.baseUrl}/${path.join('projects', encodeURIComponent(`${namespace}/${project}`), releaseType)}`
-    ).toString();
+    return new URL(`${this.baseUrl}/${join('projects', encodeURIComponent(`${namespace}/${project}`), releaseType)}`).toString();
   }
 }

--- a/packages/version/src/lib/__mocks__/load-json-file.ts
+++ b/packages/version/src/lib/__mocks__/load-json-file.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { dirname } from 'node:path';
 import normalizePath from 'normalize-path';
 
 const { loadJsonFile: actualLoadJsonFile, loadJsonFileSync: loadJsonFileSyncActual } = await vi.importActual<any>(
@@ -11,7 +11,7 @@ const syncRegistry = new Map();
 function incrementCalled(registry, manifestLocation) {
   // tempy creates dirnames that are 32 characters long, but we want a readable key
   const subPath = (manifestLocation || '').split(/[0-9a-f]{32}/).pop();
-  const key = normalizePath(path.dirname(subPath));
+  const key = normalizePath(dirname(subPath));
 
   // keyed off directory subpath, _not_ pkg.name (we don't know it yet)
   registry.set(key, (registry.get(key) || 0) + 1);

--- a/packages/version/src/lib/git-add.ts
+++ b/packages/version/src/lib/git-add.ts
@@ -1,5 +1,5 @@
 import log from 'npmlog';
-import path from 'path';
+import { relative, resolve as pathResolve } from 'node:path';
 import slash from 'slash';
 
 import { exec, ExecOpts } from '@lerna-lite/core';
@@ -12,7 +12,7 @@ import { exec, ExecOpts } from '@lerna-lite/core';
 export function gitAdd(changedFiles: string[], gitOpts: { granularPathspec: boolean }, execOpts: ExecOpts, dryRun = false) {
   // granular pathspecs should be relative to the git root, but that isn't necessarily where lerna-lite lives
   const files = gitOpts.granularPathspec
-    ? changedFiles.map((file) => slash(path.relative(execOpts.cwd, path.resolve(execOpts.cwd, file))))
+    ? changedFiles.map((file) => slash(relative(execOpts.cwd, pathResolve(execOpts.cwd, file))))
     : '.';
 
   log.silly('gitAdd', files.toString());

--- a/packages/version/src/utils/__tests__/temp-write.spec.ts
+++ b/packages/version/src/utils/__tests__/temp-write.spec.ts
@@ -1,23 +1,23 @@
-import fs from 'fs';
-import path from 'path';
-import { Readable } from 'stream';
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { Readable } from 'node:stream';
 import { tempWrite } from '../temp-write';
 
 describe('utils/temp-write', () => {
   it('tempWrite(string)', async () => {
     const filePath = await tempWrite('unicorn', 'test.png');
-    expect(fs.readFileSync(filePath, 'utf8')).toEqual('unicorn');
-    expect(path.basename(filePath)).toEqual('test.png');
+    expect(readFileSync(filePath, 'utf8')).toEqual('unicorn');
+    expect(basename(filePath)).toEqual('test.png');
   });
 
   it('tempWrite(buffer)', async () => {
     const filePath = await tempWrite(Buffer.from('unicorn'), 'test.png');
-    expect(fs.readFileSync(filePath, 'utf8')).toEqual('unicorn');
+    expect(readFileSync(filePath, 'utf8')).toEqual('unicorn');
   });
 
   it('tempWrite(buffer, path)', async () => {
     const filePath = await tempWrite(Buffer.from('unicorn'), 'foo/bar/test.png');
-    expect(fs.readFileSync(filePath, 'utf8')).toEqual('unicorn');
+    expect(readFileSync(filePath, 'utf8')).toEqual('unicorn');
 
     const regexp = process.platform === 'win32' ? /foo\\bar\\test\.png$/ : /foo\/bar\/test\.png$/;
     expect(filePath).toMatch(regexp);
@@ -30,7 +30,7 @@ describe('utils/temp-write', () => {
     readable.push('unicorn');
     readable.push(null);
     const filePath = await tempWrite(readable, 'test.png');
-    expect(fs.readFileSync(filePath, 'utf8')).toEqual('unicorn');
+    expect(readFileSync(filePath, 'utf8')).toEqual('unicorn');
   });
 
   it('rejects when tempWrite(stream) throws an error', async () => {
@@ -57,6 +57,6 @@ describe('utils/temp-write', () => {
   });
 
   it('tempWrite.sync()', () => {
-    expect(fs.readFileSync(tempWrite.sync('unicorn'), 'utf8')).toEqual('unicorn');
+    expect(readFileSync(tempWrite.sync('unicorn'), 'utf8')).toEqual('unicorn');
   });
 });

--- a/packages/version/src/utils/temp-write.ts
+++ b/packages/version/src/utils/temp-write.ts
@@ -7,14 +7,14 @@
 import fs from 'graceful-fs';
 import { isStream } from 'is-stream';
 import makeDir from 'make-dir';
-import path from 'path';
-import { Readable } from 'stream';
 import tempDir from 'temp-dir';
-import { promisify } from 'util';
+import { dirname, join } from 'node:path';
+import { Readable } from 'node:stream';
+import { promisify } from 'node:util';
 import { v4 as uuidv4 } from 'uuid';
 
 const writeFileP = promisify(fs.writeFile);
-const tempfile = (filePath?: string) => path.join(tempDir, `lerna-${uuidv4()}`, filePath || '');
+const tempfile = (filePath?: string) => join(tempDir, `lerna-${uuidv4()}`, filePath || '');
 
 const writeStream = async (filePath: string, fileContent: Readable) =>
   new Promise((resolve, reject) => {
@@ -38,7 +38,7 @@ export async function tempWrite(fileContent: Readable | fs.PathOrFileDescriptor,
   const tempPath = tempfile(filePath);
   const write = isStream(fileContent) ? writeStream : writeFileP;
 
-  await makeDir(path.dirname(tempPath));
+  await makeDir(dirname(tempPath));
   await write(tempPath, fileContent as DataView & Readable);
 
   return tempPath;
@@ -47,7 +47,7 @@ export async function tempWrite(fileContent: Readable | fs.PathOrFileDescriptor,
 tempWrite.sync = (fileContent: (DataView & Readable) | string, filePath?: string) => {
   const tempPath = tempfile(filePath);
 
-  makeDir.sync(path.dirname(tempPath));
+  makeDir.sync(dirname(tempPath));
   fs.writeFileSync(tempPath, fileContent);
 
   return tempPath;

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import dedent from 'dedent';
 import minimatch from 'minimatch';
-import os from 'node:os';
+import { EOL as OS_EOL } from 'node:os';
 import pMap from 'p-map';
 import pPipe from 'p-pipe';
 import pReduce from 'p-reduce';
@@ -801,7 +801,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
   async gitCommitAndTagVersionForUpdates() {
     const tags = this.packagesToVersion.map((pkg) => `${pkg.name}@${this.updatesVersions?.get(pkg.name)}`);
     const subject = this.options.message || 'chore: Publish new release';
-    const message = tags.reduce((msg, tag) => `${msg}${os.EOL} - ${tag}`, `${subject}${os.EOL}`);
+    const message = tags.reduce((msg, tag) => `${msg}${OS_EOL} - ${tag}`, `${subject}${OS_EOL}`);
 
     await gitCommit(message, this.gitOpts, this.execOpts, this.options.dryRun);
     for (const tag of tags) {

--- a/packages/watch/src/__tests__/watch-command.spec.ts
+++ b/packages/watch/src/__tests__/watch-command.spec.ts
@@ -48,8 +48,8 @@ vi.mock('@lerna-lite/watch', async () => await vi.importActual<any>('../watch-co
 // vi.useFakeTimers({ timerLimit: 100 });
 
 import mockStdin from 'mock-stdin';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Mock } from 'vitest';
 import yargParser from 'yargs-parser';
 
@@ -61,7 +61,7 @@ import { spawn, spawnStreaming } from '@lerna-lite/core';
 
 // helpers
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 import { normalizeRelativeDir } from '@lerna-test/helpers';
 import { factory, WatchCommand } from '../index.js';
@@ -70,7 +70,7 @@ const lernaWatch = commandRunner(cliWatchCommands);
 const initFixture = initFixtureFactory(__dirname);
 
 // assertion helpers
-const calledInPackages = () => (spawn as Mock).mock.calls.map(([, , opts]) => path.basename(opts.cwd));
+const calledInPackages = () => (spawn as Mock).mock.calls.map(([, , opts]) => basename(opts.cwd));
 const watchInPackagesStreaming = (testDir) =>
   (spawnStreaming as Mock).mock.calls.reduce((arr, [command, params, opts, prefix]) => {
     const dir = normalizeRelativeDir(testDir, opts.cwd);
@@ -172,7 +172,7 @@ describe('Watch Command', () => {
       await lernaWatch(testDir)('--debounce', '0', '--glob', 'src/**/*.{ts,tsx}', '--', 'lerna run build');
 
       expect(watchMock).toHaveBeenCalledWith(
-        [path.join(testDir, 'packages/package-1', '/src/**/*.{ts,tsx}'), path.join(testDir, 'packages/package-2', '/src/**/*.{ts,tsx}')],
+        [join(testDir, 'packages/package-1', '/src/**/*.{ts,tsx}'), join(testDir, 'packages/package-2', '/src/**/*.{ts,tsx}')],
         {
           ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
           ignoreInitial: true,
@@ -186,7 +186,7 @@ describe('Watch Command', () => {
       await lernaWatch(testDir)('--debounce', '0', '--glob', '/src/**/*.{ts,tsx}', '--', 'lerna run build');
 
       expect(watchMock).toHaveBeenCalledWith(
-        [path.join(testDir, 'packages/package-1', '/src/**/*.{ts,tsx}'), path.join(testDir, 'packages/package-2', '/src/**/*.{ts,tsx}')],
+        [join(testDir, 'packages/package-1', '/src/**/*.{ts,tsx}'), join(testDir, 'packages/package-2', '/src/**/*.{ts,tsx}')],
         {
           ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
           ignoreInitial: true,
@@ -199,7 +199,7 @@ describe('Watch Command', () => {
     it('should be able to take --await-write-finish options as a boolean', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--await-write-finish', '--', 'lerna run build');
 
-      expect(watchMock).toHaveBeenCalledWith([path.join(testDir, 'packages/package-1'), path.join(testDir, 'packages/package-2')], {
+      expect(watchMock).toHaveBeenCalledWith([join(testDir, 'packages/package-1'), join(testDir, 'packages/package-2')], {
         ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
         ignoreInitial: true,
         ignorePermissionErrors: true,
@@ -211,7 +211,7 @@ describe('Watch Command', () => {
     it('should take options prefixed with "awf" (awfPollInterval) and transform them into a valid chokidar "awaitWriteFinish" option', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--awf-poll-interval', '500', '--', 'lerna run build');
 
-      expect(watchMock).toHaveBeenCalledWith([path.join(testDir, 'packages/package-1'), path.join(testDir, 'packages/package-2')], {
+      expect(watchMock).toHaveBeenCalledWith([join(testDir, 'packages/package-1'), join(testDir, 'packages/package-2')], {
         ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
         ignoreInitial: true,
         ignorePermissionErrors: true,
@@ -223,7 +223,7 @@ describe('Watch Command', () => {
     it('should take options prefixed with "awf" (awfStabilityThreshold) and transform them into a valid chokidar "awaitWriteFinish" option', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--awf-stability-threshold', '275', '--', 'lerna run build');
 
-      expect(watchMock).toHaveBeenCalledWith([path.join(testDir, 'packages/package-1'), path.join(testDir, 'packages/package-2')], {
+      expect(watchMock).toHaveBeenCalledWith([join(testDir, 'packages/package-1'), join(testDir, 'packages/package-2')], {
         ignored: ['**/.git/**', '**/dist/**', '**/node_modules/**'],
         ignoreInitial: true,
         ignorePermissionErrors: true,
@@ -234,18 +234,18 @@ describe('Watch Command', () => {
 
     it('should execute change watch callback only in the given scope', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--', 'echo $LERNA_PACKAGE_NAME');
-      await watchChangeHandler('change', path.join(testDir, 'packages/package-2/some-file.ts'));
+      await watchChangeHandler('change', join(testDir, 'packages/package-2/some-file.ts'));
 
       expect(calledInPackages()).toEqual(['package-2']);
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(spawn).toHaveBeenLastCalledWith('echo $LERNA_PACKAGE_NAME', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({
           name: 'package-2',
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
-          LERNA_FILE_CHANGES: path.join(testDir, 'packages/package-2/some-file.ts'),
+          LERNA_FILE_CHANGES: join(testDir, 'packages/package-2/some-file.ts'),
         }),
         extendEnv: false,
         reject: true,
@@ -255,7 +255,7 @@ describe('Watch Command', () => {
 
     it('should execute change watch callback with --stream in the given scope', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--stream', '--', 'echo $LERNA_PACKAGE_NAME');
-      await watchChangeHandler('change', path.join(testDir, 'packages/package-2/some-file.ts'));
+      await watchChangeHandler('change', join(testDir, 'packages/package-2/some-file.ts'));
 
       expect(watchInPackagesStreaming(testDir)).toEqual(['packages/package-2 echo $LERNA_PACKAGE_NAME (prefix: package-2)']);
       expect(spawnStreaming).toHaveBeenCalledTimes(1);
@@ -263,13 +263,13 @@ describe('Watch Command', () => {
         'echo $LERNA_PACKAGE_NAME',
         [],
         {
-          cwd: path.join(testDir, 'packages/package-2'),
+          cwd: join(testDir, 'packages/package-2'),
           pkg: expect.objectContaining({
             name: 'package-2',
           }),
           env: expect.objectContaining({
             LERNA_PACKAGE_NAME: 'package-2',
-            LERNA_FILE_CHANGES: path.join(testDir, 'packages/package-2/some-file.ts'),
+            LERNA_FILE_CHANGES: join(testDir, 'packages/package-2/some-file.ts'),
           }),
           extendEnv: false,
           reject: true,
@@ -281,19 +281,19 @@ describe('Watch Command', () => {
 
     it('should execute change watch callback with default whitespace file delimiter', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--', 'echo $LERNA_PACKAGE_NAME $LERNA_FILE_CHANGES');
-      watchChangeHandler('change', path.join(testDir, 'packages/package-2/file-1.ts'));
-      await watchChangeHandler('change', path.join(testDir, 'packages/package-2/some-file.ts'));
+      watchChangeHandler('change', join(testDir, 'packages/package-2/file-1.ts'));
+      await watchChangeHandler('change', join(testDir, 'packages/package-2/some-file.ts'));
 
       expect(calledInPackages()).toEqual(['package-2']);
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(spawn).toHaveBeenLastCalledWith('echo $LERNA_PACKAGE_NAME $LERNA_FILE_CHANGES', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({
           name: 'package-2',
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
-          LERNA_FILE_CHANGES: [path.join(testDir, 'packages/package-2/file-1.ts'), path.join(testDir, 'packages/package-2/some-file.ts')].join(' '),
+          LERNA_FILE_CHANGES: [join(testDir, 'packages/package-2/file-1.ts'), join(testDir, 'packages/package-2/some-file.ts')].join(' '),
         }),
         extendEnv: false,
         reject: true,
@@ -304,19 +304,19 @@ describe('Watch Command', () => {
     it('should execute change watch callback with custom file delimiter when defined', async () => {
       // prettier-ignore
       await lernaWatch(testDir)('--debounce', '0', '--file-delimiter', ';;', '--', 'echo $LERNA_PACKAGE_NAME $LERNA_FILE_CHANGES');
-      watchChangeHandler('change', path.join(testDir, 'packages/package-2/file-1.ts'));
-      await watchChangeHandler('change', path.join(testDir, 'packages/package-2/some-file.ts'));
+      watchChangeHandler('change', join(testDir, 'packages/package-2/file-1.ts'));
+      await watchChangeHandler('change', join(testDir, 'packages/package-2/some-file.ts'));
 
       expect(calledInPackages()).toEqual(['package-2']);
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(spawn).toHaveBeenLastCalledWith('echo $LERNA_PACKAGE_NAME $LERNA_FILE_CHANGES', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({
           name: 'package-2',
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
-          LERNA_FILE_CHANGES: [path.join(testDir, 'packages/package-2/file-1.ts'), path.join(testDir, 'packages/package-2/some-file.ts')].join(';;'),
+          LERNA_FILE_CHANGES: [join(testDir, 'packages/package-2/file-1.ts'), join(testDir, 'packages/package-2/some-file.ts')].join(';;'),
         }),
         extendEnv: false,
         reject: true,
@@ -326,18 +326,18 @@ describe('Watch Command', () => {
 
     it('should execute watch add callback only on the given scope', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--', 'echo $LERNA_PACKAGE_NAME');
-      await watchAddHandler('add', path.join(testDir, 'packages/package-2/some-file.ts'));
+      await watchAddHandler('add', join(testDir, 'packages/package-2/some-file.ts'));
 
       expect(calledInPackages()).toEqual(['package-2']);
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(spawn).toHaveBeenLastCalledWith('echo $LERNA_PACKAGE_NAME', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({
           name: 'package-2',
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
-          LERNA_FILE_CHANGES: path.join(testDir, 'packages/package-2/some-file.ts'),
+          LERNA_FILE_CHANGES: join(testDir, 'packages/package-2/some-file.ts'),
         }),
         extendEnv: false,
         reject: true,
@@ -347,18 +347,18 @@ describe('Watch Command', () => {
 
     it('should execute watch add callback only the given scope', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--', 'echo $LERNA_PACKAGE_NAME');
-      await watchAddDirHandler('addDir', path.join(testDir, 'packages/package-2/some-folder'));
+      await watchAddDirHandler('addDir', join(testDir, 'packages/package-2/some-folder'));
 
       expect(calledInPackages()).toEqual(['package-2']);
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(spawn).toHaveBeenLastCalledWith('echo $LERNA_PACKAGE_NAME', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({
           name: 'package-2',
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
-          LERNA_FILE_CHANGES: path.join(testDir, 'packages/package-2/some-folder'),
+          LERNA_FILE_CHANGES: join(testDir, 'packages/package-2/some-folder'),
         }),
         extendEnv: false,
         reject: true,
@@ -368,18 +368,18 @@ describe('Watch Command', () => {
 
     it('should execute watch add callback only the given scope', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--', 'echo $LERNA_PACKAGE_NAME');
-      await watchUnlinkHandler('unlink', path.join(testDir, 'packages/package-2/some-file.ts'));
+      await watchUnlinkHandler('unlink', join(testDir, 'packages/package-2/some-file.ts'));
 
       expect(calledInPackages()).toEqual(['package-2']);
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(spawn).toHaveBeenLastCalledWith('echo $LERNA_PACKAGE_NAME', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({
           name: 'package-2',
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
-          LERNA_FILE_CHANGES: path.join(testDir, 'packages/package-2/some-file.ts'),
+          LERNA_FILE_CHANGES: join(testDir, 'packages/package-2/some-file.ts'),
         }),
         extendEnv: false,
         reject: true,
@@ -389,18 +389,18 @@ describe('Watch Command', () => {
 
     it('should execute watch add callback only the given scope', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--', 'echo $LERNA_PACKAGE_NAME');
-      await watchUnlinkDirHandler('unlinkDir', path.join(testDir, 'packages/package-2/some-folder'));
+      await watchUnlinkDirHandler('unlinkDir', join(testDir, 'packages/package-2/some-folder'));
 
       expect(calledInPackages()).toEqual(['package-2']);
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(spawn).toHaveBeenLastCalledWith('echo $LERNA_PACKAGE_NAME', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({
           name: 'package-2',
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
-          LERNA_FILE_CHANGES: path.join(testDir, 'packages/package-2/some-folder'),
+          LERNA_FILE_CHANGES: join(testDir, 'packages/package-2/some-folder'),
         }),
         extendEnv: false,
         reject: true,
@@ -411,24 +411,24 @@ describe('Watch Command', () => {
     it('should execute watch callback only the given scoped package', async () => {
       await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--', 'echo $LERNA_PACKAGE_NAME');
 
-      watchAddHandler('add', path.join(testDir, 'packages/package-1/my-file.ts'));
-      watchAddHandler('add', path.join(testDir, 'packages/package-2/new-file-1.ts'));
-      watchUnlinkHandler('unlink', path.join(testDir, 'packages/package-2/new-file-1.ts'));
-      watchAddDirHandler('addDir', path.join(testDir, 'packages/package-2/new-folder'));
-      watchUnlinkDirHandler('unlinkDir', path.join(testDir, 'packages/package-2/new-folder'));
-      await watchChangeHandler('change', path.join(testDir, 'packages/package-2/some-file.ts'));
+      watchAddHandler('add', join(testDir, 'packages/package-1/my-file.ts'));
+      watchAddHandler('add', join(testDir, 'packages/package-2/new-file-1.ts'));
+      watchUnlinkHandler('unlink', join(testDir, 'packages/package-2/new-file-1.ts'));
+      watchAddDirHandler('addDir', join(testDir, 'packages/package-2/new-folder'));
+      watchUnlinkDirHandler('unlinkDir', join(testDir, 'packages/package-2/new-folder'));
+      await watchChangeHandler('change', join(testDir, 'packages/package-2/some-file.ts'));
 
       expect(calledInPackages()).toEqual(['package-2']);
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(spawn).toHaveBeenCalledWith('echo $LERNA_PACKAGE_NAME', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({ name: 'package-2' }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
           LERNA_FILE_CHANGES: [
-            path.join(testDir, 'packages/package-2/new-file-1.ts'),
-            path.join(testDir, 'packages/package-2/new-folder'),
-            path.join(testDir, 'packages/package-2/some-file.ts'),
+            join(testDir, 'packages/package-2/new-file-1.ts'),
+            join(testDir, 'packages/package-2/new-folder'),
+            join(testDir, 'packages/package-2/some-file.ts'),
           ].join(' '),
         }),
         extendEnv: false,
@@ -441,26 +441,26 @@ describe('Watch Command', () => {
       // prettier-ignore
       await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-{1,2}', '--', 'echo $LERNA_PACKAGE_NAME && Promise.resolve(true)');
 
-      watchAddHandler('add', path.join(testDir, 'packages/package-2/new-file-1.ts'));
-      watchUnlinkHandler('unlink', path.join(testDir, 'packages/package-2/new-file-1.ts'));
-      watchAddDirHandler('addDir', path.join(testDir, 'packages/package-2/new-folder'));
-      watchUnlinkDirHandler('unlinkDir', path.join(testDir, 'packages/package-2/new-folder'));
-      watchChangeHandler('change', path.join(testDir, 'packages/package-2/some-file.ts'));
-      watchChangeHandler('addDir', path.join(testDir, 'packages/package-1/src'));
-      watchChangeHandler('change', path.join(testDir, 'packages/package-1/src/some-file-88.ts'));
-      await watchChangeHandler('change', path.join(testDir, 'packages/package-1/src/file-2.ts'));
+      watchAddHandler('add', join(testDir, 'packages/package-2/new-file-1.ts'));
+      watchUnlinkHandler('unlink', join(testDir, 'packages/package-2/new-file-1.ts'));
+      watchAddDirHandler('addDir', join(testDir, 'packages/package-2/new-folder'));
+      watchUnlinkDirHandler('unlinkDir', join(testDir, 'packages/package-2/new-folder'));
+      watchChangeHandler('change', join(testDir, 'packages/package-2/some-file.ts'));
+      watchChangeHandler('addDir', join(testDir, 'packages/package-1/src'));
+      watchChangeHandler('change', join(testDir, 'packages/package-1/src/some-file-88.ts'));
+      await watchChangeHandler('change', join(testDir, 'packages/package-1/src/file-2.ts'));
 
       expect(calledInPackages()).toEqual(['package-2', 'package-1']);
       expect(spawn).toHaveBeenCalledTimes(2);
       expect(spawn).toHaveBeenCalledWith('echo $LERNA_PACKAGE_NAME && Promise.resolve(true)', [], {
-        cwd: path.join(testDir, 'packages/package-2'),
+        cwd: join(testDir, 'packages/package-2'),
         pkg: expect.objectContaining({ name: 'package-2' }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-2',
           LERNA_FILE_CHANGES: [
-            path.join(testDir, 'packages/package-2/new-file-1.ts'),
-            path.join(testDir, 'packages/package-2/new-folder'),
-            path.join(testDir, 'packages/package-2/some-file.ts'),
+            join(testDir, 'packages/package-2/new-file-1.ts'),
+            join(testDir, 'packages/package-2/new-folder'),
+            join(testDir, 'packages/package-2/some-file.ts'),
           ].join(' '),
         }),
         extendEnv: false,
@@ -468,14 +468,14 @@ describe('Watch Command', () => {
         shell: true,
       });
       expect(spawn).toHaveBeenCalledWith('echo $LERNA_PACKAGE_NAME && Promise.resolve(true)', [], {
-        cwd: path.join(testDir, 'packages/package-1'),
+        cwd: join(testDir, 'packages/package-1'),
         pkg: expect.objectContaining({ name: 'package-1' }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: 'package-1',
           LERNA_FILE_CHANGES: [
-            path.join(testDir, 'packages/package-1/src'),
-            path.join(testDir, 'packages/package-1/src/some-file-88.ts'),
-            path.join(testDir, 'packages/package-1/src/file-2.ts'),
+            join(testDir, 'packages/package-1/src'),
+            join(testDir, 'packages/package-1/src/some-file-88.ts'),
+            join(testDir, 'packages/package-1/src/file-2.ts'),
           ].join(' '),
         }),
         extendEnv: false,
@@ -490,7 +490,7 @@ describe('Watch Command', () => {
       try {
         // prettier-ignore
         await lernaWatch(testDir)('--debounce', '0', '--scope', 'package-2', '--', 'echo $LERNA_PACKAGE_NAME');
-        const promise = watchAddHandler('add', path.join(testDir, 'packages/package-2/some-file.ts'));
+        const promise = watchAddHandler('add', join(testDir, 'packages/package-2/some-file.ts'));
         stdin.send('x');
         stdin.end();
         await promise;

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -10,7 +10,7 @@ import {
 } from '@lerna-lite/core';
 import { FilterOptions, getFilteredPackages } from '@lerna-lite/filter-packages';
 import chokidar from 'chokidar';
-import path from 'path';
+import { join } from 'node:path';
 
 import { CHOKIDAR_AVAILABLE_OPTIONS, DEBOUNCE_DELAY, FILE_DELIMITER } from './constants.js';
 import { ChangesStructure } from './models.js';
@@ -92,7 +92,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
         // does user have a glob defined, if so append it to the pkg location. Glob example for TS files: /**/*.ts
         let watchingPath = pkg.location;
         if (this.options.glob) {
-          watchingPath = path.join(pkg.location, '/', this.options.glob); // append glob to pkg location
+          watchingPath = join(pkg.location, '/', this.options.glob); // append glob to pkg location
         }
         packageLocations.push(watchingPath);
       });

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -1,10 +1,10 @@
 import { glob } from 'glob';
-import path from 'path';
+import { join } from 'node:path';
 import { removeSync } from 'fs-extra/esm';
 import tempDir from 'temp-dir';
 import normalizePath from 'normalize-path';
 
-glob(normalizePath(path.join(tempDir, '/lerna-*'))).then((deleteFolders) => {
+glob(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
   // delete silently all files/folders that startsWith "lerna-"
   console.log(`Found ${deleteFolders.length} temp folders to cleanup.`);
   (deleteFolders || []).forEach((folder) => removeSync(folder));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

NodeJS is now telling us to prefer `import:` instead of `default` imports for better ESM support, for example `from 'fs'` should be `from 'node:fs'`. We also use `fs-extra` which is giving us hint to use `fs-extra/esm` for better ESM support. 

## Motivation and Context

Prefer ESM approach as much as possible for the next major release, this is also part of a breaking change since it requires Node 16 and higher
- ref #262

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
