### PR TITLE
chore(version): throw when createReleaseDiscussion missing cat name

### DIFF
--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -89,7 +89,7 @@ describe.each([
 
   it('throws an error if --conventional-commits is not passed', async () => {
     const cwd = await initFixture('independent');
-    const command = new VersionCommand(createArgv(cwd, '--create-release', type));
+    const command = lernaVersion(cwd)('--create-release', type);
 
     await expect(command).rejects.toThrow('To create a release, you must enable --conventional-commits');
 
@@ -98,16 +98,25 @@ describe.each([
 
   it('throws an error if --create-release-discussion is provided without defining --create-release', async () => {
     const cwd = await initFixture('independent');
-    const command = new VersionCommand(createArgv(cwd, '--create-release-discussion', 'some-discussion'));
+    const command = lernaVersion(cwd)('--create-release-discussion', 'some-discussion');
 
     await expect(command).rejects.toThrow('To create a release discussion, you must define --create-release');
 
     expect(client.releases.size).toBe(0);
   });
 
+  it('throws an error if --create-release-discussion is missing a category name', async () => {
+    const cwd = await initFixture('independent');
+    const command = lernaVersion(cwd)('--create-release', type, '--conventional-commits', '--create-release-discussion');
+
+    await expect(command).rejects.toThrow('A discussion category name must be provided to the --create-release-discussion option.');
+
+    expect(client.releases.size).toBe(0);
+  });
+
   it('throws an error if --no-changelog also passed', async () => {
     const cwd = await initFixture('independent');
-    const command = new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--no-changelog'));
+    const command = lernaVersion(cwd)('--create-release', type, '--conventional-commits', '--no-changelog');
 
     await expect(command).rejects.toThrow('To create a release, you cannot pass --no-changelog');
 
@@ -116,7 +125,7 @@ describe.each([
 
   it('throws an error if environment variables are not present', async () => {
     const cwd = await initFixture('normal');
-    const command = new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits'));
+    const command = lernaVersion(cwd)('--create-release', type, '--conventional-commits');
     const message = `Environment variables for ${type} are missing!`;
 
     client.mockImplementationOnce(() => {

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -144,6 +144,13 @@ export class VersionCommand extends Command<VersionCommandOption> {
       throw new ValidationError('ERELEASE', 'To create a release discussion, you must define --create-release');
     }
 
+    if (this.options.createReleaseDiscussion !== undefined && !this.options.createReleaseDiscussion) {
+      throw new ValidationError(
+        'ERELEASE',
+        'A discussion category name must be provided to the --create-release-discussion option.'
+      );
+    }
+
     if (this.releaseClient && this.options.changelog === false) {
       throw new ValidationError('ERELEASE', 'To create a release, you cannot pass --no-changelog');
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just some simple code change on the new `--create-release-discussion` option

## Motivation and Context

We should probably throw an error when user us trying to use `--create-release-discussion` without providing a category name

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
