### PR TITLE
fix(publish): add normalize-path as a dependency

### DIFF
--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -61,6 +61,7 @@
     "has-unicode": "^2.0.1",
     "libnpmaccess": "^7.0.2",
     "libnpmpublish": "^7.1.3",
+    "normalize-path": "^3.0.0",
     "npm-package-arg": "^10.1.0",
     "npm-packlist": "^7.0.4",
     "npm-registry-fetch": "^14.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,9 @@ importers:
       libnpmpublish:
         specifier: ^7.1.3
         version: 7.1.3
+      normalize-path:
+        specifier: ^3.0.0
+        version: 3.0.0
       npm-package-arg:
         specifier: ^10.1.0
         version: 10.1.0


### PR DESCRIPTION

## Description

`normalize-path` should be a dependency of the `@lerna-lite/publish` package, otherwise it throws errors while running on CI.

## Motivation and Context

While running a workflow on GitHub Actions, one of my packages wasn't published because the package `normalize-path` was missing. Installing it as a dependency of my repository worked, but as it is a dependency of `@lerna-lite/publish` it should be installed in the package itself instead.

![image](https://user-images.githubusercontent.com/19496473/233069441-7694150d-575c-4350-921c-4b42c57898da.png)

## How Has This Been Tested?

No testing needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
