### PR TITLE
chore(version): remove sync lock support for npm version below 8.5.0

### DIFF
--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -732,8 +732,6 @@ This flag will leverage your package manager client to update the project lock f
 
 #### Notes for each client:
 
-> `npm` users: we recommend having npm client version >=8.5.0 installed, so that we can run `npm install --package-lock-only` instead of `npm shrinkwrap` with version < 8.5.0 which would require an extra, and negative, step of renaming the lock file after execution. Also note that npm >=8.5.0 will become the minimal requirement in the future.
-
 > `pnpm`/`yarn` users: we recommend using the [`workspace:` protocol](#workspace-protocol) since it will prefer local dependencies and will make it less likely to fetch packages accidentally from the registry.
 
 > `yarn` users: please note that this will only work with Yarn Berry 3.x and higher since it uses `yarn install --mode update-lockfile` (this will not work with yarn 1.x classic)
@@ -745,10 +743,8 @@ lerna version --sync-workspace-lock
 Depending on the `npmClient` defined, it will perform the following:
 
 ```sh
-# npm is assuming a `package-lock.json` lock file
-# we highly recommend npm client >= 8.5.0
-npm install --package-lock-only     # npm client >= 8.5.0
-npm shrinkwrap --package-lock-only  # npm client < 8.5.0 will execute a file rename of shrinkwrap file behind the scene
+# npm is assuming a `package-lock.json` lock file and npm client >= 8.5.0 is required
+npm install --package-lock-only
 
 # pnpm is assuming a "pnpm-lock.yaml" lock file and "npmClient": "pnpm"
 pnpm install --lockfile-only --ignore-scripts

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -137,16 +137,18 @@ describe('run install lockfile-only', () => {
       expect(lockFileOutput).toBe('package-lock.json');
     });
 
-    it(`should update project root lockfile by calling npm script "npm shrinkwrap --package-lock-only" when npm version is below 8.5.0`, async () => {
+    it(`should display a log error when npm version is below 8.5.0 and not actually sync anything`, async () => {
       (execSync as any).mockReturnValueOnce('8.4.0');
       const cwd = await initFixture('lockfile-version2');
+      const logSpy = vi.spyOn(npmlog, 'error');
 
-      const lockFileOutput = await runInstallLockFileOnly('npm', cwd, []);
+      await runInstallLockFileOnly('npm', cwd, []);
 
       expect(execSync).toHaveBeenCalledWith('npm', ['--version']);
-      expect(exec).toHaveBeenCalledWith('npm', ['shrinkwrap', '--package-lock-only'], { cwd });
-      expect(renameSync).toHaveBeenCalledWith('npm-shrinkwrap.json', 'package-lock.json');
-      expect(lockFileOutput).toBe('package-lock.json');
+      expect(logSpy).toHaveBeenCalledWith(
+        'lock',
+        expect.stringContaining('your npm version is lower than 8.5.0 which is the minimum requirement to use `--sync-workspace-lock`')
+      );
     });
 
     it(`should update project root lockfile by calling npm script "npm install --package-lock-only" with extra npm client arguments when provided`, async () => {

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -7,15 +7,11 @@ vi.mock('@lerna-lite/core', async () => {
     execSync: vi.fn(execSync),
   };
 });
-vi.mock('node:fs', async () => ({
-  ...(await vi.importActual<any>('node:fs')),
-  renameSync: vi.fn(() => true),
-}));
 
 import npmlog from 'npmlog';
 import { Mock } from 'vitest';
 import { pathExistsSync, readJsonSync } from 'fs-extra/esm';
-import { promises as fsPromises, renameSync } from 'node:fs';
+import { promises as fsPromises } from 'node:fs';
 import { dirname as pathDirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Package } from '@lerna-lite/core';

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -1,5 +1,5 @@
 import { loadJsonFile } from 'load-json-file';
-import { renameSync, promises } from 'node:fs';
+import { promises } from 'node:fs';
 import { EOL } from 'node:os';
 import { join } from 'node:path';
 import log from 'npmlog';
@@ -159,8 +159,7 @@ export async function runInstallLockFileOnly(
         const localNpmVersion = execSync('npm', ['--version']);
         log.silly(`npm`, `current local npm version is "${localNpmVersion}"`);
 
-        // for npm version >=8.5.0 we can simply call "npm install --package-lock-only"
-        // however, when lower then we need to call "npm shrinkwrap --package-lock-only" and then rename "npm-shrinkwrap.json" file back to "package-lock.json"
+        // with npm version >=8.5.0, we can simply call "npm install --package-lock-only"
         if (semver.gte(localNpmVersion, '8.5.0')) {
           log.verbose('lock', `updating lock file via "npm install --package-lock-only"`);
           await exec('npm', ['install', '--package-lock-only', ...npmClientArgs], { cwd });

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -165,19 +165,10 @@ export async function runInstallLockFileOnly(
           log.verbose('lock', `updating lock file via "npm install --package-lock-only"`);
           await exec('npm', ['install', '--package-lock-only', ...npmClientArgs], { cwd });
         } else {
-          // TODO: remove this in the next major release
-          // with npm < 8.5.0, we need to update the lock file in 2 steps
-          // 1. using shrinkwrap will delete current lock file and create new "npm-shrinkwrap.json" but will avoid npm retrieving package version info from registry
-          log.verbose('lock', `updating lock file via "npm shrinkwrap --package-lock-only".`);
-          log.warn(
-            `npm`,
-            `Your npm version is lower than 8.5.0, we recommend upgrading your npm client to avoid the use of "npm shrinkwrap" instead of the regular (better) "npm install --package-lock-only".`
+          log.error(
+            'lock',
+            'your npm version is lower than 8.5.0 which is the minimum requirement to use `--sync-workspace-lock`'
           );
-          await exec('npm', ['shrinkwrap', '--package-lock-only', ...npmClientArgs], { cwd });
-
-          // 2. rename "npm-shrinkwrap.json" back to "package-lock.json"
-          log.verbose('lock', `renaming "npm-shrinkwrap.json" file back to "package-lock.json"`);
-          renameSync('npm-shrinkwrap.json', 'package-lock.json');
         }
 
         outputLockfileName = inputLockfileName;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove support for npm version below 8.5.0 for the `--sync-workspace-lock` option, the new release will require NPM to be at least 8.5.0 so we can drop old code

## Motivation and Context

The code implementation of `--sync-workspace-lock` for NPM below 8.5.0 was achieved in 2 steps instead of 1 step with NPM >=8.5.0, we had to 
1. run npm shrinkwrap lock, which created the file `npm-shrinkwrap.json`
2. then rename `npm-shrinkwrap.json` back to `package-lock.json`

but in >=8.5.0 it's achieved in 1 simple step we can simply run `npm install --package-lock-only` without any shrinkwrap

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
