### PR TITLE
feat(version): add `--skip-bump-only-release` to avoid empty gh releases

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -655,6 +655,9 @@
             "forceGitTag": {
               "$ref": "#/$defs/commandOptions/version/forceGitTag"
             },
+            "skipBumpOnlyRelease": {
+              "$ref": "#/$defs/commandOptions/version/skipBumpOnlyRelease"
+            },
             "syncWorkspaceLock": {
               "$ref": "#/$defs/commandOptions/version/syncWorkspaceLock"
             },
@@ -1372,6 +1375,10 @@
         "forceGitTag": {
           "type": "boolean",
           "description": "During `lerna version`, when true, pass the `--force` flag to `git tag`."
+        },
+        "skipBumpOnlyRelease": {
+          "type": "boolean",
+          "description": "Skip GitHub/GitLab release creation when the version is a \"Version bump only for package x\""
         },
         "syncWorkspaceLock": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -250,6 +250,10 @@ export default {
         describe: 'Runs `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient`.',
         type: 'boolean',
       },
+      'skip-bump-only-release': {
+        describe: 'do we want to skip creating a release (github/gitlab) when the version is a "version bump only"?',
+        type: 'boolean',
+      },
       'workspace-strict-match': {
         describe:
           'Strict match transform version numbers to an exact range (like "1.2.3") rather than with a caret (like ^1.2.3) when using `workspace:*`.',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -292,6 +292,9 @@ export interface VersionCommandOption {
   /** Additional arguments to pass to the npm client when performing 'npm install'. */
   npmClientArgs?: string[];
 
+  /** Defaults to false, should we skip GitHub/GitLab release creation when the version is a "Version bump only for package x" */
+  skipBumpOnlyRelease?: boolean;
+
   /** Runs `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient`. */
   syncWorkspaceLock?: boolean;
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -81,6 +81,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--changelog-include-commits-client-login [msg]`](#--changelog-include-commits-client-login-msg)
     - [`--changelog-header-message <msg>`](#--changelog-header-message-msg)
     - [`--create-release <type>`](#--create-release-type)
+    - [`--skip-bump-only-release`](#--skip-bump-only-release)
     - [`--describe-tag <pattern>`](#--describe-tag-pattern)
     - [`--exact`](#--exact)
     - [`--independent-subpackages`](#--independent-subpackages)
@@ -385,6 +386,19 @@ lerna version --conventional-commits --create-release gitlab
 ```
 
 When run with this flag, `lerna version` will create an official GitHub or GitLab release based on the changed packages. Requires `--conventional-commits` to be passed so that changelogs can be generated.
+
+> **Note** to avoid creating too many "Version bump only for package x" when using independent mode, you could enable the option `--skip-bump-only-release`
+
+### `--skip-bump-only-release`
+
+When this option is enabled and a package version is only being bumped without any conventional commits detected, the GitHub/GitLab release will be skipped. This will avoid creating releases with only "Version bump only for package x" in the release notes, however please note that each changelog will still be updated the version bump only text.
+
+```sh
+lerna version --create-release github --skip-bump-only-release
+
+# or the same for gitlab
+lerna version --create-release gitlab --skip-bump-only-release
+```
 
 ### `--describe-tag <pattern>`
 When `lerna version` is executed, it will identifies packages that have been updated since the previous tagged release. The rules it identifies are based on describe tag pattern (excuted `git describe --match` behind the scenes).

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -391,7 +391,7 @@ When run with this flag, `lerna version` will create an official GitHub or GitLa
 
 ### `--skip-bump-only-release`
 
-When this option is enabled and a package version is only being bumped without any conventional commits detected, the GitHub/GitLab release will be skipped. This will avoid creating releases with only "Version bump only for package x" in the release notes, however please note that each changelog will still be updated the version bump only text.
+When this option is enabled and a package version is only being bumped without any conventional commits detected, the GitHub/GitLab release will be skipped. This will avoid creating releases with only "Version bump only for package x" in the release notes, however please note that each changelog are still going to be updated with the "version bump only" text.
 
 ```sh
 lerna version --create-release github --skip-bump-only-release

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -27,7 +27,7 @@ export async function createReleaseClient(type: 'github' | 'gitlab'): Promise<Gi
 export function createRelease(
   client: GitCreateReleaseClientOutput,
   { tags, releaseNotes }: ReleaseCommandProps,
-  { gitRemote, execOpts }: ReleaseOptions,
+  { gitRemote, execOpts, skipBumpOnlyRelease }: ReleaseOptions,
   dryRun = false
 ) {
   const { GH_TOKEN } = process.env;
@@ -37,8 +37,9 @@ export function createRelease(
     releaseNotes.map(({ notes, name }) => {
       const tag = name === 'fixed' ? tags[0] : tags.find((t) => t.startsWith(`${name}@`));
 
-      /* c8 ignore next 2 */
-      if (!tag) {
+      // when using independent mode, it could happen that a few version bump only releases are created
+      // and since these aren't very useful for most users, user could choose to skip creating these releases when detecting a version bump only
+      if (!tag || (skipBumpOnlyRelease && notes?.includes('**Note:** Version bump only for package'))) {
         return Promise.resolve();
       }
 

--- a/packages/version/src/models/index.ts
+++ b/packages/version/src/models/index.ts
@@ -108,4 +108,5 @@ export interface ReleaseCommandProps {
 export interface ReleaseOptions {
   gitRemote: string;
   execOpts: ExecOpts;
+  skipBumpOnlyRelease?: boolean;
 }

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -363,7 +363,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       await createRelease(
         this.releaseClient,
         { tags: this.tags, releaseNotes: this.releaseNotes },
-        { gitRemote: this.options.gitRemote, execOpts: this.execOpts },
+        { gitRemote: this.options.gitRemote, execOpts: this.execOpts, skipBumpOnlyRelease: this.options.skipBumpOnlyRelease },
         this.options.dryRun
       );
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using `independent` mode, a GitHub/GitLab release is created for each package and very often some of the package will only have a `"Version bump only for package x"` added to the changelog and a release is created even for these simple bump only package. However these kind of release are not very useful and could be skipped, this is what this option flag will provide to the user when the package is detected to be a version bump only, with this flag enabled, it will not create a release for that package

**Note** this will be available only under the new `major` v2.0.0 version and higher of Lerna-Lite

## Motivation and Context

Avoid creating too many releases with info that are not that useful, most users are interested in "what changed?" and not so much in "nothing changed in package x"

## How Has This Been Tested?

unit tests only

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
