### PR TITLE
chore: change all istanbul ignores to c8 ignores

### DIFF
--- a/packages/core/src/child-process.ts
+++ b/packages/core/src/child-process.ts
@@ -63,7 +63,7 @@ export function spawn(command: string, args: string[], opts?: ExecaOptions & { p
  * @param {import("execa").Options} [opts]
  * @param {string} [prefix]
  */
-// istanbul ignore next
+/* c8 ignore next */
 export function spawnStreaming(
   command: string,
   args: string[],
@@ -112,12 +112,11 @@ export function getExitCode(result: any) {
   }
 
   // https://nodejs.org/docs/latest-v6.x/api/errors.html#errors_error_code
-  // istanbul ignore else
   if (typeof result.code === 'string' || typeof result.exitCode === 'string') {
     return constants.errno[result.code ?? result.exitCode];
   }
 
-  // istanbul ignore next: extremely weird
+  /* c8 ignore next: extremely weird */
   throw new TypeError(`Received unexpected exit code value ${JSON.stringify(result.code ?? result.exitCode)}`);
 }
 

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -123,7 +123,6 @@ export class Command<T extends AvailableCommandOption> {
     });
 
     // passed via yargs context in tests, never actual CLI
-    /* istanbul ignore else */
     if (argv.onResolved || argv.onRejected) {
       runner = runner.then(argv.onResolved, argv.onRejected);
 
@@ -151,7 +150,7 @@ export class Command<T extends AvailableCommandOption> {
     return this.runner?.then(onResolved, onRejected);
   }
 
-  /* istanbul ignore next */
+  /* c8 ignore next 3 */
   catch(onRejected: typeof Promise.reject) {
     return this.runner?.catch(onRejected);
   }
@@ -170,7 +169,7 @@ export class Command<T extends AvailableCommandOption> {
     let loglevel;
     let progress;
 
-    /* istanbul ignore next */
+    /* c8 ignore next 3 */
     if (isCI || !process.stderr.isTTY || process.env.TERM === 'dumb') {
       log.disableColor();
       progress = false;
@@ -247,7 +246,7 @@ export class Command<T extends AvailableCommandOption> {
   }
 
   enableProgressBar() {
-    /* istanbul ignore next */
+    /* c8 ignore next 3 */
     if (this.options.progress !== false) {
       log.enableProgress();
     }

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -28,7 +28,7 @@ function shallowCopy(json: any) {
   return Object.keys(json).reduce((obj, key) => {
     const val: any = json[key];
 
-    /* istanbul ignore if */
+    /* c8 ignore next 2 */
     if (Array.isArray(val)) {
       obj[key] = val.slice();
     } else if (val && typeof val === 'object') {

--- a/packages/core/src/project/lib/make-file-finder.ts
+++ b/packages/core/src/project/lib/make-file-finder.ts
@@ -80,7 +80,6 @@ export function makeSyncFileFinder(rootPath: string, packageConfigs: string[]) {
     // POSIX results always need to be normalized
     results = normalize(results);
 
-    /* istanbul ignore else */
     if (fileMapper) {
       results = results.map(fileMapper);
     }

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -61,7 +61,7 @@ export class Project {
       }
 
       // re-throw other errors, could be ours or third-party
-      // istanbul ignore next
+      /* c8 ignore next */
       throw err;
     }
 
@@ -157,7 +157,7 @@ export class Project {
       });
     } catch (err: any) {
       // redecorate JSON syntax errors, avoid debug dump
-      // istanbul ignore next
+      /* c8 ignore next 3 */
       if (err.name === 'JSONError') {
         throw new ValidationError(err.name, err.message);
       }
@@ -192,7 +192,7 @@ export class Project {
         });
       }
     } catch (err: any) {
-      /* istanbul ignore next */
+      /* c8 ignore next */
       throw new ValidationError(err.name, err.message);
     }
 

--- a/packages/core/src/utils/npm-conf.ts
+++ b/packages/core/src/utils/npm-conf.ts
@@ -27,16 +27,15 @@ function npmConf(opts: any) {
   const projectConf = pathResolve(conf.localPrefix, '.npmrc');
   const userConf = conf.get('userconfig');
 
-  /* istanbul ignore else */
   if (!conf.get('global') && projectConf !== userConf) {
     conf.addFile(projectConf, 'project');
   } else {
+    /* c8 ignore next */
     conf.add({}, 'project');
   }
 
   conf.addFile(conf.get('userconfig'), 'user');
 
-  /* istanbul ignore else */
   if (conf.get('prefix')) {
     const etc = pathResolve(conf.get('prefix'), 'etc');
     conf.root.globalconfig = pathResolve(etc, 'npmrc');
@@ -48,7 +47,7 @@ function npmConf(opts: any) {
 
   const caFile = conf.get('cafile');
 
-  /* istanbul ignore if */
+  /* c8 ignore next 3 */
   if (caFile) {
     conf.loadCAFile(caFile);
   }

--- a/packages/core/src/utils/run-lifecycle.ts
+++ b/packages/core/src/utils/run-lifecycle.ts
@@ -84,7 +84,6 @@ export function runLifecycle(pkg: Package, stage: string, options: LifecycleConf
     }
   }
 
-  /* istanbul ignore else */
   // eslint-disable-next-line no-underscore-dangle
   if (pkg.__isLernaPackage) {
     // To ensure npm-lifecycle creates the correct npm_package_* env vars,

--- a/packages/exec/src/exec-command.ts
+++ b/packages/exec/src/exec-command.ts
@@ -102,7 +102,6 @@ export class ExecCommand extends Command<ExecCommandOption & FilterOptions> {
     } else {
       // detect error (if any) from collected results
       chain = chain.then((results: Array<{ exitCode: number; failed?: boolean; pkg: Package; stderr: any }>) => {
-        /* istanbul ignore else */
         if (results.some((result) => result.failed)) {
           // propagate "highest" error code, it's probably the most useful
           const codes = results.filter((result) => result.failed).map((result) => result.exitCode);

--- a/packages/publish/src/lib/get-packed.ts
+++ b/packages/publish/src/lib/get-packed.ts
@@ -24,7 +24,7 @@ export function getPacked(pkg: Package, tarFilePath: string): Promise<Tarball> {
 
         const p = entry.path;
 
-        /* istanbul ignore if */
+        /* c8 ignore next 5 */
         if (p.startsWith('package/node_modules/')) {
           const name: string = p.match(/^package\/node_modules\/((?:@[^/]+\/)?[^/]+)/)[1];
 

--- a/packages/publish/src/lib/npm-dist-tag.ts
+++ b/packages/publish/src/lib/npm-dist-tag.ts
@@ -24,7 +24,7 @@ export function add(spec: string, tag = '', options: DistTagOptions, otpCache: O
 
   opts.log.verbose('dist-tag', `adding "${cleanTag}" to ${name}@${version}`);
 
-  // istanbul ignore next
+  /* c8 ignore next 3 */
   if (opts.dryRun) {
     opts.log.silly('dist-tag', 'dry-run configured, bailing now');
     return Promise.resolve();
@@ -77,7 +77,7 @@ export function remove(spec: string, tag: string, options: DistTagOptions, otpCa
 
   opts.log.verbose('dist-tag', `removing "${tag}" from ${opts.spec.name}`);
 
-  // istanbul ignore next
+  /* c8 ignore next 3 */
   if (opts.dryRun) {
     opts.log.silly('dist-tag', 'dry-run configured, bailing now');
     return Promise.resolve();
@@ -122,7 +122,7 @@ export function list(spec: string, options: DistTagOptions) {
     spec: npa(spec),
   };
 
-  // istanbul ignore next
+  /* c8 ignore next 3 */
   if (opts.dryRun) {
     opts.log.silly('dist-tag', 'dry-run configured, bailing now');
     return Promise.resolve();

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -578,7 +578,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
       return chain;
     }
 
-    /* istanbul ignore if */
+    /* c8 ignore next 3 */
     if (process.env.LERNA_INTEGRATION) {
       return chain;
     }

--- a/packages/run/src/lib/timer.ts
+++ b/packages/run/src/lib/timer.ts
@@ -1,5 +1,5 @@
 export function timer() {
-  /* istanbul ignore if */
+  /* c8 ignore next 2 */
   if (process.env.LERNA_INTEGRATION) {
     return () => 0;
   }

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -119,7 +119,6 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
     } else {
       // detect error (if any) from collected results
       chain = chain.then((results: Array<{ exitCode: number; failed?: boolean; pkg?: Package; stderr: any }>) => {
-        /* istanbul ignore else */
         if (results?.some((result?: { failed?: boolean }) => result?.failed)) {
           // propagate 'highest' error code, it's probably the most useful
           const codes = results.filter((result) => result?.failed).map((result) => result.exitCode);

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -13,7 +13,7 @@ export function createReleaseClient(type: 'github' | 'gitlab'): GitCreateRelease
       return createGitLabClient();
     case 'github':
       return createGitHubClient();
-    /* istanbul ignore next: guarded by yargs.choices() */
+    /* c8 ignore next: guarded by yargs.choices() */
     default:
       throw new ValidationError('ERELEASE', 'Invalid release client type');
   }
@@ -37,7 +37,7 @@ export function createRelease(
     releaseNotes.map(({ notes, name }) => {
       const tag = name === 'fixed' ? tags[0] : tags.find((t) => t.startsWith(`${name}@`));
 
-      /* istanbul ignore if */
+      /* c8 ignore next 2 */
       if (!tag) {
         return Promise.resolve();
       }

--- a/packages/version/src/utils/otplease.ts
+++ b/packages/version/src/utils/otplease.ts
@@ -20,7 +20,6 @@ const semaphore: any = {
   },
   release() {
     const resolve = this._resolve;
-    // istanbul ignore else
     if (resolve) {
       this._resolve = undefined;
       this._promise = undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Convert all Istanbul ignore comments to c8 ignore comments

## Motivation and Context

Since we migrated from Jest to Vitest, we also also use c8 reporter which is better for ESM code, so we need to review all Istanbul ignore comments and use c8 ignore comments instead

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
