### PR TITLE
feat(version): remove deprecated `--changelog-version-message` option

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -577,9 +577,6 @@
             "changelogHeaderMessage": {
               "$ref": "#/$defs/commandOptions/version/changelogHeaderMessage"
             },
-            "changelogVersionMessage": {
-              "$ref": "#/$defs/commandOptions/version/changelogVersionMessage"
-            },
             "describeTag": {
               "$ref": "#/$defs/commandOptions/shared/describeTag"
             },
@@ -1297,10 +1294,6 @@
         "changelogIncludeCommitsClientLogin": {
           "anyOf": [{ "type": "string" }, { "type": "boolean" }],
           "description": "During `lerna version`, specify if we want to include the commit remote client login name (ie GitHub username), this option is only available when using --conventional-commits with changelogs. We can also optionally provide a custom message or else a default format will be used."
-        },
-        "changelogVersionMessage": {
-          "type": "string",
-          "description": "During `lerna version`, add a custom message as a prefix to each new version in your \"changelog.md\" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs."
         },
         "changelogPreset": {
           "anyOf": [

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -90,13 +90,6 @@ export default {
         requiresArg: false,
         type: 'string',
       },
-      'changelog-version-message': {
-        describe:
-          'Add a custom message as a prefix to each new version in your "changelog.md" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs.',
-        group: 'Version Command Options:',
-        requiresArg: true,
-        type: 'string',
-      },
       'changelog-preset': {
         describe: 'Custom conventional-changelog preset.',
         type: 'string',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -149,12 +149,6 @@ export interface VersionCommandOption {
    */
   changelogIncludeCommitsClientLogin?: boolean | string;
 
-  /**
-   * Add a custom message as a prefix to each new version in your "changelog.md" which is located in the root of your project.
-   * This option is only available when using `--conventional-commits` with changelogs.
-   */
-  changelogVersionMessage?: string;
-
   /** Defaults 'angular', custom conventional-changelog preset. */
   changelogPreset?: string;
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -81,7 +81,6 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--changelog-include-commits-git-author [msg]`](#--changelog-include-commits-git-author-msg) (new)
     - [`--changelog-include-commits-client-login [msg]`](#--changelog-include-commits-client-login-msg) (new)
     - [`--changelog-header-message <msg>`](#--changelog-header-message-msg) (new)
-    - [`--changelog-version-message <msg>`](#--changelog-version-message-msg) (new)
     - [`--create-release <type>`](#--create-release-type)
     - [`--describe-tag <pattern>`](#--describe-tag-pattern) (new)
     - [`--exact`](#--exact)
@@ -362,18 +361,10 @@ lerna version --conventional-commits --changelog-include-commits-client-login " 
 
 ### `--changelog-header-message <msg>`
 
-Add a custom message at the top of all "changelog.md" files. This option is only available when using `--conventional-commits` and will only impact your project root "changelog.md".
+Add a custom message at the top of all "changelog.md" files. This option is only available when using `--conventional-commits`
 
 ```sh
 lerna version --conventional-commits --changelog-header-message "My Custom Header Message"
-```
-
-### `--changelog-version-message <msg>`
-
-Add a custom message as a prefix to your new version in your "changelog.md" which is located in the root of your project. This option is only available when using `--conventional-commits` and will only impact your project root "changelog.md".
-
-```sh
-lerna version --conventional-commits --changelog-version-message "My Great New Version Message"
 ```
 
 ### `--conventional-bump-prerelease`

--- a/packages/version/src/conventional-commits/update-changelog.ts
+++ b/packages/version/src/conventional-commits/update-changelog.ts
@@ -26,7 +26,6 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
     changelogIncludeCommitsGitAuthor,
     changelogIncludeCommitsClientLogin,
     changelogHeaderMessage = '',
-    changelogVersionMessage = '',
     commitsSinceLastRelease,
     rootPath,
     tagPrefix = 'v',
@@ -95,13 +94,12 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
 
     log.silly(type, 'writing new entry: %j', newEntry);
 
-    const changelogVersion = type === 'root' ? changelogVersionMessage : '';
     const changelogHeader = CHANGELOG_HEADER.replace(
       /%s/g,
       changelogHeaderMessage?.length > 0 ? changelogHeaderMessage + EOL : ''
     );
 
-    const content = [changelogHeader, changelogVersion, newEntry, changelogContents]
+    const content = [changelogHeader, newEntry, changelogContents]
       .join(BLANK_LINE)
       .trim()
       .replace(/[\r\n]{2,}/gm, '\n\n'); // conventional-changelog adds way too many extra line breaks, let's remove a few of them

--- a/packages/version/src/models/index.ts
+++ b/packages/version/src/models/index.ts
@@ -55,7 +55,6 @@ export type RemoteCommit = {
 
 export interface UpdateChangelogOption {
   changelogHeaderMessage?: string;
-  changelogVersionMessage?: string;
   changelogPreset?: string;
   changelogIncludeCommitsGitAuthor?: boolean | string;
   changelogIncludeCommitsClientLogin?: boolean | string;

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -584,13 +584,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
   }
 
   updatePackageVersions() {
-    const {
-      conventionalCommits,
-      changelogPreset,
-      changelogHeaderMessage,
-      changelogVersionMessage,
-      changelog = true,
-    } = this.options;
+    const { conventionalCommits, changelogPreset, changelogHeaderMessage, changelog = true } = this.options;
     const independentVersions = this.project.isIndependent();
     const rootPath = this.project.manifest.location;
     const changedFiles = new Set<string>();
@@ -659,7 +653,6 @@ export class VersionCommand extends Command<VersionCommandOption> {
           changelogIncludeCommitsGitAuthor: this.changelogIncludeCommitsGitAuthor,
           changelogIncludeCommitsClientLogin: this.changelogIncludeCommitsClientLogin,
           changelogHeaderMessage,
-          changelogVersionMessage,
           commitsSinceLastRelease: this.commitsSinceLastRelease,
         }).then(({ logPath, newEntry }) => {
           // commit the updated changelog
@@ -746,7 +739,6 @@ export class VersionCommand extends Command<VersionCommandOption> {
             changelogIncludeCommitsGitAuthor: this.changelogIncludeCommitsGitAuthor,
             changelogIncludeCommitsClientLogin: this.changelogIncludeCommitsClientLogin,
             changelogHeaderMessage,
-            changelogVersionMessage,
             commitsSinceLastRelease: this.commitsSinceLastRelease,
           }).then(({ logPath, newEntry }) => {
             // commit the updated changelog


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove unused and deprecated `--changelog-version-message`

## Motivation and Context

I don't believe anyone used this option, not even me, so there's no reason to keep this option for the next major release

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
