### PR TITLE
fix(version): allowPeerDependenciesUpdate should work w/`workspace:^`, fix #590

### DIFF
--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -774,7 +774,7 @@ describe('Package', () => {
             b: 'workspace:~1.0.0',
           },
           peerDependencies: {
-            a: '>=1.0.0', // range will not be bumped
+            a: 'workspace:^',
             b: 'workspace:~1.0.0', // will be bumped
           },
         });
@@ -794,7 +794,7 @@ describe('Package', () => {
               b: ~1.1.0,
             },
             peerDependencies: {
-              a: >=1.0.0,
+              a: ^2.0.0,
               b: ~1.1.0,
             },
           }

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -311,7 +311,7 @@ export class Package {
       // when user allows peer bump and is a regular semver version, we'll push it to the array of dependencies to potentially bump
       // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but the following would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
       // prettier-ignore
-      if (allowPeerDependenciesUpdate && /^(workspace:)?[~^]?[\d\.]*([\-]+[\w\.\-\+]+)*$/i.test(this.peerDependencies[depName] || '')) {
+      if (allowPeerDependenciesUpdate && /^(workspace:)?[~^*]?[\d\.]*([\-]+[\w\.\-\+]+)*$/i.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);
       }
       // when peer bump is disabled, we could end up with peerDependencies not being reviewed

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -309,7 +309,7 @@ export class Package {
     // when we have peer dependencies, we might need to perform certain actions
     if (this.peerDependencies?.[depName]) {
       // when user allows peer bump and is a regular semver version, we'll push it to the array of dependencies to potentially bump
-      // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but the following would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
+      // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but the following would not (">=2.0.0", "14 || 15" or "workspace:<2.0.0")
       // prettier-ignore
       if (allowPeerDependenciesUpdate && /^(workspace:)?[~^*]?[\d\.]*([\-]+[\w\.\-\+]+)*$/i.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -306,18 +306,24 @@ export class Package {
     const localDependencies = this.retrievePackageDependencies(depName);
     const updatingDependencies = [localDependencies];
 
-    // when we have peer dependencies, we might need to perform certain things
+    // when we have peer dependencies, we might need to perform certain actions
     if (this.peerDependencies?.[depName]) {
       // when user allows peer bump and is a regular semver version, we'll push it to the array of dependencies to potentially bump
-      // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but these would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
+      // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but the following would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
       // prettier-ignore
-      if (allowPeerDependenciesUpdate && /^(workspace:)?[~^]?[\d\.]+([\-]+[\w\.\-\+]+)*$/i.test(this.peerDependencies[depName] || '')) {
+      if (allowPeerDependenciesUpdate && /^(workspace:)?[~^]?[\d\.]*([\-]+[\w\.\-\+]+)*$/i.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);
       }
       // when peer bump is disabled, we could end up with peerDependencies not being reviewed
       // and some might still have the `workspace:` prefix so make sure to remove any of these prefixes
       else if (updatedByCommand === 'publish' && this.peerDependencies[depName].startsWith('workspace:')) {
         this.peerDependencies[depName] = this.peerDependencies[depName].replace('workspace:', '');
+
+        // when it's only 1 char left "^" or "~", we'll assume that the version is invalid (note that "*" is valid)
+        // so reassigning the resolved package version seems like the best action to do in this case
+        if (/^[~^]$/.test(this.peerDependencies[depName])) {
+          this.peerDependencies[depName] = resolved.fetchSpec || '';
+        }
       }
     }
 

--- a/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-2/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-2/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "dependencies": {
     "package-1": "workspace:*"
+  },
+  "peerDependencies": {
+    "package-1": "workspace:*"
   }
 }

--- a/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-3/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-3/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "dependencies": {
     "package-2": "workspace:^"
+  },
+  "peerDependencies": {
+    "package-2": "workspace:^"
   }
 }

--- a/packages/publish/src/__tests__/publish-licenses.spec.ts
+++ b/packages/publish/src/__tests__/publish-licenses.spec.ts
@@ -105,7 +105,7 @@ describe('licenses', () => {
   it('warns when packages need a license and the root license file is missing', async () => {
     const cwd = await initFixture('licenses-missing');
 
-    await lernaPublish(cwd)('--no-manually-update-root-lockfile', '--workspace-strict-match');
+    await lernaPublish(cwd)('--no-manually-update-root-lockfile');
 
     const [warning] = loggingOutput('warn');
     expect(warning).toMatchInlineSnapshot(`

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -97,11 +97,15 @@ describe("workspace protocol 'workspace:' specifiers", () => {
       expect((writePkg as any).updatedManifest('package-2').dependencies).toMatchObject({
         'package-1': '1.1.0', // workspace:*
       });
+      expect((writePkg as any).updatedManifest('package-2').peerDependencies).toMatchObject({
+        // peer deps should be bumped to a fixed minor version
+        'package-1': '1.1.0', // workspace:^
+      });
       expect((writePkg as any).updatedManifest('package-3').dependencies).toMatchObject({
         'package-2': '^1.1.0', // workspace:^
       });
       expect((writePkg as any).updatedManifest('package-3').peerDependencies).toMatchObject({
-        // peer deps should be bumped when major
+        // peer deps should be bumped to a minor with ^ spec
         'package-2': '^1.1.0', // workspace:^
       });
       expect((writePkg as any).updatedManifest('package-4').optionalDependencies).toMatchObject({

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -99,7 +99,7 @@ describe("workspace protocol 'workspace:' specifiers", () => {
       });
       expect((writePkg as any).updatedManifest('package-2').peerDependencies).toMatchObject({
         // peer deps should be bumped to a fixed minor version
-        'package-1': '1.1.0', // workspace:^
+        'package-1': '1.1.0', // workspace:*
       });
       expect((writePkg as any).updatedManifest('package-3').dependencies).toMatchObject({
         'package-2': '^1.1.0', // workspace:^

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -100,6 +100,10 @@ describe("workspace protocol 'workspace:' specifiers", () => {
       expect((writePkg as any).updatedManifest('package-3').dependencies).toMatchObject({
         'package-2': '^1.1.0', // workspace:^
       });
+      expect((writePkg as any).updatedManifest('package-3').peerDependencies).toMatchObject({
+        // peer deps should be bumped when major
+        'package-2': '^1.1.0', // workspace:^
+      });
       expect((writePkg as any).updatedManifest('package-4').optionalDependencies).toMatchObject({
         'package-3': '~1.1.0', // workspace:~
       });
@@ -152,6 +156,10 @@ describe("workspace protocol 'workspace:' specifiers", () => {
       });
       expect((writePkg as any).updatedManifest('package-3').dependencies).toMatchObject({
         'package-2': '^2.0.0', // workspace:^
+      });
+      expect((writePkg as any).updatedManifest('package-3').peerDependencies).toMatchObject({
+        // peer deps without the allow peer bump flag will not be bumped
+        'package-2': '^1.0.0', // workspace:^
       });
       expect((writePkg as any).updatedManifest('package-4').optionalDependencies).toMatchObject({
         'package-3': '~2.0.0', // workspace:~

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -169,7 +169,8 @@ By default peer dependencies versions will not be bumped unless this flag is ena
 > > _Until we can get fancier, we should never automatically modify them to match the new version being published (which is the current incorrect behavior)._
 
 #### Examples
-For the example shown below, we will consider the packages to have the following versions (`"A": "1.2.0"`, `"B": "0.4.0"` anc `"C": 2.0.0"`)
+For the example shown below, we will consider the packages to have the following versions (`"A": "1.2.0"`, `"B": "0.4.0"` anc `"C": 2.0.0"`). The examples shown below includes very basic demo of what `workspace:` can do, for more info on that subject please read [`workspace:` protocol](#workspace-protocol).
+
 ##### with flag enabled
 with the new flag both deps would be updated and bumped, for example if we do a `minor` bump
 ```js

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -169,34 +169,39 @@ By default peer dependencies versions will not be bumped unless this flag is ena
 > > _Until we can get fancier, we should never automatically modify them to match the new version being published (which is the current incorrect behavior)._
 
 #### Examples
+For the example shown below, we will consider the packages to have the following versions (`"A": "1.2.0"`, `"B": "0.4.0"` anc `"C": 2.0.0"`)
 ##### with flag enabled
 with the new flag both deps would be updated and bumped, for example if we do a `minor` bump
-```sh
+```js
 {
   "name": "B",
   "dependencies": {
-    "A": "workspace:^1.2.0"   // will update to "workspace:^1.3.0",
-    "B": "^0.4.0":            // will update to "^0.5.0"
+    "A": "workspace:^1.2.0",  // will bump the version to "workspace:^1.3.0" and publish as "^1.3.0"
+    "B": "^0.4.0",            // will bump to "^0.5.0"
+    "C": "workspace:^"        // will bump the version to "workspace:^2.1.0" and publish as "^2.1.0"
    },
   "peerDependencies": {
-    "A": "workspace:^1.2.0"   // will update to "workspace:^1.3.0"
-    "B": ">=0.2.0":           // will not be updateed because range with operator (>=) are skipped
+    "A": "workspace:^1.2.0",  // will update the version to "workspace:^1.3.0" and publish as "^1.3.0"
+    "B": ">=0.2.0",           // will not be updated because range with operator (>=) are skipped
+    "C": "workspace:^"        // will keep the version to "workspace:^" but publish as "^2.1.0"
   }
 }
 ```
 
 ##### without flag
 without the flag it will only update the first package it finds, that is `dependencies` in this case, so peer deps would never be updated
-```sh
+```js
 {
   "name": "B",
   "dependencies": {
-    "A": "workspace:^1.2.0"   // will update to "workspace:^1.3.0"
-    "B": "^0.4.0":            // will update to "^0.5.0"
+    "A": "workspace:^1.2.0",  // will bump to "workspace:^1.3.0"
+    "B": "^0.4.0",            // will bump to "^0.5.0"
+    "C": "workspace:^"
    },
   "peerDependencies": {
-    "A": "workspace:^1.2.0"   // will NEVER be updateed
-    "B": ">=0.2.0":           // will NEVER be updateed
+    "A": "workspace:^1.2.0",  // will NOT bump the version and will publish as "^1.2.0"
+    "B": ">=0.2.0",           // will NOT bump the version and will publish as ">=0.2.0"
+    "C": "workspace:^"        // will NOT bump the version and will publish previously resolved version "^2.0.0"
   }
 }
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `peerDependencies` is a special case and will only be bumped when the flag `--allow-peer-dependencies-update` is enabled. A package set as `workspace:^` (without any semver number) should be able to be bumped and it wasn't before this PR.

## Motivation and Context

The `--allow-peer-dependencies-update` implementation was only tested with `workspace:` and semver, but it wasn't tested with just `workspace:^` (or `~`) and the end result was actually producing an invalid version `^` (which is obviously wrong). 

This PR fixes 2 problems with `peerDependencies` identified in #587 and #590:

_the example below is assuming that the version is at `1.0.0` and we are processing a `minor` bump_
1. when version is `workspace:^` and `--allow-peer-dependencies-update` is enabled, the version in `package.json` should remain as `workspace:^` but the version that will be published should be bumped to `"1.1.0"`
   - this issue was caused by a very small RegEx that wasn't being match when using `workspace:^` without a semver number
3. when version is `workspace:^` and we **do not** provide `--allow-peer-dependencies-update`, it was previously trying to publish as `^` (which is an invalid version). In this case we now fallback to the previously resolved version when publishing (in this case `"1.0.0"`)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
