### PR TITLE
fix(publish): skip lifecycle scripts on pkg fields removal, fixes #637

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,9 @@
     "prebuild": "rimraf dist",
     "build": "tsc",
     "build:incremental": "tsc --incremental --sourceMap false --excludeDirectories dist",
-    "pack-tarball": "npm pack"
+    "pack-tarball": "npm pack",
+    "prepack": "echo hello from prepack",
+    "postpack": "echo hello from postpack"
   },
   "license": "MIT",
   "author": "Ghislain B.",

--- a/packages/core/src/utils/__tests__/string-util.spec.ts
+++ b/packages/core/src/utils/__tests__/string-util.spec.ts
@@ -1,27 +1,43 @@
 import { describe, expect, it } from 'vitest';
 
-import { pluralize } from '../string-utils';
+import { excludeValuesFromArray, pluralize } from '../string-utils';
 
 describe('String Utils', () => {
-  it('should return a singular word when string length is below 1', () => {
-    const str1 = pluralize('item', 0);
-    const str2 = pluralize('item', 1);
+  describe('pluralize() method', () => {
+    it('should return a singular word when string length is below 1', () => {
+      const str1 = pluralize('item', 0);
+      const str2 = pluralize('item', 1);
 
-    expect(str1).toBe('item');
-    expect(str2).toBe('item');
+      expect(str1).toBe('item');
+      expect(str2).toBe('item');
+    });
+
+    it('should return a plural word when string length is greater than 1', () => {
+      const str1 = pluralize('item', 2);
+
+      expect(str1).toBe('items');
+    });
+
+    it('should return a custom plural word when string length is greater than 1 and a custom format is provided', () => {
+      const str1 = pluralize('cheval', 1, 'chevaux');
+      const str2 = pluralize('cheval', 2, 'chevaux');
+
+      expect(str1).toBe('cheval');
+      expect(str2).toBe('chevaux');
+    });
   });
 
-  it('should return a plural word when string length is greater than 1', () => {
-    const str1 = pluralize('item', 2);
+  describe('excludeValuesFromArray() method', () => {
+    it('should return same input array when no exclusion found from input array', () => {
+      const inArr = ['John', 'Jane', 'Doe'];
+      const outArr = excludeValuesFromArray(inArr, ['banana', 'orange']);
+      expect(outArr).toEqual(inArr);
+    });
 
-    expect(str1).toBe('items');
-  });
-
-  it('should return a custom plural word when string length is greater than 1 and a custom format is provided', () => {
-    const str1 = pluralize('cheval', 1, 'chevaux');
-    const str2 = pluralize('cheval', 2, 'chevaux');
-
-    expect(str1).toBe('cheval');
-    expect(str2).toBe('chevaux');
+    it('should return input array minus exclusion', () => {
+      const inArr = ['apple', 'raisin', 'orange', 'blueberry', 'banana'];
+      const outArr = excludeValuesFromArray(inArr, ['banana', 'orange']);
+      expect(outArr).toEqual(['apple', 'raisin', 'blueberry']);
+    });
   });
 });

--- a/packages/core/src/utils/string-utils.ts
+++ b/packages/core/src/utils/string-utils.ts
@@ -3,3 +3,9 @@ export function pluralize(str, strLn, customPluralStr = '') {
   const pluralStr = customPluralStr || `${str}s`;
   return strLn > 1 ? pluralStr : str;
 }
+
+/** Returns an array of strings minus any excluded values */
+export function excludeValuesFromArray(inputValues: string[], excludeValues: string[]) {
+  const checker = (value) => !excludeValues.some((element) => value === element);
+  return inputValues.filter(checker);
+}

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -296,6 +296,9 @@ Removal of complex object value(s) are also supported via the dot notation as sh
 lerna version --remove-package-fields 'scripts.build'
 ```
 
+> **Note** lifecycle scripts are executed after the field removal process and for that reason if any of these scripts are found, it will not delete them and completely skip them whenever found (`prepublish`, `prepublishOnly`, `prepack`, `postpack`).
+
+
 ##### output
 
 ```diff

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -290,14 +290,13 @@ Remove certain fields from every package before publishing them to the registry,
 lerna version --remove-package-fields 'devDependencies' 'scripts'
 ```
 
+> **Note** lifecycle scripts (`prepublish`, `prepublishOnly`, `prepack`, `postpack`) are executed after the field removal process and for that reason if any of these scripts are found, it will leave them in place and skip the removal whenever found.
+
 Removal of complex object value(s) are also supported via the dot notation as shown below.
 
 ```sh
 lerna version --remove-package-fields 'scripts.build'
 ```
-
-> **Note** lifecycle scripts are executed after the field removal process and for that reason if any of these scripts are found, it will not delete them and completely skip them whenever found (`prepublish`, `prepublishOnly`, `prepack`, `postpack`).
-
 
 ##### output
 

--- a/packages/publish/src/__tests__/__fixtures__/remove-fields/packages/package-1/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/remove-fields/packages/package-1/package.json
@@ -5,6 +5,8 @@
   "browser": "src/index.ts",
   "main": "dist/cjs/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.json"
+    "build": "tsc --project tsconfig.json",
+    "prepack": "echo from prepack-1",
+    "postpack": "echo from postpack-1"
   }
 }

--- a/packages/publish/src/__tests__/__fixtures__/remove-fields/packages/package-4/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/remove-fields/packages/package-4/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "build:dev": "tsc --incremental --watch"
+    "build:dev": "tsc --incremental --watch",
+    "prepack": "echo from prepack-4",
+    "postpack": "echo from postpack-4"
   }
 }

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -31,7 +31,9 @@
     "prebuild": "rimraf dist",
     "build": "tsc",
     "build:incremental": "tsc --incremental --sourceMap false --excludeDirectories dist",
-    "pack-tarball": "npm pack"
+    "pack-tarball": "npm pack",
+    "prepack": "echo hello from prepack",
+    "postpack": "echo hello from postpack"
   },
   "license": "MIT",
   "author": "Ghislain B.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

when executing `--remove-package-fields 'scripts'`, we should skip the removal of any lifecycle scripts (`prepublish`, `prepublishOnly`, `prepack`, `postpack`) because these scripts needs to be executed after the field removal process.

## Motivation and Context

fixes #637 were it failed publishing because some of these lifecycle scripts were being defined crashed because at the time of the lifecycle execution the script was already deleted. 

Also note that I tried to move the execution of the field removal to after the `packUpdated()` call (as I wrote in this [comment](https://github.com/lerna-lite/lerna-lite/issues/637#issuecomment-1587816645) but then at that point it's too late to remove since we already packed the tarball, it's a chicken and egg kinda problem, so the easisst way to deal with this is to keep these special lifecycle scripts in place when found and delete the rest

## How Has This Been Tested?

add unit tests and also test locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
