### PR TITLE
docs: remove `-W` flag from all `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Note that `package-a` will not be created, it is only shown here to help clarify
 Finally install the commands that are of interest to you (`publish`, `version`, `run`, `exec`, ...)
 
 ```sh
-$ npm i @lerna-lite/publish -D -W
+$ npm i @lerna-lite/publish -D
 ```
 
 ## Installation
@@ -207,14 +207,14 @@ or from a CDN
 
 | Command | Install | Description |
 | --------| --------| ----------- |
-| ☁️ [publish](https://github.com/lerna-lite/lerna-lite/tree/main/packages/publish#readme) | `npm i @lerna-lite/publish -D -W` | publish each workspace package |
-| 📑 [version](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#readme) | `npm i @lerna-lite/version -D -W` | create new version for each workspace package |
-| 🕜 [changed](https://github.com/lerna-lite/lerna-lite/tree/main/packages/changed#readme) | `npm i @lerna-lite/changed -D -W` | list local packages changed since last release |
-| 🌓 [diff](https://github.com/lerna-lite/lerna-lite/tree/main/packages/diff#readme)       | `npm i @lerna-lite/diff -D -W`    | git diff all packages since the last release   |
-| 👷 [exec](https://github.com/lerna-lite/lerna-lite/tree/main/packages/exec#readme)       | `npm i @lerna-lite/exec -D -W`    | execute an command in each workspace package       |
-| 📖 [list](https://github.com/lerna-lite/lerna-lite/tree/main/packages/list#readme)       | `npm i @lerna-lite/list -D -W`    | list local packages                            |
-| 🏃 [run](https://github.com/lerna-lite/lerna-lite/tree/main/packages/run#readme)         | `npm i @lerna-lite/run -D -W`      | run npm script in each workspace package           |
-| 👓 [watch](https://github.com/lerna-lite/lerna-lite/tree/main/packages/watch#readme)     | `npm i @lerna-lite/watch -D -W`    | watch for changes & execute commands when fired |
+| ☁️ [publish](https://github.com/lerna-lite/lerna-lite/tree/main/packages/publish#readme) | `npm i @lerna-lite/publish -D` | publish each workspace package |
+| 📑 [version](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#readme) | `npm i @lerna-lite/version -D` | create new version for each workspace package |
+| 🕜 [changed](https://github.com/lerna-lite/lerna-lite/tree/main/packages/changed#readme) | `npm i @lerna-lite/changed -D` | list local packages changed since last release |
+| 🌓 [diff](https://github.com/lerna-lite/lerna-lite/tree/main/packages/diff#readme)       | `npm i @lerna-lite/diff -D`    | git diff all packages since the last release   |
+| 👷 [exec](https://github.com/lerna-lite/lerna-lite/tree/main/packages/exec#readme)       | `npm i @lerna-lite/exec -D`    | execute an command in each workspace package       |
+| 📖 [list](https://github.com/lerna-lite/lerna-lite/tree/main/packages/list#readme)       | `npm i @lerna-lite/list -D`    | list local packages                            |
+| 🏃 [run](https://github.com/lerna-lite/lerna-lite/tree/main/packages/run#readme)         | `npm i @lerna-lite/run -D`      | run npm script in each workspace package           |
+| 👓 [watch](https://github.com/lerna-lite/lerna-lite/tree/main/packages/watch#readme)     | `npm i @lerna-lite/watch -D`    | watch for changes & execute commands when fired |
 
 > **Note** since the `publish` package depends on the `version` package, you could simply install `@lerna-lite/publish` to automatically give you access to the `version` command.
 
@@ -238,7 +238,7 @@ If you are migrating from Lerna, it should be fairly easy to just replace Lerna 
 1. remove Lerna from your local & global dependencies
 
 ```sh
-npm uninstall lerna -W   # OR yarn remove lerna -W
+npm uninstall lerna      # OR yarn remove lerna -W
 npm uninstall -g lerna   # OR yarn global remove lerna
 ```
 
@@ -246,7 +246,7 @@ npm uninstall -g lerna   # OR yarn global remove lerna
 
 ```sh
 # Lerna CLI (includes `init`)
