### PR TITLE
chore: remove unused vitest/globals types

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "moduleResolution": "bundler",
     "target": "ES2020",
     "lib": ["es2020", "dom"],
-    "types": ["node", "vitest/globals"],
+    "types": ["node"],
     "typeRoots": ["node_modules/@types"],
     "allowSyntheticDefaultImports": true,
     "composite": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description



## Motivation and Context

we're not using `vitest/globals` types anymore and it's throwing an error with latest TypeScript 5.1, so let's just remove it

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
