### PR TITLE
fix(cli): missing --allow-peer-dependencies-update flag

### DIFF
--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -26,6 +26,10 @@ export default {
         describe: 'Specify which branches to allow versioning from.',
         type: 'array',
       },
+      'allow-peer-dependencies-update': {
+        describe: 'Allow bumping versions of peer dependencies.',
+        type: 'boolean',
+      },
       amend: {
         describe: 'Amend the existing commit, instead of generating a new one.',
         type: 'boolean',


### PR DESCRIPTION
## Description

The documented --allow-peer-dependencies-update flag is currently only supported through `Lerna.json`. This pull request introduces CLI support for this flag.

## Motivation and Context

This change is required to ensure that all documented features are functional and available to users. 

## How Has This Been Tested?

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.