### PR TITLE
chore: replace `glob` by `globby` to cleanup temp files

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "file-url": "^4.0.0",
     "find-up": "^6.3.0",
     "fs-extra": "^11.1.1",
-    "glob": "^10.2.2",
     "globby": "^13.1.4",
     "load-json-file": "^7.0.1",
     "normalize-newline": "^4.1.0",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -57,7 +57,7 @@
     "chalk": "^5.2.0",
     "columnify": "^1.6.0",
     "fs-extra": "^11.1.1",
-    "glob": "^10.2.2",
+    "globby": "^13.1.4",
     "has-unicode": "^2.0.1",
     "libnpmaccess": "^7.0.2",
     "libnpmpublish": "^7.1.4",

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { glob } from 'glob';
+import { globby } from 'globby';
 import { outputFileSync, removeSync } from 'fs-extra/esm';
 import { EOL } from 'node:os';
 import { join, relative } from 'node:path';
@@ -324,7 +324,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     // optionally cleanup temp packed files after publish, opt-in option
     if (this.options.cleanupTempFiles) {
-      glob(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
+      globby(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
         // delete silently all files/folders that startsWith "lerna-"
         deleteFolders.forEach((folder) => removeSync(folder));
         this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,6 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
-      glob:
-        specifier: ^10.2.2
-        version: 10.2.2
       globby:
         specifier: ^13.1.4
         version: 13.1.4
@@ -518,9 +515,9 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
-      glob:
-        specifier: ^10.2.2
-        version: 10.2.2
+      globby:
+        specifier: ^13.1.4
+        version: 13.1.4
       has-unicode:
         specifier: ^2.0.1
         version: 2.0.1

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -1,10 +1,10 @@
-import { glob } from 'glob';
+import { globby } from 'globby';
 import { join } from 'node:path';
 import { removeSync } from 'fs-extra/esm';
 import tempDir from 'temp-dir';
 import normalizePath from 'normalize-path';
 
-glob(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
+globby(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
   // delete silently all files/folders that startsWith "lerna-"
   console.log(`Found ${deleteFolders.length} temp folders to cleanup.`);
   (deleteFolders || []).forEach((folder) => removeSync(folder));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

use `globby`, instead of `glob`, to cleanup temp files & folders

## Motivation and Context

we already use `globby` in other sections of the code, so let's use the same dependency everywhere and reduce number of dependencies by 1 less

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
