### PR TITLE
feat(version): use await import instead of require() for GHE release

### DIFF
--- a/packages/version/src/__tests__/__snapshots__/version-build-metadata.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-build-metadata.spec.ts.snap
@@ -342,67 +342,6 @@ index SHA..SHA 100644
 +  "version": "1.0.2+21AF26D3--117B344092BD"
 `;
 
-exports[`--build-metadata without prompt > accepts build metadata with cd version 1`] = `
-v2.0.0-alpha.0+exp.sha.SHA
-
-HEAD -> main, tag: v2.0.0-alpha.0+exp.sha.SHA
-
-diff --git a/lerna.json b/lerna.json
-index SHA..SHA 100644
---- a/lerna.json
-+++ b/lerna.json
-@@ -2 +2 @@
--  "version": "1.0.0"
-+  "version": "2.0.0-alpha.0+exp.sha.SHA"
-diff --git a/packages/package-1/package.json b/packages/package-1/package.json
-index SHA..SHA 100644
---- a/packages/package-1/package.json
-+++ b/packages/package-1/package.json
-@@ -3 +3 @@
--  "version": "1.0.0"
-+  "version": "2.0.0-alpha.0+exp.sha.SHA"
-diff --git a/packages/package-2/package.json b/packages/package-2/package.json
-index SHA..SHA 100644
---- a/packages/package-2/package.json
-+++ b/packages/package-2/package.json
-@@ -3 +3 @@
--  "version": "1.0.0",
-+  "version": "2.0.0-alpha.0+exp.sha.SHA",
-@@ -5 +5 @@
--    "package-1": "^1.0.0"
-+    "package-1": "^2.0.0-alpha.0+exp.sha.SHA"
-diff --git a/packages/package-3/package.json b/packages/package-3/package.json
-index SHA..SHA 100644
---- a/packages/package-3/package.json
-+++ b/packages/package-3/package.json
-@@ -3 +3 @@
--  "version": "1.0.0",
-+  "version": "2.0.0-alpha.0+exp.sha.SHA",
-@@ -8 +8 @@
--    "package-2": "^1.0.0"
-+    "package-2": "^2.0.0-alpha.0+exp.sha.SHA"
-diff --git a/packages/package-4/package.json b/packages/package-4/package.json
-index SHA..SHA 100644
---- a/packages/package-4/package.json
-+++ b/packages/package-4/package.json
-@@ -3 +3 @@
--  "version": "1.0.0",
-+  "version": "2.0.0-alpha.0+exp.sha.SHA",
-diff --git a/packages/package-5/package.json b/packages/package-5/package.json
-index SHA..SHA 100644
---- a/packages/package-5/package.json
-+++ b/packages/package-5/package.json
-@@ -4 +4 @@
--    "package-1": "^1.0.0"
-+    "package-1": "^2.0.0-alpha.0+exp.sha.SHA"
-@@ -7 +7 @@
--    "package-3": "^1.0.0"
-+    "package-3": "^2.0.0-alpha.0+exp.sha.SHA"
-@@ -10 +10 @@
--  "version": "1.0.0"
-+  "version": "2.0.0-alpha.0+exp.sha.SHA"
-`;
-
 exports[`--build-metadata without prompt > accepts build metadata with default prerelease id 1`] = `
 v1.0.1-alpha.0+20130313144700
 

