### PR TITLE
Fix GitHub Enterprise plugin import path

### DIFF
--- a/packages/version/src/git-clients/github-client.ts
+++ b/packages/version/src/git-clients/github-client.ts
@@ -15,7 +15,7 @@ export async function createGitHubClient() {
   }
 
   if (GHE_VERSION) {
-    const plugin = await import(`@octokit/plugin-enterprise-rest/ghe-${GHE_VERSION}`);
+    const plugin = await import(`@octokit/plugin-enterprise-rest/ghe-${GHE_VERSION}/index.js`);
     Octokit.plugin(plugin);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I ran `lerna version` on my company project and tried to create a release on GitHub Enterprise and encountered the following error. (GHE_VERSION="2.19")

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/foobar/node_modules/.pnpm/@lerna-lite+version@2.4.0_@lerna-lite+publish@2.4.0/node_ modules/@octokit/plugin-enterprise-rest/ghe-v2.19'
```

On investigation, I found that `@lerna-lite/version` is an ESM, but `@octokit/plugin-enterprise-rest` is a CJS and the path resolution fails when importing the plugin.

So I tried changing the `GHE_VERSION` to `2.19/index.js` and ran the `lerna version` and that worked.

However, it is incorrect that the user of the library needs to specify `2.19/index.js` for the `GHE_VERSION`.

I have therefore created a Pull Request.

## Motivation and Context



## How Has This Been Tested?

I've had success with my company's GitHub Enterprise Server, but I have no way of sharing it with you. sorry.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
