### PR TITLE
fix(version): `--dry-run` opt should only accept valid bool, fixes #569

### DIFF
--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -81,7 +81,13 @@ export default {
       'dry-run': {
         describe: 'Displays the process command that would be performed without executing it.',
         group: 'Version Command Options:',
-        type: 'boolean',
+        coerce: (val: boolean | string) => {
+          // make sure user isn't providing anything else but a boolean or a parseable string as boolean (ie "true")
+          if (typeof val === 'string' && !/(true|false)/i.test(val)) {
+            throw new Error(`--dry-run option must be of type boolean and you provided: ${val}`);
+          }
+          return Boolean(val);
+        },
       },
       exact: {
         describe: 'Specify cross-dependency version numbers exactly rather than with a caret (^).',

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -1009,4 +1009,20 @@ describe('VersionCommand', () => {
       expect((collectUpdates as Mock).mock.calls[0][3].isIndependent).toBe(true);
     });
   });
+
+  describe('CLI arguments', () => {
+    it('throws when --dry-run has a string argument other than "true" or "false"', async () => {
+      const cwd = await initFixture('lifecycle');
+      const command = lernaVersion(cwd)('--no-changelog', '--dry-run', 'premajor');
+
+      await expect(command).rejects.toThrow('--dry-run option must be of type boolean and you provided: premajor');
+    });
+
+    it('does not throw when --dry-run has a string argument "true"', async () => {
+      const cwd = await initFixture('lifecycle');
+      const command = lernaVersion(cwd)('--no-changelog', '--dry-run', 'true');
+
+      await expect(command).resolves;
+    });
+  });
 });

--- a/packages/version/src/__tests__/version-conventional-commits.spec.ts
+++ b/packages/version/src/__tests__/version-conventional-commits.spec.ts
@@ -172,6 +172,15 @@ describe('--conventional-commits', () => {
       });
     });
 
+    it('throws when --conventional-prerelease is used with an argument that returns nothing to prerelease', async () => {
+      prereleaseVersionBumps.forEach((bump) => (recommendVersion as Mock).mockResolvedValueOnce(bump));
+      const cwd = await initFixture('prerelease-independent');
+
+      const command = new VersionCommand(createArgv(cwd, '--conventional-commits', '--conventional-prerelease', 'premajor'));
+
+      await expect(command).rejects.toThrow('No packages found to prerelease when using "--conventional-prerelease premajor".');
+    });
+
     it('accepts --changelog-preset option', async () => {
       const cwd = await initFixture('independent');
       const changelogOpts = {

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -477,7 +477,16 @@ export class VersionCommand extends Command<VersionCommandOption> {
       ? () => true
       : (_node, name) => prereleasePackageNames.has(name);
 
-    return collectPackages(this.packageGraph, { isCandidate }).map((pkg) => pkg?.name ?? '');
+    const prePkgs = collectPackages(this.packageGraph, { isCandidate }).map((pkg) => pkg?.name ?? '');
+
+    if (typeof this.options.conventionalPrerelease === 'string' && prePkgs.length === 0) {
+      throw new ValidationError(
+        'ENOPRERELEASE',
+        `No packages found to prerelease when using "--conventional-prerelease ${this.options.conventionalPrerelease}".`
+      );
+    }
+
+    return prePkgs;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

in some cases the `--dry-run` could be misused and provide unexpected results, also `--conventional-prerelease` should throw when provided an invalid argument that returns no packages

## Motivation and Context

2 problems were brought up in issue #569

1. an extra string argument following `--dry-run` (ie: `--dry-run premajor`) was interpreted as being an argument to the dry-run option and then parsed as `true` when in fact that string argument ("premajor") wasn't valid and wasn't expected to the dry-run option and we should throw an error when that happens. The parsing of the string and converted to `true` was because when we provide `type: 'boolean'` to yargs CLI, it will parse it in this similar fashion `Boolean('premajor')` and this returns `true` even thought that is not what we wanted, we could use yargs `coerce` function to throw when it's now a valid boolean

2. `--conventional-prerelease` should probably throw when an argument is provided which returns no packages to prerelease (that is if I understood the docs correctly), for example `--conventional-prerelease premajor` returns to packages to prerelease.

## How Has This Been Tested?

added unit tests and validated by running VSCode debugger in Vitest

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
