### PR TITLE
feat(version): add new `--create-release-discussion` option

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -14,6 +14,7 @@
     "version": {
       "conventionalCommits": true,
       "createRelease": "github",
+      "createReleaseDiscussion": "Releases",
       "syncWorkspaceLock": true,
       "changelogIncludeCommitsClientLogin": " - by @%l",
       "changelogHeaderMessage": "## Automate your Workspace Versioning, Publishing & Changelogs with [Lerna-Lite](https://github.com/lerna-lite/lerna-lite) 📦🚀",

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -598,6 +598,9 @@
             "createRelease": {
               "$ref": "#/$defs/commandOptions/version/createRelease"
             },
+            "createReleaseDiscussion": {
+              "$ref": "#/$defs/commandOptions/version/createReleaseDiscussion"
+            },
             "ignoreChanges": {
               "$ref": "#/$defs/commandOptions/shared/ignoreChanges"
             },
@@ -1319,6 +1322,10 @@
           "type": "string",
           "description": "During `lerna version`, an official GitHub or GitLab release for every version.",
           "enum": ["github", "gitlab"]
+        },
+        "createReleaseDiscussion": {
+          "type": "string",
+          "description": "Create a GitHub Discussion from the new release (note that createRelease must be enabled for this to work)."
         },
         "message": {
           "type": "string",

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -114,6 +114,10 @@ export default {
         type: 'string',
         choices: ['gitlab', 'github'],
       },
+      'create-release-discussion': {
+        describe: 'Create a GitHub Discussion from the new release (note that createRelease must be enabled for this to work).',
+        type: 'string',
+      },
       'ignore-changes': {
         describe: [
           'Ignore changes in files matched by glob(s) when detecting changed packages.',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -184,6 +184,9 @@ export interface VersionCommandOption {
   /** Create an official GitHub or GitLab release for every version. */
   createRelease?: RemoteClientType;
 
+  /** Create a GitHub Discussion from the new release (note that createRelease must be enabled for this to work and it only works with GitHub at the moment). */
+  createReleaseDiscussion?: string;
+
   /** Specify cross-dependency version numbers exactly rather than with a caret (^). */
   exact?: boolean;
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -81,6 +81,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--changelog-include-commits-client-login [msg]`](#--changelog-include-commits-client-login-msg)
     - [`--changelog-header-message <msg>`](#--changelog-header-message-msg)
     - [`--create-release <type>`](#--create-release-type)
+    - [`--create-release-discussion <name>`](#--create-release-discussion-name)
     - [`--skip-bump-only-release`](#--skip-bump-only-release)
     - [`--describe-tag <pattern>`](#--describe-tag-pattern)
     - [`--exact`](#--exact)
@@ -394,6 +395,17 @@ lerna version --conventional-commits --create-release gitlab
 When run with this flag, `lerna version` will create an official GitHub or GitLab release based on the changed packages. Requires `--conventional-commits` to be passed so that changelogs can be generated.
 
 > **Note** to avoid creating too many "Version bump only for package x" when using independent mode, you could enable the option `--skip-bump-only-release`
+
+### `--create-release-discussion <name>`
+
+Create a discussion for this release, this will create both a Release and a Discussion.
+
+```sh
+lerna version --conventional-commits --create-release github --create-release-discussion announcement
+```
+
+> **Note** currently only available for GitHub Releases following this GitHub blog post [You can now link discussions to new releases](https://github.blog/changelog/2021-04-06-releases-support-comments-and-reactions-with-discussion-linking/)
+
 
 ### `--skip-bump-only-release`
 

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -347,7 +347,6 @@ it('should create a github release discussion when enabled', async () => {
   (createReleaseClient as Mock).mockImplementation(() => Promise.resolve({ repos: { createRelease: createReleaseMock } }));
 
   const cwd = await initFixture('normal');
-  const client = createGitHubClient as any;
 
   (recommendVersion as Mock).mockResolvedValueOnce('1.1.0');
 

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -344,7 +344,7 @@ describe.each([
 it('should create a github release discussion when enabled', async () => {
   process.env.GH_TOKEN = 'TOKEN';
   const createReleaseMock = vi.fn(() => Promise.resolve(true));
-  (createReleaseClient as Mock).mockImplementation(() => Promise.resolve({ repos: { createRelease: createReleaseMock }}));
+  (createReleaseClient as Mock).mockImplementation(() => Promise.resolve({ repos: { createRelease: createReleaseMock } }));
 
   const cwd = await initFixture('normal');
   const client = createGitHubClient as any;

--- a/packages/version/src/models/index.ts
+++ b/packages/version/src/models/index.ts
@@ -72,6 +72,7 @@ export interface GitClientReleaseOption {
   body?: string;
   draft?: boolean;
   prerelease?: boolean;
+  discussion_category_name?: string;
 }
 
 export type GitCreateReleaseFn = (options: GitClientReleaseOption) => Promise<{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

GitHub allows us to create a discussion from a release as per this GitHub blog post [You can now link discussions to new releases](https://github.blog/changelog/2021-04-06-releases-support-comments-and-reactions-with-discussion-linking/)

## Motivation and Context

This will create both a Release and Discussion. by providing a discussion category name. As per my original Discussion #602

The Octokit API that would help for this is [Octokit - create a release](https://octokit.github.io/rest.js/v19#repos-create-release) and [GitHub Rest API - create a release](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release) and the option that I need to use is `discussion_category_name`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
