### PR TITLE
fix: cannot find `publish` module if `cli` inside a monorepo package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,6 +62,14 @@
     "npmlog": "^7.0.1",
     "yargs": "^17.7.1"
   },
+  "peerDependencies": {
+    "@lerna-lite/publish": "2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@lerna-lite/publish": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "yargs-parser": "^21.1.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@lerna-lite/init':
         specifier: workspace:*
         version: link:../init
+      '@lerna-lite/publish':
+        specifier: 2.0.0
+        version: link:../publish
       dedent:
         specifier: ^0.7.0
         version: 0.7.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes `Cannot find package '@lerna-lite/publish' imported from ...` error for monorepo projects.

## Motivation and Context

## How Has This Been Tested?

- Clone https://github.com/volarjs/workspace
- Run `$ pnpm i && npm run setup:vue`
- Run `$ cd volar && npm run release`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