-npm install @lerna-lite/cli -D -W
+npm install @lerna-lite/cli -D
 ```
 
 3. finally install the Lerna-Lite command(s) that you wish to use (`changed`, `diff`, `exec`, `list`, `run`, `publish`, `version` and/or `watch`)
@@ -254,7 +254,7 @@ _refer to [installation](#installation) table above_
 
 ```sh
 # install any of the optional commands (refer to installation table)
-npm install @lerna-lite/publish -D -W
+npm install @lerna-lite/publish -D
 ```
 > **Note** you might see a lot of diff changes across your `changelog.md` files after switching to Lerna-Lite and that is totally expected since Lerna-Lite has code in place to remove empty lines that were added by Lerna for no real reason.
 

--- a/packages/changed/README.md
+++ b/packages/changed/README.md
@@ -13,7 +13,7 @@ List local packages that have changed since the last tagged release
 ## Installation
 
 ```sh
-npm install @lerna-lite/changed -D -W
+npm install @lerna-lite/changed -D
 
 # then use it (see usage below)
 lerna changed

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ CLI will only provide the `init` command by default, all other commands are enti
 
 ```sh
 # simple install or install it globally with -g
-npm install @lerna-lite/cli -D -W
+npm install @lerna-lite/cli -D
 
 # then use it `lerna <command>`
 lerna version

--- a/packages/cli/src/cli-commands/cli-changed-commands.ts
+++ b/packages/cli/src/cli-commands/cli-changed-commands.ts
@@ -51,7 +51,7 @@ export default {
       new ChangedCommand(argv);
     } catch (err: unknown) {
       console.error(
-        `"@lerna-lite/changed" is optional and was not found. Please install it with "npm install @lerna-lite/changed -D -W".`,
+        `"@lerna-lite/changed" is optional and was not found. Please install it with "npm install @lerna-lite/changed -D".`,
         err
       );
     }

--- a/packages/cli/src/cli-commands/cli-diff-commands.ts
+++ b/packages/cli/src/cli-commands/cli-diff-commands.ts
@@ -21,7 +21,7 @@ export default {
       new DiffCommand(argv);
     } catch (err: unknown) {
       console.error(
-        `"@lerna-lite/diff" is optional and was not found. Please install it with "npm install @lerna-lite/diff -D -W".`,
+        `"@lerna-lite/diff" is optional and was not found. Please install it with "npm install @lerna-lite/diff -D".`,
         err
       );
     }

--- a/packages/cli/src/cli-commands/cli-exec-commands.ts
+++ b/packages/cli/src/cli-commands/cli-exec-commands.ts
@@ -84,7 +84,7 @@ export default {
       new ExecCommand(argv);
     } catch (err: unknown) {
       console.error(
-        `"@lerna-lite/exec" is optional and was not found. Please install it with "npm install @lerna-lite/exec -D -W".`,
+        `"@lerna-lite/exec" is optional and was not found. Please install it with "npm install @lerna-lite/exec -D".`,
         err
       );
     }

--- a/packages/cli/src/cli-commands/cli-list-commands.ts
+++ b/packages/cli/src/cli-commands/cli-list-commands.ts
@@ -24,7 +24,7 @@ export default {
       new ListCommand(argv);
     } catch (err: unknown) {
       console.error(
-        `"@lerna-lite/list" is optional and was not found. Please install it with "npm install @lerna-lite/list -D -W".`,
+        `"@lerna-lite/list" is optional and was not found. Please install it with "npm install @lerna-lite/list -D".`,
         err
       );
     }

--- a/packages/cli/src/cli-commands/cli-publish-commands.ts
+++ b/packages/cli/src/cli-commands/cli-publish-commands.ts
@@ -165,7 +165,7 @@ export default {
       new PublishCommand(argv);
     } catch (err: unknown) {
       console.error(
-        `"@lerna-lite/publish" is optional and was not found. Please install it with "npm install @lerna-lite/publish -D -W".`,
+        `"@lerna-lite/publish" is optional and was not found. Please install it with "npm install @lerna-lite/publish -D".`,
         err
       );
     }

--- a/packages/cli/src/cli-commands/cli-run-commands.ts
+++ b/packages/cli/src/cli-commands/cli-run-commands.ts
@@ -106,7 +106,7 @@ export default {
       new RunCommand(argv);
     } catch (err: unknown) {
       console.error(
-        `"@lerna-lite/run" is optional and was not found. Please install it with "npm install @lerna-lite/run -D -W".`,
+        `"@lerna-lite/run" is optional and was not found. Please install it with "npm install @lerna-lite/run -D".`,
         err
       );
     }

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -311,7 +311,7 @@ export default {
       new VersionCommand(argv);
     } catch (err: unknown) {
       console.error(
-        `"@lerna-lite/version" is optional and was not found. Please install it with "npm install @lerna-lite/version -D -W".`,
+        `"@lerna-lite/version" is optional and was not found. Please install it with "npm install @lerna-lite/version -D".`,
         err
       );
     }

--- a/packages/cli/src/cli-commands/cli-watch-commands.ts
+++ b/packages/cli/src/cli-commands/cli-watch-commands.ts
@@ -155,7 +155,7 @@ export default {
       new WatchCommand(argv);
     } catch (err: unknown) {
       console.error(
-        `"@lerna-lite/watch" is optional and was not found. Please install it with "npm install @lerna-lite/watch -D -W".`,
+        `"@lerna-lite/watch" is optional and was not found. Please install it with "npm install @lerna-lite/watch -D".`,
         err
       );
     }

--- a/packages/diff/README.md
+++ b/packages/diff/README.md
@@ -13,7 +13,7 @@ Diff all packages or a single package since the last release
 ## Installation
 
 ```sh
