### PR TITLE
fix(version): invalid --conventional-prerelease should throw, fix #569

### DIFF
--- a/packages/version/src/__tests__/version-conventional-commits.spec.ts
+++ b/packages/version/src/__tests__/version-conventional-commits.spec.ts
@@ -172,6 +172,15 @@ describe('--conventional-commits', () => {
       });
     });
 
+    it('throws when --conventional-prerelease is used with an argument that returns nothing to prerelease', async () => {
+      prereleaseVersionBumps.forEach((bump) => (recommendVersion as Mock).mockResolvedValueOnce(bump));
+      const cwd = await initFixture('prerelease-independent');
+
+      const command = new VersionCommand(createArgv(cwd, '--conventional-commits', '--conventional-prerelease', 'premajor'));
+
+      await expect(command).rejects.toThrow('No packages found to prerelease when using "--conventional-prerelease premajor".');
+    });
+
     it('accepts --changelog-preset option', async () => {
       const cwd = await initFixture('independent');
       const changelogOpts = {

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -479,7 +479,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
 
     const prePkgs = collectPackages(this.packageGraph, { isCandidate }).map((pkg) => pkg?.name ?? '');
 
-    if (typeof this.options.conventionalPrerelease === 'string' && prePkgs.length === 0) {
+    if (typeof this.options.conventionalPrerelease !== 'boolean' && prePkgs.length === 0) {
       throw new ValidationError(
         'ENOPRERELEASE',
         `No packages found to prerelease when using "--conventional-prerelease ${this.options.conventionalPrerelease}".`

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -477,7 +477,16 @@ export class VersionCommand extends Command<VersionCommandOption> {
       ? () => true
       : (_node, name) => prereleasePackageNames.has(name);
 
-    return collectPackages(this.packageGraph, { isCandidate }).map((pkg) => pkg?.name ?? '');
+    const prePkgs = collectPackages(this.packageGraph, { isCandidate }).map((pkg) => pkg?.name ?? '');
+
+    if (typeof this.options.conventionalPrerelease === 'string' && prePkgs.length === 0) {
+      throw new ValidationError(
+        'ENOPRERELEASE',
+        `No packages found to prerelease when using "--conventional-prerelease ${this.options.conventionalPrerelease}".`
+      );
+    }
+
+    return prePkgs;
   }
 
   /**

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -479,7 +479,11 @@ export class VersionCommand extends Command<VersionCommandOption> {
 
     const prePkgs = collectPackages(this.packageGraph, { isCandidate }).map((pkg) => pkg?.name ?? '');
 
-    if (typeof this.options.conventionalPrerelease !== 'boolean' && prePkgs.length === 0) {
+    if (
+      this.options.conventionalPrerelease !== undefined &&
+      typeof this.options.conventionalPrerelease !== 'boolean' &&
+      prePkgs.length === 0
+    ) {
       throw new ValidationError(
         'ENOPRERELEASE',
         `No packages found to prerelease when using "--conventional-prerelease ${this.options.conventionalPrerelease}".`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The issue #569 brought up a problem where dry-run option was used to test a release (ie `--conventional-prerelease --dry-run premajor`) but when dry-run was removed it caused an unexpected result (ie `--conventional-prerelease premajor`) the latter changed the result because `premajor` was then passed to `--conventional-prerelease` which was the case with `--dry-run` in place

## Motivation and Context

`--conventional-prerelease` should probably throw when an argument is provided which didn't find any packages to prerelease (that is if I understood the docs correctly), for example `--conventional-prerelease premajor` is incorrect because that is not the name of a package but providing  `--conventional-prerelease *` should work because that is equal to all packages . It should also throw if we provide something different than a boolean, for example a number  `--conventional-prerelease 22` is an error 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
