### PR TITLE
fix: cannot find optional commands if `cli` inside a monorepo package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,15 +62,35 @@
     "npmlog": "^7.0.1",
     "yargs": "^17.7.1"
   },
-  "peerDependencies": {
-    "@lerna-lite/publish": "2.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@lerna-lite/publish": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "yargs-parser": "^21.1.1"
+  },
+  "peerDependencies": {
+    "@lerna-lite/exec": "2.x",
+    "@lerna-lite/list": "2.x",
+    "@lerna-lite/publish": "2.x",
+    "@lerna-lite/run": "2.x",
+    "@lerna-lite/version": "2.x",
+    "@lerna-lite/watch": "2.x"
+  },
+  "peerDependenciesMeta": {
+    "@lerna-lite/exec": {
+      "optional": true
+    },
+    "@lerna-lite/list": {
+      "optional": true
+    },
+    "@lerna-lite/publish": {
+      "optional": true
+    },
+    "@lerna-lite/run": {
+      "optional": true
+    },
+    "@lerna-lite/version": {
+      "optional": true
+    },
+    "@lerna-lite/watch": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,12 +185,27 @@ importers:
       '@lerna-lite/core':
         specifier: workspace:*
         version: link:../core
+      '@lerna-lite/exec':
+        specifier: 2.x
+        version: link:../exec
       '@lerna-lite/init':
         specifier: workspace:*
         version: link:../init
+      '@lerna-lite/list':
+        specifier: 2.x
+        version: link:../list
       '@lerna-lite/publish':
-        specifier: 2.0.0
+        specifier: 2.x
         version: link:../publish
+      '@lerna-lite/run':
+        specifier: 2.x
+        version: link:../run
+      '@lerna-lite/version':
+        specifier: 2.x
+        version: link:../version
+      '@lerna-lite/watch':
+        specifier: 2.x
+        version: link:../watch
       dedent:
         specifier: ^0.7.0
         version: 0.7.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spreading the previous PR #573 to all command to fix the same problem but for all commands when installed as `optionalDependencies` inside a monorepo that contains a monorepo

## Motivation and Context

As per PR #573, this fixes `Cannot find package '@lerna-lite/publish' imported from ...` error for monorepo projects when any of the commands are installed as `optionalDependencies` (like [Volar](https://github.com/vuejs/language-tools) does)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
