### PR TITLE
chore: execute CI workflow against Node20 instead of Node19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 19
+          node-version: 20
           cache: 'pnpm'
 
       - name: Get pnpm store directory
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 19]
+        node: [16, 18, 20]
         platform: [ubuntu-latest]
 
     name: 'Build & Unit Tests on Ubuntu / Node${{ matrix.node }}'
@@ -120,5 +120,5 @@ jobs:
       - name: Upload test coverage to Codecov
         uses: codecov/codecov-action@v3.1.2
         if: |
-          contains(matrix.node, 19) &&
+          contains(matrix.node, 20) &&
           !contains(github.event.head_commit.message, 'chore(release)')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Node 19 will be a short live while Node 20 will enter LTS in October of this year 2023

## Motivation and Context

Run CI workflow against latest NodeJS version

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