--- a/packages/version/src/conventional-commits/get-github-commits.ts
+++ b/packages/version/src/conventional-commits/get-github-commits.ts
@@ -38,7 +38,7 @@ export async function getGithubCommits(
   execOpts?: ExecOpts
 ): Promise<RemoteCommit[]> {
   const repo = parseGitRepo(gitRemote, execOpts);
-  const octokit = createGitHubClient();
+  const octokit = await createGitHubClient();
   const remoteCommits: Array<RemoteCommit> = [];
   let afterCursor = '';
   let hasNextPage = false;

--- a/packages/version/src/git-clients/__tests__/github-client.spec.ts
+++ b/packages/version/src/git-clients/__tests__/github-client.spec.ts
@@ -17,25 +17,25 @@ describe('createGitHubClient', () => {
   it('doesnt error if GH_TOKEN env var is set', () => {
     process.env.GH_TOKEN = 'TOKEN';
 
-    expect(() => {
-      createGitHubClient();
+    expect(async () => {
+      await createGitHubClient();
     }).not.toThrow();
   });
 
-  it('initializes GHE plugin when GHE_VERSION env var is set', () => {
+  it('initializes GHE plugin when GHE_VERSION env var is set', async () => {
     process.env.GH_TOKEN = 'TOKEN';
     process.env.GHE_VERSION = '2.18';
 
-    createGitHubClient();
+    await createGitHubClient();
 
     expect(Octokit.plugin).toHaveBeenCalledWith(expect.anything());
   });
 
-  it('sets octokit `baseUrl` when GHE_API_URL is set', () => {
+  it('sets octokit `baseUrl` when GHE_API_URL is set', async () => {
     process.env.GH_TOKEN = 'TOKEN';
     process.env.GHE_API_URL = 'http://some/host';
 
-    createGitHubClient();
+    await createGitHubClient();
 
     expect(Octokit).toHaveBeenCalledWith({
       auth: 'token TOKEN',

--- a/packages/version/src/git-clients/github-client.ts
+++ b/packages/version/src/git-clients/github-client.ts
@@ -1,11 +1,10 @@
 import { execSync } from '@lerna-lite/core';
 import { Octokit } from '@octokit/rest';
 import { SyncOptions } from 'execa';
-import { createRequire } from 'node:module';
 import parseGitUrl from 'git-url-parse';
 import log from 'npmlog';
 
-export function createGitHubClient() {
+export async function createGitHubClient() {
   log.silly('createGitHubClient', '');
 
   const { GH_TOKEN, GHE_API_URL, GHE_VERSION } = process.env;
@@ -16,9 +15,8 @@ export function createGitHubClient() {
   }
 
   if (GHE_VERSION) {
-    // TODO: probably need to replace with await impot() since createRequire() didn't seem to work when tried in conventional-commits dynamic preset imports
-    const require = createRequire(import.meta.url);
-    Octokit.plugin(require(`@octokit/plugin-enterprise-rest/ghe-${GHE_VERSION}`));
+    const plugin = await import(`@octokit/plugin-enterprise-rest/ghe-${GHE_VERSION}`);
+    Octokit.plugin(plugin);
   }
 
   if (GHE_API_URL) {

--- a/packages/version/src/git-clients/gitlab-client.ts
+++ b/packages/version/src/git-clients/gitlab-client.ts
@@ -1,12 +1,13 @@
 import log from 'npmlog';
 
 import { GitLabClient } from './GitLabClient.js';
+import { GitCreateReleaseClientOutput } from '../models/index.js';
 
-function OcktokitAdapter(client) {
+function OcktokitAdapter(client): GitCreateReleaseClientOutput {
   return { repos: { createRelease: client.createRelease.bind(client) } };
 }
 
-function createGitLabClient() {
+export function createGitLabClient() {
   const { GL_API_URL, GL_TOKEN } = process.env;
 
   log.silly('Creating a GitLab client...', '');
@@ -19,5 +20,3 @@ function createGitLabClient() {
 
   return OcktokitAdapter(client);
 }
-
-export { createGitLabClient };

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -5,14 +5,14 @@ import newGithubReleaseUrl from 'new-github-release-url';
 import semver from 'semver';
 
 import { createGitHubClient, createGitLabClient, parseGitRepo } from '../git-clients/index.js';
-import { GitCreateReleaseClientOutput, ReleaseClient, ReleaseCommandProps, ReleaseOptions } from '../models/index.js';
+import { GitCreateReleaseClientOutput, ReleaseCommandProps, ReleaseOptions } from '../models/index.js';
 
-export function createReleaseClient(type: 'github' | 'gitlab'): GitCreateReleaseClientOutput {
+export async function createReleaseClient(type: 'github' | 'gitlab'): Promise<GitCreateReleaseClientOutput> {
   switch (type) {
     case 'gitlab':
       return createGitLabClient();
     case 'github':
-      return createGitHubClient();
+      return await createGitHubClient();
     /* c8 ignore next: guarded by yargs.choices() */
     default:
       throw new ValidationError('ERELEASE', 'Invalid release client type');
@@ -25,7 +25,7 @@ export function createReleaseClient(type: 'github' | 'gitlab'): GitCreateRelease
  * @param {{ gitRemote: string; execOpts: import('@lerna/child-process').ExecOpts }} opts
  */
 export function createRelease(
-  client: ReleaseClient,
+  client: GitCreateReleaseClientOutput,
   { tags, releaseNotes }: ReleaseCommandProps,
   { gitRemote, execOpts }: ReleaseOptions,
   dryRun = false

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -45,7 +45,7 @@ import {
   runInstallLockFileOnly,
   saveUpdatedLockJsonFile,
 } from './lib/update-lockfile-version.js';
-import { ReleaseClient, ReleaseNote, RemoteCommit } from './models/index.js';
+import { GitCreateReleaseClientOutput, ReleaseNote, RemoteCommit } from './models/index.js';
 import {
   applyBuildMetadata,
   getCommitsSinceLastRelease,
@@ -73,7 +73,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
   commitAndTag = true;
   pushToRemote = true;
   hasRootedLeaf = false;
-  releaseClient?: ReleaseClient;
+  releaseClient?: GitCreateReleaseClientOutput;
   releaseNotes: ReleaseNote[] = [];
   gitOpts: any;
   runPackageLifecycle: any;
@@ -101,7 +101,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
     super(argv);
   }
 
-  configureProperties() {
+  async configureProperties() {
     super.configureProperties();
 
     // Defaults are necessary here because yargs defaults
@@ -131,12 +131,9 @@ export class VersionCommand extends Command<VersionCommandOption> {
     this.changelogIncludeCommitsGitAuthor = changelogIncludeCommitsGitAuthor === '' ? true : changelogIncludeCommitsGitAuthor;
     // never automatically push to remote when amending a commit
 
-    // prettier-ignore
-    this.releaseClient = (
-      this.pushToRemote &&
-      this.options.createRelease &&
-      createReleaseClient(this.options.createRelease)
-    ) as ReleaseClient | undefined;
+    if (this.pushToRemote && this.options.createRelease) {
+      this.releaseClient = await createReleaseClient(this.options.createRelease);
+    }
     this.releaseNotes = [];
 
     if (this.releaseClient && this.options.conventionalCommits !== true) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use `await import()` instead of `require()` to be fully ESM compatible

## Motivation and Context

I tried `createRequire` but that caused issue when I tried it under the conventional commits changelog creation, so I assume it might also give problems when creating GitHub Release with GHE which was loading Oktokit GHE plugin dynamic imports. Using `await import()` is more bullet proof for ESM  

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
