### PR TITLE
chore(run): deprecate `lerna run --use-nx` option

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1550,7 +1550,7 @@
         },
         "verbose": {
           "type": "boolean",
-          "description": "When true, escalates loglevel to 'verbose' and shows nx verbose output if useNx is true."
+          "description": "(deprecated) When true, escalates loglevel to 'verbose' and shows nx verbose output if useNx is true."
         }
       }
     }

--- a/packages/cli/src/cli-commands/cli-run-commands.ts
+++ b/packages/cli/src/cli-commands/cli-run-commands.ts
@@ -84,7 +84,8 @@ export default {
         },
         'use-nx': {
           group: 'Command Options:',
-          describe: 'enables integration with Nx instead of the default Lerna task runner (which uses `p-map` and `p-queue`).',
+          describe:
+            '(deprecated) Enables integration with Nx instead of the default Lerna task runner (which uses `p-map` and `p-queue`).',
           type: 'boolean',
         },
         verbose: {

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -405,7 +405,7 @@ export interface RunCommandOption {
   /** proxy for `--no-bail`. */
   bail?: boolean;
 
-  /** When useNx is enabled, do we want to automatically load .env files */
+  /** @deprecated When useNx is enabled, do we want to automatically load .env files */
   loadEnvFiles?: boolean;
 
   /** Do not prefix streaming output. */
@@ -423,10 +423,10 @@ export interface RunCommandOption {
   /** npm script to run by the command. */
   script: string;
 
-  /** when "useNx" is enabled, do we want to skip caching with Nx? */
+  /** @deprecated when "useNx" is enabled, do we want to skip caching with Nx? */
   skipNxCache?: boolean;
 
-  /** enables integration with [Nx](https://nx.dev) instead of the default Lerna task runner (which uses `p-map` and `p-queue`). */
+  /** @deprecated this will be removed in next major version. Enables integration with [Nx](https://nx.dev) instead of the default Lerna task runner (which uses `p-map` and `p-queue`). */
   useNx?: boolean;
 }
 

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -172,7 +172,7 @@ export interface ProjectConfig extends LernaConfig, QueryGraphConfig {
   /** During `lerna exec` and `lerna run`, stream output with lines prefixed by originating package name. */
   stream?: boolean;
 
-  /** Enables integration with [Nx](https://nx.dev). */
+  /** @deprecated Enables integration with [Nx](https://nx.dev). */
   useNx?: boolean;
 
   /** When useNx is true, show verbose output from dependent tasks. */

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -68,7 +68,8 @@ $ lerna run --scope my-component test
     - [`--profile`](#--profile)
     - [`--profile-location <location>`](#--profile-location-location)
     - [`--load-env-files`](#--load-env-files)
-    - [`--use-nx`](#--use-nx)
+    - [`--use-nx`](#--use-nx) (deprecated)
+      - now deprecated, it will be removed in next major
 
 ### `--npm-client <client>`
 
@@ -168,6 +169,8 @@ When the task runner is powered by Nx (via [`--use-nx`](#use-nx)) it will automa
 For more details about what `.env` files will be loaded by default please see: https://nx.dev/recipes/environment-variables/define-environment-variables
 
 ### `--use-nx`
+
+> **Note** this feature is now deprecated and will be removed in the next major version, if you wish to use Nx then you should consider using the original [Lerna](https://github.com/lerna/lerna) since it has full Nx integration. The goal of Lerna-Lite is to stay light hence the deprecation of this option.
 
 Enables integration with [Nx](https://nx.dev). Enabling this option will tell Lerna to delegate
 running tasks to Nx instead of using `p-map` and `p-queue`. This only works if Nx is installed and `nx.json` is present. You can also skip cache by providing `--skip-nx-cache`

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -480,6 +480,7 @@ describe('RunCommand', () => {
       expect(collectedOutput).not.toContain('Nx read the output from the cache');
     });
 
+    // deprecated
     it('should log a warning when using obsolete options with useNx', async () => {
       collectedOutput = '';
 

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -88,6 +88,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
   }
 
   execute() {
+    // deprecated
     if (!this.options.useNx) {
       this.logger.info('', 'Executing command in %d %s: %j', this.count, this.packagePlural, this.joinedCommand);
     }
@@ -216,6 +217,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
     return scriptName.includes(':') ? `"${scriptName}"` : scriptName;
   }
 
+  // now deprecated
   async runScriptsUsingNx() {
     if (this.options.ci) {
       process.env.CI = 'true';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This option doesn't seem to be used much by users, I only found 1 user out of 50 who was taking advantage of this option. So we can start the process of deprecating the option and simply remove it later in the next major version (in a year or so), so it can still be used until then

## Motivation and Context

The goal of Lerna-Lite is to provide a light (lite) alternative to Lerna and since barely anyone were using this option, I don't see any reason to keep this option in the code. This will lower the code size and avoid issues whenever a new Nx version comes out. On a final note, Lerna is becoming another Nx branded product, so for sure they have the best possible integration with Nx and if the user is interested in using, then this user will probably be using Lerna anyway (instead of Lerna-Lite)

## How Has This Been Tested?

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
