### PR TITLE
chore: cleanup workspace-strict-match option that was removed in latest

### DIFF
--- a/packages/cli/src/cli-commands/cli-publish-commands.ts
+++ b/packages/cli/src/cli-commands/cli-publish-commands.ts
@@ -135,11 +135,6 @@ export default {
         describe: 'Verify package read-write access for current npm user.',
         type: 'boolean',
       },
-      'workspace-strict-match': {
-        describe:
-          'Strict match transform version numbers to an exact range (like "1.2.3") rather than with a caret (like ^1.2.3) when using `workspace:*`.',
-        type: 'boolean',
-      },
     };
 
     composeVersionOptions(yargs);

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -258,11 +258,6 @@ export default {
         describe: 'do we want to skip creating a release (github/gitlab) when the version is a "version bump only"?',
         type: 'boolean',
       },
-      'workspace-strict-match': {
-        describe:
-          'Strict match transform version numbers to an exact range (like "1.2.3") rather than with a caret (like ^1.2.3) when using `workspace:*`.',
-        type: 'boolean',
-      },
       y: {
         describe: 'Skip all confirmation prompts.',
         alias: 'yes',

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -75,145 +75,143 @@ describe("workspace protocol 'workspace:' specifiers", () => {
     await gitCommit(cwd, 'setup');
   };
 
-  describe('workspace-strict-match enabled', () => {
-    it('overwrites workspace protocol with local minor bumped version before npm publish but after git commit & also expect bump peerDependencies when allowPeerDependenciesUpdate flag is enabled', async () => {
-      const cwd = await initFixture('workspace-protocol-specs');
+  it('overwrites workspace protocol with local minor bumped version before npm publish but after git commit & also expect bump peerDependencies when allowPeerDependenciesUpdate flag is enabled', async () => {
+    const cwd = await initFixture('workspace-protocol-specs');
 
-      await gitTag(cwd, 'v1.0.0');
-      await setupChanges(cwd);
-      await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--workspace-strict-match', '--allow-peer-dependencies-update'));
+    await gitTag(cwd, 'v1.0.0');
+    await setupChanges(cwd);
+    await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--allow-peer-dependencies-update'));
 
-      expect((writePkg as any).updatedVersions()).toEqual({
-        'package-1': '1.1.0',
-        'package-2': '1.1.0',
-        'package-3': '1.1.0',
-        'package-4': '1.1.0',
-        'package-5': '1.1.0',
-        'package-6': '1.1.0',
-        'package-7': '1.1.0',
-      });
-
-      // notably missing is package-1, which has no relative file: dependencies
-      expect((writePkg as any).updatedManifest('package-2').dependencies).toMatchObject({
-        'package-1': '1.1.0', // workspace:*
-      });
-      expect((writePkg as any).updatedManifest('package-2').peerDependencies).toMatchObject({
-        // peer deps should be bumped to a fixed minor version
-        'package-1': '1.1.0', // workspace:*
-      });
-      expect((writePkg as any).updatedManifest('package-3').dependencies).toMatchObject({
-        'package-2': '^1.1.0', // workspace:^
-      });
-      expect((writePkg as any).updatedManifest('package-3').peerDependencies).toMatchObject({
-        // peer deps should be bumped to a minor with ^ spec
-        'package-2': '^1.1.0', // workspace:^
-      });
-      expect((writePkg as any).updatedManifest('package-4').optionalDependencies).toMatchObject({
-        'package-3': '~1.1.0', // workspace:~
-      });
-      expect((writePkg as any).updatedManifest('package-5').dependencies).toMatchObject({
-        // all fixed versions are bumped when minor
-        'package-4': '^1.1.0', // workspace:^1.0.0
-        'package-6': '~1.1.0', // workspace:~1.0.0
-      });
-      expect((writePkg as any).updatedManifest('package-5').peerDependencies).toMatchObject({
-        // peer dependencies without operator range will be bumped with the flag enabled
-        'package-4': '>=1.0.0', // workspace:>=1.0.0, range shouldn't be bumped
-        'package-6': '~1.1.0', // workspace:~1.0.0
-      });
-      expect((writePkg as any).updatedManifest('package-6').dependencies).toMatchObject({
-        'package-1': '>=1.0.0', // workspace:>=1.0.0, range shouldn't be bumped
-      });
-      expect((writePkg as any).updatedManifest('package-6').peerDependencies).toMatchObject({
-        'package-1': '>=1.0.0', // workspace:>=1.0.0
-      });
-      // private packages do not need local version resolution
-      expect((writePkg as any).updatedManifest('package-7').dependencies).toMatchObject({
-        'package-1': '^1.1.0',
-      });
-      expect((writePkg as any).updatedManifest('package-7').peerDependencies).toMatchObject({
-        'package-2': '^1.1.0',
-        'package-3': '>=1.0.0',
-      });
+    expect((writePkg as any).updatedVersions()).toEqual({
+      'package-1': '1.1.0',
+      'package-2': '1.1.0',
+      'package-3': '1.1.0',
+      'package-4': '1.1.0',
+      'package-5': '1.1.0',
+      'package-6': '1.1.0',
+      'package-7': '1.1.0',
     });
 
-    it('overwrites workspace protocol with local major bumped version before npm publish but after git commit', async () => {
-      const cwd = await initFixture('workspace-protocol-specs');
+    // notably missing is package-1, which has no relative file: dependencies
+    expect((writePkg as any).updatedManifest('package-2').dependencies).toMatchObject({
+      'package-1': '1.1.0', // workspace:*
+    });
+    expect((writePkg as any).updatedManifest('package-2').peerDependencies).toMatchObject({
+      // peer deps should be bumped to a fixed minor version
+      'package-1': '1.1.0', // workspace:*
+    });
+    expect((writePkg as any).updatedManifest('package-3').dependencies).toMatchObject({
+      'package-2': '^1.1.0', // workspace:^
+    });
+    expect((writePkg as any).updatedManifest('package-3').peerDependencies).toMatchObject({
+      // peer deps should be bumped to a minor with ^ spec
+      'package-2': '^1.1.0', // workspace:^
+    });
+    expect((writePkg as any).updatedManifest('package-4').optionalDependencies).toMatchObject({
+      'package-3': '~1.1.0', // workspace:~
+    });
+    expect((writePkg as any).updatedManifest('package-5').dependencies).toMatchObject({
+      // all fixed versions are bumped when minor
+      'package-4': '^1.1.0', // workspace:^1.0.0
+      'package-6': '~1.1.0', // workspace:~1.0.0
+    });
+    expect((writePkg as any).updatedManifest('package-5').peerDependencies).toMatchObject({
+      // peer dependencies without operator range will be bumped with the flag enabled
+      'package-4': '>=1.0.0', // workspace:>=1.0.0, range shouldn't be bumped
+      'package-6': '~1.1.0', // workspace:~1.0.0
+    });
+    expect((writePkg as any).updatedManifest('package-6').dependencies).toMatchObject({
+      'package-1': '>=1.0.0', // workspace:>=1.0.0, range shouldn't be bumped
+    });
+    expect((writePkg as any).updatedManifest('package-6').peerDependencies).toMatchObject({
+      'package-1': '>=1.0.0', // workspace:>=1.0.0
+    });
+    // private packages do not need local version resolution
+    expect((writePkg as any).updatedManifest('package-7').dependencies).toMatchObject({
+      'package-1': '^1.1.0',
+    });
+    expect((writePkg as any).updatedManifest('package-7').peerDependencies).toMatchObject({
+      'package-2': '^1.1.0',
+      'package-3': '>=1.0.0',
+    });
+  });
 
-      await gitTag(cwd, 'v1.0.0');
-      await setupChanges(cwd);
-      await new PublishCommand(createArgv(cwd, '--bump', 'major', '--yes'));
+  it('overwrites workspace protocol with local major bumped version before npm publish but after git commit', async () => {
+    const cwd = await initFixture('workspace-protocol-specs');
 
-      expect((writePkg as any).updatedVersions()).toEqual({
-        'package-1': '2.0.0',
-        'package-2': '2.0.0',
-        'package-3': '2.0.0',
-        'package-4': '2.0.0',
-        'package-5': '2.0.0',
-        'package-6': '2.0.0',
-        'package-7': '2.0.0',
-      });
+    await gitTag(cwd, 'v1.0.0');
+    await setupChanges(cwd);
+    await new PublishCommand(createArgv(cwd, '--bump', 'major', '--yes'));
 
-      // notably missing is package-1, which has no relative file: dependencies
-      expect((writePkg as any).updatedManifest('package-2').dependencies).toMatchObject({
-        'package-1': '2.0.0', // workspace:*
-      });
-      expect((writePkg as any).updatedManifest('package-3').dependencies).toMatchObject({
-        'package-2': '^2.0.0', // workspace:^
-      });
-      expect((writePkg as any).updatedManifest('package-3').peerDependencies).toMatchObject({
-        // peer deps without the allow peer bump flag will not be bumped
-        'package-2': '^1.0.0', // workspace:^
-      });
-      expect((writePkg as any).updatedManifest('package-4').optionalDependencies).toMatchObject({
-        'package-3': '~2.0.0', // workspace:~
-      });
-      expect((writePkg as any).updatedManifest('package-5').dependencies).toMatchObject({
-        // all fixed versions are bumped when major
-        'package-4': '^2.0.0', // workspace:^1.0.0
-        'package-6': '~2.0.0', // workspace:~1.0.0
-      });
-      expect((writePkg as any).updatedManifest('package-5').peerDependencies).toMatchObject({
-        // peer dependencies will not be bumped by default without a flag
-        'package-4': '>=1.0.0', // workspace:^1.0.0
-        'package-6': '~1.0.0', // workspace:~1.0.0
-      });
-      expect((writePkg as any).updatedManifest('package-6').dependencies).toMatchObject({
-        'package-1': '>=1.0.0', // workspace:>=1.0.0
-      });
-      expect((writePkg as any).updatedManifest('package-6').peerDependencies).toMatchObject({
-        'package-1': '>=1.0.0', // workspace:>=1.0.0, not bumped without a flag
-      });
-      // private packages do not need local version resolution
-      expect((writePkg as any).updatedManifest('package-7').dependencies).toMatchObject({
-        'package-1': '^2.0.0', // ^1.0.0
-      });
-      expect((writePkg as any).updatedManifest('package-7').peerDependencies).toMatchObject({
-        'package-2': '^1.0.0', // not bumped without a flag
-        'package-3': '>=1.0.0',
-      });
+    expect((writePkg as any).updatedVersions()).toEqual({
+      'package-1': '2.0.0',
+      'package-2': '2.0.0',
+      'package-3': '2.0.0',
+      'package-4': '2.0.0',
+      'package-5': '2.0.0',
+      'package-6': '2.0.0',
+      'package-7': '2.0.0',
     });
 
-    it('remove workspace protocol from external dependencies and minor bump other local dependencies with workspace protocol', async () => {
-      const cwd = await initFixture('workspace-protocol-specs');
-      const logErrorSpy = vi.spyOn(npmlog, 'error');
+    // notably missing is package-1, which has no relative file: dependencies
+    expect((writePkg as any).updatedManifest('package-2').dependencies).toMatchObject({
+      'package-1': '2.0.0', // workspace:*
+    });
+    expect((writePkg as any).updatedManifest('package-3').dependencies).toMatchObject({
+      'package-2': '^2.0.0', // workspace:^
+    });
+    expect((writePkg as any).updatedManifest('package-3').peerDependencies).toMatchObject({
+      // peer deps without the allow peer bump flag will not be bumped
+      'package-2': '^1.0.0', // workspace:^
+    });
+    expect((writePkg as any).updatedManifest('package-4').optionalDependencies).toMatchObject({
+      'package-3': '~2.0.0', // workspace:~
+    });
+    expect((writePkg as any).updatedManifest('package-5').dependencies).toMatchObject({
+      // all fixed versions are bumped when major
+      'package-4': '^2.0.0', // workspace:^1.0.0
+      'package-6': '~2.0.0', // workspace:~1.0.0
+    });
+    expect((writePkg as any).updatedManifest('package-5').peerDependencies).toMatchObject({
+      // peer dependencies will not be bumped by default without a flag
+      'package-4': '>=1.0.0', // workspace:^1.0.0
+      'package-6': '~1.0.0', // workspace:~1.0.0
+    });
+    expect((writePkg as any).updatedManifest('package-6').dependencies).toMatchObject({
+      'package-1': '>=1.0.0', // workspace:>=1.0.0
+    });
+    expect((writePkg as any).updatedManifest('package-6').peerDependencies).toMatchObject({
+      'package-1': '>=1.0.0', // workspace:>=1.0.0, not bumped without a flag
+    });
+    // private packages do not need local version resolution
+    expect((writePkg as any).updatedManifest('package-7').dependencies).toMatchObject({
+      'package-1': '^2.0.0', // ^1.0.0
+    });
+    expect((writePkg as any).updatedManifest('package-7').peerDependencies).toMatchObject({
+      'package-2': '^1.0.0', // not bumped without a flag
+      'package-3': '>=1.0.0',
+    });
+  });
 
-      await gitTag(cwd, 'v1.0.0');
-      await setupChanges(cwd);
-      await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--workspace-strict-match'));
+  it('remove workspace protocol from external dependencies and minor bump other local dependencies with workspace protocol', async () => {
+    const cwd = await initFixture('workspace-protocol-specs');
+    const logErrorSpy = vi.spyOn(npmlog, 'error');
 
-      expect(logErrorSpy).toHaveBeenCalledWith(
-        'publish',
-        [
-          `Your package named "package-6" has external dependencies not handled by Lerna-Lite and without workspace version suffix, `,
-          `we recommend using defined versions with workspace protocol. Your dependency is currently being published with "tiny-registry": "".`,
-        ].join('')
-      );
-      expect((writePkg as any).updatedManifest('package-6').dependencies).toMatchObject({
-        'package-1': '>=1.0.0', // workspace:>=1.0.0 will not be bumped without a flag
-        'tiny-registry': '', // workspace:*
-        'tiny-tarball': '^2.3.4', // workspace:^2.3.4
-      });
+    await gitTag(cwd, 'v1.0.0');
+    await setupChanges(cwd);
+    await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes'));
+
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      'publish',
+      [
+        `Your package named "package-6" has external dependencies not handled by Lerna-Lite and without workspace version suffix, `,
+        `we recommend using defined versions with workspace protocol. Your dependency is currently being published with "tiny-registry": "".`,
+      ].join('')
+    );
+    expect((writePkg as any).updatedManifest('package-6').dependencies).toMatchObject({
+      'package-1': '>=1.0.0', // workspace:>=1.0.0 will not be bumped without a flag
+      'tiny-registry': '', // workspace:*
+      'tiny-tarball': '^2.3.4', // workspace:^2.3.4
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cleanup some leftover code for the `--workspace-strict-match` that was removed in latest major 2.0 version

## Motivation and Context

just code cleanup, the option no longer exist but some lines and the CLI option was forgotten 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
