### PR TITLE
feat(publish): add name of package that fails to publish

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,0 @@
-import 'vitest/globals';

--- a/helpers/logging-output.ts
+++ b/helpers/logging-output.ts
@@ -1,4 +1,5 @@
 import log from 'npmlog';
+import { afterEach } from 'vitest';
 
 import { multiLineTrimRight } from './index.js';
 

--- a/packages/publish/src/__tests__/publish-from-git.spec.ts
+++ b/packages/publish/src/__tests__/publish-from-git.spec.ts
@@ -242,6 +242,8 @@ describe('publish from-git', () => {
 
     await expect(command).rejects.toEqual({ code: 'UNAUTHORIZED', name: 'ValidationError' });
     expect(process.exitCode).toBe(1);
+    const logMessages = loggingOutput('notice');
+    expect(logMessages).toContain('Package failed to publish: package-1');
 
     // reset exit code
     process.exitCode = undefined;

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -904,6 +904,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
                 }
 
                 this.logger.silly('', err);
+                this.logger.warn('notice', `Package failed to publish: ${pkg.name}`);
                 this.logger.error(err.code, (err.body && err.body.error) || err.message);
 
                 // avoid dumping logs, this isn't a lerna problem


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna PR 3644

> Add a warning log entry when `lerna publish` fails that includes the package name.

## Motivation and Context

As per Lerna PR 

> Sometimes there error returned from the registry doesn't include the package name. For instance `ERR! E402 You must sign up for private packages`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
