### PR TITLE
feat(publish): remove `--require-scripts`, keep npm scripts lifecycle

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -369,9 +369,6 @@
             "removePackageFields": {
               "$ref": "#/$defs/commandOptions/publish/removePackageFields"
             },
-            "requireScripts": {
-              "$ref": "#/$defs/commandOptions/publish/requireScripts"
-            },
             "noGitReset": {
               "$ref": "#/$defs/commandOptions/publish/noGitReset"
             },
@@ -911,9 +908,6 @@
     "removePackageFields": {
       "$ref": "#/$defs/commandOptions/publish/removePackageFields"
     },
-    "requireScripts": {
-      "$ref": "#/$defs/commandOptions/publish/requireScripts"
-    },
     "noGitReset": {
       "$ref": "#/$defs/commandOptions/publish/noGitReset"
     },
@@ -1216,10 +1210,6 @@
             "type": "string"
           },
           "description": "Remove fields from each package.json before publishing them to the registry, removing fields from a complex object is also supported via the dot notation (ie 'scripts.build')"
-        },
-        "requireScripts": {
-          "type": "boolean",
-          "description": "@deprecated During `lerna publish`, when true, execute ./scripts/prepublish.js and ./scripts/postpublish.js, relative to package root."
         },
         "noGitReset": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-publish-commands.ts
+++ b/packages/cli/src/cli-commands/cli-publish-commands.ts
@@ -109,10 +109,6 @@ export default {
           'Remove fields from each package.json before publishing them to the registry, removing fields from a complex object is also supported via the dot notation (ie "scripts.build").',
         type: 'array',
       },
-      'require-scripts': {
-        describe: 'Execute ./scripts/prepublish.js and ./scripts/postpublish.js, relative to package root.',
-        type: 'boolean',
-      },
       'no-git-reset': {
         describe: 'Do not reset changes to working tree after publishing is complete.',
         type: 'boolean',
@@ -194,9 +190,6 @@ export default {
           log.warn('deprecated', '--npm-tag has been renamed --dist-tag');
         }
 
-        if (argv.requireScripts) {
-          log.warn('deprecated', '--require-scripts has been deprecated and will be removed in next major');
-        }
         /* eslint-enable no-param-reassign */
 
         return argv;

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -338,9 +338,6 @@ export interface PublishCommandOption extends VersionCommandOption {
   /** Remove fields from each package.json before publishing them to the registry, removing fields from a complex object is also supported via the dot notation (ie "scripts.build") */
   removePackageFields?: string[];
 
-  /** @deprecated Execute ./scripts/prepublish.js and ./scripts/postpublish.js, relative to package root. */
-  requireScripts?: boolean;
-
   /** Do not reset changes to working tree after publishing is complete. */
   noGitReset?: boolean;
 

--- a/packages/publish/src/__tests__/publish-lifecycle-scripts.spec.ts
+++ b/packages/publish/src/__tests__/publish-lifecycle-scripts.spec.ts
@@ -42,7 +42,6 @@ import { runLifecycle } from '@lerna-lite/core';
 // helpers
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loggingOutput } from '@lerna-test/helpers/logging-output';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -179,20 +178,5 @@ describe('lifecycle scripts', () => {
         'ignore-scripts': true,
       })
     );
-  });
-});
-
-// @deprecated, execScript should be removed since requireScripts is deprecated
-describe('execScript', () => {
-  it('execute --require-scripts but fails since scripts folder does not exist and log error with script not found message is shown', async () => {
-    const cwd = await initFixture('lifecycle');
-
-    await lernaPublish(cwd)('--require-scripts');
-    const logInfoMessages = loggingOutput('info');
-    const logSillyMessages = loggingOutput('silly');
-
-    expect(logInfoMessages).toContain('enabled');
-    expect(logSillyMessages.filter((x) => x.includes('No prepublish script found at'))).toBeTruthy();
-    expect(logSillyMessages.filter((x) => x.includes('No postpublish script found at'))).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove old deprecated option `--require-scripts`, it was only used by Babel when Lerna was originally created a long time ago, it's so old that it wasn't even documented

## Motivation and Context

The option `--require-scripts` have been deprecated for a very long time and using npm scripts have been the preferred approach for many years already, it also follows this Lerna [PR 1862](https://github.com/lerna/lerna/pull/1862)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
