### PR TITLE
Revert "chore: replace `glob` by `globby` to cleanup temp files"

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "file-url": "^4.0.0",
     "find-up": "^6.3.0",
     "fs-extra": "^11.1.1",
+    "glob": "^10.2.2",
     "globby": "^13.1.4",
     "load-json-file": "^7.0.1",
     "normalize-newline": "^4.1.0",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -57,7 +57,7 @@
     "chalk": "^5.2.0",
     "columnify": "^1.6.0",
     "fs-extra": "^11.1.1",
-    "globby": "^13.1.4",
+    "glob": "^10.2.2",
     "has-unicode": "^2.0.1",
     "libnpmaccess": "^7.0.2",
     "libnpmpublish": "^7.1.4",

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { globby } from 'globby';
+import { glob } from 'glob';
 import { outputFileSync, removeSync } from 'fs-extra/esm';
 import { EOL } from 'node:os';
 import { join, relative } from 'node:path';
@@ -324,7 +324,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     // optionally cleanup temp packed files after publish, opt-in option
     if (this.options.cleanupTempFiles) {
-      globby(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
+      glob(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
         // delete silently all files/folders that startsWith "lerna-"
         deleteFolders.forEach((folder) => removeSync(folder));
         this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
+      glob:
+        specifier: ^10.2.2
+        version: 10.2.2
       globby:
         specifier: ^13.1.4
         version: 13.1.4
@@ -515,9 +518,9 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
-      globby:
-        specifier: ^13.1.4
-        version: 13.1.4
+      glob:
+        specifier: ^10.2.2
+        version: 10.2.2
       has-unicode:
         specifier: ^2.0.1
         version: 2.0.1

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -1,10 +1,10 @@
-import { globby } from 'globby';
+import { glob } from 'glob';
 import { join } from 'node:path';
 import { removeSync } from 'fs-extra/esm';
 import tempDir from 'temp-dir';
 import normalizePath from 'normalize-path';
 
-globby(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
+glob(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
   // delete silently all files/folders that startsWith "lerna-"
   console.log(`Found ${deleteFolders.length} temp folders to cleanup.`);
   (deleteFolders || []).forEach((folder) => removeSync(folder));


### PR DESCRIPTION
Reverts lerna-lite/lerna-lite#605, it actually doesn't seem to work with `globby`, so let's revert and `glob` which seems to be faster than `globby` now too