-npm install @lerna-lite/diff -D -W
+npm install @lerna-lite/diff -D
 
 # then use it (see usage below)
 lerna diff

--- a/packages/exec/README.md
+++ b/packages/exec/README.md
@@ -15,7 +15,7 @@ This package was added mainly because NPM Workspaces don't yet support executing
 ## Installation
 
 ```sh
-npm install @lerna-lite/exec -D -W
+npm install @lerna-lite/exec -D
 
 # then use it (see usage below)
 lerna exec <command>

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -13,7 +13,7 @@ Create/initialize a new Lerna-Lite repo or upgrade an existing repo to the curre
 ## Installation
 
 ```sh
-npm install @lerna-lite/cli -D -W
+npm install @lerna-lite/cli -D
 
 # then use it (see usage below)
 lerna init

--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -13,7 +13,7 @@ List local packages
 ## Installation
 
 ```sh
-npm install @lerna-lite/list -D -W
+npm install @lerna-lite/list -D
 
 # then use it (see usage below)
 lerna ls

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -13,7 +13,7 @@ Lerna-Lite Publish command, publish package(s) in the current project
 ## Installation
 
 ```sh
-npm install @lerna-lite/publish -D -W
+npm install @lerna-lite/publish -D
 
 # then use it (see usage below)
 lerna publish

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -15,7 +15,7 @@ This package was added mainly because NPM Workspaces don't yet support running N
 ## Installation
 
 ```sh
-npm install @lerna-lite/run -D -W
+npm install @lerna-lite/run -D
 
 # then use it (see usage below)
 lerna run <script>

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -13,7 +13,7 @@ Lerna-Lite Version command, bump version of packages changed since the last rele
 ## Installation
 
 ```sh
-npm install @lerna-lite/version -D -W
+npm install @lerna-lite/version -D
 
 # then use it (see usage below)
 lerna version

--- a/packages/watch/README.md
+++ b/packages/watch/README.md
@@ -15,7 +15,7 @@ Watch for changes within packages and execute commands from the root of the repo
 ## Installation
 
 ```sh
-npm install @lerna-lite/watch -D -W
+npm install @lerna-lite/watch -D
 
 # then use it (see usage below), sure yeah why not
 lerna watch


### PR DESCRIPTION
## Description

Remove the `-W` flag from all `npm install` commands in the docs and in some error messages.

## Motivation and Context

The `-W` flag is not supported by `npm`. See discussion #613.

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other: Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
