### PR TITLE
chore: add Vitest quote serializer everywhere to avoid no-thread diff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,4 @@ We'd love for you to contribute and to make this project even better than it is 
 5. add/run Vitest unit tests (make sure to run the previous steps first):
    - `pnpm test` (watch mode)
    - `pnpm test:coverage` (full test coverage)
-6. If you did step 2 up to 5, then the final step would be the Pull Request... but wait! For readability purposes, we would like you to only submit the relevant pieces of code that you changed. We are basically asking you to do a Build and make sure there's no errors (Yes please) but to not include the produced `dist` folder. We just want to see the real changes, nothing else (but we still want to make sure it Builds before creating a PR).
-
-> **Note** running the unit tests might failed when run one at a time because of this Vitest [bug](https://github.com/vitest-dev/vitest/issues/3129), the issue is with quote escaping in snapshot (sometime it uses single quote, sometime double, sometime none). The only known fix is to ignore snapshot escaping when running single tests, however when running "all tests" then it should always pass. It doesn't look like Vitest will fix it any time soon, so it's unfortunately a bug we have to live with for now. Again just make sure that when running "all tests" it passes successfully. 
+6. after achieving step 2 to 5, then the final step would be to create the Pull Request...

--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -18,6 +18,17 @@ import { NpaResolveResult, RawManifest } from '../models';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// remove quotes around top-level strings
+expect.addSnapshotSerializer({
+  test(val) {
+    return typeof val === 'string';
+  },
+  serialize(val, config, indentation, depth) {
+    // top-level strings don't need quotes, but nested ones do (object properties, etc)
+    return depth ? `"${val}"` : val;
+  },
+});
+
 describe('Package', () => {
   const factory = (json) => new Package(json, normalize(`/root/path/to/${json.name || 'package'}`), normalize('/root'));
 
@@ -391,9 +402,9 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            peerDependencies: {
-              a: ^1.0.0,
-              b: ^1.0.0,
+            "peerDependencies": {
+              "a": "^1.0.0",
+              "b": "^1.0.0",
             },
           }
         `);
@@ -415,9 +426,9 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            peerDependencies: {
-              a: ^2.0.0,
-              b: >=1.0.0,
+            "peerDependencies": {
+              "a": "^2.0.0",
+              "b": ">=1.0.0",
             },
           }
         `);
@@ -439,9 +450,9 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            peerDependencies: {
-              a: ^1.0.0-alpha.1,
-              b: >=1.0.0-alpha.0,
+            "peerDependencies": {
+              "a": "^1.0.0-alpha.1",
+              "b": ">=1.0.0-alpha.0",
             },
           }
         `);
@@ -463,9 +474,9 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            peerDependencies: {
-              a: ^1.0.0-alpha.1+SHA,
-              b: >=1.0.0-alpha.0+SHA,
+            "peerDependencies": {
+              "a": "^1.0.0-alpha.1+SHA",
+              "b": ">=1.0.0-alpha.0+SHA",
             },
           }
         `);
@@ -491,12 +502,12 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: workspace:^2.0.0,
-              b: workspace:>=1.0.0,
-              c: workspace:./foo,
-              d: file:./foo,
-              e: ^1.0.0,
+            "dependencies": {
+              "a": "workspace:^2.0.0",
+              "b": "workspace:>=1.0.0",
+              "c": "workspace:./foo",
+              "d": "file:./foo",
+              "e": "^1.0.0",
             },
           }
         `);
@@ -527,16 +538,16 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: workspace:^2.0.0,
-              b: workspace:>=1.0.0,
-              c: workspace:./foo,
-              d: file:./foo,
-              e: ^1.0.0,
+            "dependencies": {
+              "a": "workspace:^2.0.0",
+              "b": "workspace:>=1.0.0",
+              "c": "workspace:./foo",
+              "d": "file:./foo",
+              "e": "^1.0.0",
             },
-            peerDependencies: {
-              a: workspace:^2.0.0,
-              b: workspace:>=1.0.0,
+            "peerDependencies": {
+              "a": "workspace:^2.0.0",
+              "b": "workspace:>=1.0.0",
             },
           }
         `);
@@ -563,15 +574,15 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: workspace:^2.0.0,
-              b: workspace:>=1.0.0,
-              c: workspace:./foo,
-              d: file:./foo,
-              e: ^1.0.0,
+            "dependencies": {
+              "a": "workspace:^2.0.0",
+              "b": "workspace:>=1.0.0",
+              "c": "workspace:./foo",
+              "d": "file:./foo",
+              "e": "^1.0.0",
             },
-            peerDependencies: {
-              a: workspace:>=1.0.0,
+            "peerDependencies": {
+              "a": "workspace:>=1.0.0",
             },
           }
         `);
@@ -598,15 +609,15 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: workspace:^2.0.0,
-              b: workspace:>=1.0.0,
-              c: workspace:./foo,
-              d: file:./foo,
-              e: ^1.0.0,
+            "dependencies": {
+              "a": "workspace:^2.0.0",
+              "b": "workspace:>=1.0.0",
+              "c": "workspace:./foo",
+              "d": "file:./foo",
+              "e": "^1.0.0",
             },
-            peerDependencies: {
-              a: workspace:>=1.0.0 < 2.0.0,
+            "peerDependencies": {
+              "a": "workspace:>=1.0.0 < 2.0.0",
             },
           }
         `);
@@ -627,9 +638,9 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            devDependencies: {
-              a: workspace:*,
-              b: workspace:^1.0.0,
+            "devDependencies": {
+              "a": "workspace:*",
+              "b": "workspace:^1.0.0",
             },
           }
         `);
@@ -650,9 +661,9 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            optionalDependencies: {
-              a: workspace:^,
-              b: workspace:^1.0.0,
+            "optionalDependencies": {
+              "a": "workspace:^",
+              "b": "workspace:^1.0.0",
             },
           }
         `);
@@ -673,9 +684,9 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: workspace:~,
-              b: workspace:^1.0.0,
+            "dependencies": {
+              "a": "workspace:~",
+              "b": "workspace:^1.0.0",
             },
           }
         `);
@@ -698,11 +709,11 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              b: workspace:^1.0.0,
+            "dependencies": {
+              "b": "workspace:^1.0.0",
             },
-            peerDependencies: {
-              a: workspace:2.0.0,
+            "peerDependencies": {
+              "a": "workspace:2.0.0",
             },
           }
         `);
@@ -723,9 +734,9 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: workspace:>=1.2.0,
-              b: workspace:^1.0.0,
+            "dependencies": {
+              "a": "workspace:>=1.2.0",
+              "b": "workspace:^1.0.0",
             },
           }
         `);
@@ -755,13 +766,13 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: 2.0.0,
-              b: ^1.1.0,
+            "dependencies": {
+              "a": "2.0.0",
+              "b": "^1.1.0",
             },
-            peerDependencies: {
-              a: >=1.0.0,
-              b: ^1.1.0,
+            "peerDependencies": {
+              "a": ">=1.0.0",
+              "b": "^1.1.0",
             },
           }
         `);
@@ -789,13 +800,13 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: ^2.0.0,
-              b: ~1.1.0,
+            "dependencies": {
+              "a": "^2.0.0",
+              "b": "~1.1.0",
             },
-            peerDependencies: {
-              a: ^2.0.0,
-              b: ~1.1.0,
+            "peerDependencies": {
+              "a": "^2.0.0",
+              "b": "~1.1.0",
             },
           }
         `);
@@ -824,13 +835,13 @@ describe('Package', () => {
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: ~2.0.0,
-              b: ^1.1.0,
+            "dependencies": {
+              "a": "~2.0.0",
+              "b": "^1.1.0",
             },
-            peerDependencies: {
-              a: >=1.0.0,
-              b: ~1.0.0,
+            "peerDependencies": {
+              "a": ">=1.0.0",
+              "b": "~1.0.0",
             },
           }
         `);
@@ -866,12 +877,12 @@ describe('Package', () => {
         );
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
-            dependencies: {
-              a: latest,
-              b: ^2.2.4,
+            "dependencies": {
+              "a": "latest",
+              "b": "^2.2.4",
             },
-            peerDependencies: {
-              b: ^2.2.4,
+            "peerDependencies": {
+              "b": "^2.2.4",
             },
           }
         `);

--- a/packages/core/src/package-graph/__tests__/package-graph.spec.ts
+++ b/packages/core/src/package-graph/__tests__/package-graph.spec.ts
@@ -16,7 +16,7 @@ describe('PackageGraph', () => {
         new Package({ name: 'pkg-2', version: '3.0.0' } as Package, '/test/pkg-3', '/test'),
       ];
 
-      expect(() => new PackageGraph(pkgs)).toThrowErrorMatchingSnapshot();
+      expect(() => new PackageGraph(pkgs)).toThrowError('Package name "pkg-2" used in multiple packages:\n\t/test/pkg-2\n\t/test/pkg-3');
     });
 
     it('externalizes non-satisfied semver of local sibling', () => {

--- a/packages/core/src/project/__tests__/project.spec.ts
+++ b/packages/core/src/project/__tests__/project.spec.ts
@@ -4,6 +4,17 @@ import { outputFile, remove, writeJson } from 'fs-extra/esm';
 import { basename, dirname, join, resolve as pathResolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// remove quotes around top-level strings
+expect.addSnapshotSerializer({
+  test(val) {
+    return typeof val === 'string';
+  },
+  serialize(val, config, indentation, depth) {
+    // top-level strings don't need quotes, but nested ones do (object properties, etc)
+    return depth ? `"${val}"` : val;
+  },
+});
+
 // Serialize the JSONError output to be more human readable
 expect.addSnapshotSerializer({
   serialize(str: string) {
@@ -78,7 +89,7 @@ describe('Project', () => {
 
       expect(new Project(cwd).config).toMatchInlineSnapshot(`
         {
-          version: 1.0.0,
+          "version": "1.0.0",
         }
       `);
     });
@@ -237,15 +248,15 @@ describe('Project', () => {
       expect(result).toMatchInlineSnapshot(`
         [
           {
-            name: pkg-1,
-            version: 1.0.0,
+            "name": "pkg-1",
+            "version": "1.0.0",
           },
           {
-            dependencies: {
-              pkg-1: ^1.0.0,
+            "dependencies": {
+              "pkg-1": "^1.0.0",
             },
-            name: pkg-2,
-            version: 1.0.0,
+            "name": "pkg-2",
+            "version": "1.0.0",
           },
         ]
       `);
@@ -263,15 +274,15 @@ describe('Project', () => {
       expect(project.getPackagesSync()).toMatchInlineSnapshot(`
         [
           {
-            name: pkg-1,
-            version: 1.0.0,
+            "name": "pkg-1",
+            "version": "1.0.0",
           },
           {
-            dependencies: {
-              pkg-1: ^1.0.0,
+            "dependencies": {
+              "pkg-1": "^1.0.0",
             },
-            name: pkg-2,
-            version: 1.0.0,
+            "name": "pkg-2",
+            "version": "1.0.0",
           },
         ]
       `);

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -74,6 +74,17 @@ import { getTwoFactorAuthRequired } from '../lib/get-two-factor-auth-required';
 import { gitCheckout } from '../lib/git-checkout';
 import * as npmDistTag from '../lib/npm-dist-tag';
 
+// remove quotes around top-level strings
+expect.addSnapshotSerializer({
+  test(val) {
+    return typeof val === 'string';
+  },
+  serialize(val, config, indentation, depth) {
+    // top-level strings don't need quotes, but nested ones do (object properties, etc)
+    return depth ? `"${val}"` : val;
+  },
+});
+
 const createArgv = (cwd, ...args) => {
   args.unshift('publish');
   if (args.length > 0 && args[1]?.length > 0 && !args[1].startsWith('-')) {
@@ -152,18 +163,18 @@ describe('PublishCommand', () => {
       expect(promptConfirmation).toHaveBeenLastCalledWith('Are you sure you want to publish these packages?');
       expect((packDirectory as any).registry).toMatchInlineSnapshot(`
         Set {
-          package-1,
-          package-4,
-          package-2,
-          package-3,
+          "package-1",
+          "package-4",
+          "package-2",
+          "package-3",
         }
       `);
       expect((npmPublish as typeof npmPublishMock).registry).toMatchInlineSnapshot(`
         Map {
-          package-1 => latest,
-          package-4 => latest,
-          package-2 => latest,
-          package-3 => latest,
+          "package-1" => "latest",
+          "package-4" => "latest",
+          "package-2" => "latest",
+          "package-3" => "latest",
         }
       `);
       expect((npmPublish as typeof npmPublishMock).order()).toEqual([
@@ -197,18 +208,18 @@ describe('PublishCommand', () => {
       expect(promptConfirmation).toHaveBeenLastCalledWith('Are you sure you want to publish these packages?');
       expect((packDirectory as any).registry).toMatchInlineSnapshot(`
         Set {
-          @my-workspace/package-1,
-          @my-workspace/package-4,
-          @my-workspace/package-2,
-          @my-workspace/package-3,
+          "@my-workspace/package-1",
+          "@my-workspace/package-4",
+          "@my-workspace/package-2",
+          "@my-workspace/package-3",
         }
       `);
       expect((npmPublish as typeof npmPublishMock).registry).toMatchInlineSnapshot(`
         Map {
-          @my-workspace/package-1 => latest,
-          @my-workspace/package-4 => latest,
-          @my-workspace/package-2 => latest,
-          @my-workspace/package-3 => latest,
+          "@my-workspace/package-1" => "latest",
+          "@my-workspace/package-4" => "latest",
+          "@my-workspace/package-2" => "latest",
+          "@my-workspace/package-3" => "latest",
         }
       `);
       expect((npmPublish as typeof npmPublishMock).order()).toEqual([
@@ -289,8 +300,8 @@ describe('PublishCommand', () => {
       const logMessages = loggingOutput('warn');
       expect(logMessages).toMatchInlineSnapshot(`
         [
-          --graph-type=dependencies is deprecated and will be removed in the next major version of lerna-lite. If you have a use-case you feel requires it please open an issue to discuss: https://github.com/lerna/lerna/issues/new/choose,
-          we recommend using --sync-workspace-lock which will sync your lock file via your favorite npm client instead of relying on Lerna-Lite itself to update it.,
+          "--graph-type=dependencies is deprecated and will be removed in the next major version of lerna-lite. If you have a use-case you feel requires it please open an issue to discuss: https://github.com/lerna/lerna/issues/new/choose",
+          "we recommend using --sync-workspace-lock which will sync your lock file via your favorite npm client instead of relying on Lerna-Lite itself to update it.",
         ]
       `);
     });
@@ -545,18 +556,18 @@ describe('PublishCommand', () => {
       expect(promptConfirmation).toHaveBeenLastCalledWith('Are you sure you want to publish these packages?');
       expect((packDirectory as any).registry).toMatchInlineSnapshot(`
         Set {
-          package-1,
-          package-4,
-          package-2,
-          package-3,
+          "package-1",
+          "package-4",
+          "package-2",
+          "package-3",
         }
       `);
       expect((npmPublish as typeof npmPublishMock).registry).toMatchInlineSnapshot(`
         Map {
-          package-1 => latest,
-          package-4 => latest,
-          package-2 => latest,
-          package-3 => latest,
+          "package-1" => "latest",
+          "package-4" => "latest",
+          "package-2" => "latest",
+          "package-3" => "latest",
         }
       `);
       expect((npmPublish as typeof npmPublishMock).order()).toEqual([

--- a/packages/publish/src/__tests__/publish-licenses.spec.ts
+++ b/packages/publish/src/__tests__/publish-licenses.spec.ts
@@ -108,11 +108,11 @@ describe('licenses', () => {
     await lernaPublish(cwd)('--no-manually-update-root-lockfile');
 
     const [warning] = loggingOutput('warn');
-    expect(warning).toMatchInlineSnapshot(`
-      Packages package-1 and package-3 are missing a license.
-      One way to fix this is to add a LICENSE.md file to the root of this repository.
-      See https://choosealicense.com for additional guidance.
-    `);
+    expect(warning).toBe(
+      'Packages package-1 and package-3 are missing a license.\n' +
+        'One way to fix this is to add a LICENSE.md file to the root of this repository.\n' +
+        'See https://choosealicense.com for additional guidance.'
+    );
 
     expect(createTempLicenses).toHaveBeenLastCalledWith(undefined, []);
     expect(removeTempLicenses).toHaveBeenLastCalledWith([]);

--- a/packages/publish/src/__tests__/publish-tagging.spec.ts
+++ b/packages/publish/src/__tests__/publish-tagging.spec.ts
@@ -91,12 +91,12 @@ test('publish --temp-tag', async () => {
 
   await new PublishCommand(createArgv(cwd, '--temp-tag'));
 
-  expect((npmPublish as any).registry).toMatchInlineSnapshot(`
-    Map {
-      @integration/package-1 => lerna-temp,
-      @integration/package-2 => lerna-temp,
-    }
-  `);
+  expect((npmPublish as any).registry).toEqual(
+    new Map([
+      ['@integration/package-1', 'lerna-temp'],
+      ['@integration/package-2', 'lerna-temp'],
+    ])
+  );
 
   const conf = expect.objectContaining({
     tag: 'latest',
@@ -117,12 +117,12 @@ test('publish --dist-tag beta --temp-tag', async () => {
 
   await new PublishCommand(createArgv(cwd, '--dist-tag', 'beta', '--temp-tag'));
 
-  expect((npmPublish as any).registry).toMatchInlineSnapshot(`
-    Map {
-      @integration/package-1 => lerna-temp,
-      @integration/package-2 => lerna-temp,
-    }
-  `);
+  expect((npmPublish as any).registry).toEqual(
+    new Map([
+      ['@integration/package-1', 'lerna-temp'],
+      ['@integration/package-2', 'lerna-temp'],
+    ])
+  );
 
   const conf = expect.objectContaining({
     tag: 'beta',
@@ -173,12 +173,12 @@ test('publish --pre-dist-tag beta --temp-tag', async () => {
 
   await new PublishCommand(createArgv(cwd, '--bump', 'prerelease', '--dist-tag', 'next', '--preid', 'beta', '--pre-dist-tag', 'beta', '--temp-tag'));
 
-  expect((npmPublish as any).registry).toMatchInlineSnapshot(`
-    Map {
-      @integration/package-1 => lerna-temp,
-      @integration/package-2 => lerna-temp,
-    }
-  `);
+  expect((npmPublish as any).registry).toEqual(
+    new Map([
+      ['@integration/package-1', 'lerna-temp'],
+      ['@integration/package-2', 'lerna-temp'],
+    ])
+  );
 
   const conf = expect.objectContaining({
     tag: 'next',

--- a/packages/run/src/__tests__/__snapshots__/run-command.spec.ts.snap
+++ b/packages/run/src/__tests__/__snapshots__/run-command.spec.ts.snap
@@ -2,46 +2,46 @@
 
 exports[`RunCommand > in a basic repo > omits package prefix with --parallel --no-prefix 1`] = `
 [
-  packages/package-1 npm run env (prefixed: false),
-  packages/package-2 npm run env (prefixed: false),
-  packages/package-3 npm run env (prefixed: false),
-  packages/package-4 npm run env (prefixed: false),
+  "packages/package-1 npm run env (prefixed: false)",
+  "packages/package-2 npm run env (prefixed: false)",
+  "packages/package-3 npm run env (prefixed: false)",
+  "packages/package-4 npm run env (prefixed: false)",
 ]
 `;
 
 exports[`RunCommand > in a basic repo > omits package prefix with --stream --no-prefix 1`] = `
 [
-  packages/package-1 npm run my-script (prefixed: false),
-  packages/package-3 npm run my-script (prefixed: false),
+  "packages/package-1 npm run my-script (prefixed: false)",
+  "packages/package-3 npm run my-script (prefixed: false)",
 ]
 `;
 
 exports[`RunCommand > in a basic repo > run in --stream and --no-bail 1`] = `
 [
-  packages/package-1 npm run my-script (prefixed: true),
-  packages/package-3 npm run my-script (prefixed: true),
+  "packages/package-1 npm run my-script (prefixed: true)",
+  "packages/package-3 npm run my-script (prefixed: true)",
 ]
 `;
 
 exports[`RunCommand > in a basic repo > runs a script in all packages with --parallel 1`] = `
 [
-  packages/package-1 npm run env (prefixed: true),
-  packages/package-2 npm run env (prefixed: true),
-  packages/package-3 npm run env (prefixed: true),
-  packages/package-4 npm run env (prefixed: true),
+  "packages/package-1 npm run env (prefixed: true)",
+  "packages/package-2 npm run env (prefixed: true)",
+  "packages/package-3 npm run env (prefixed: true)",
+  "packages/package-4 npm run env (prefixed: true)",
 ]
 `;
 
 exports[`RunCommand > in a basic repo > runs a script in packages with --stream 1`] = `
 [
-  packages/package-1 npm run my-script (prefixed: true),
-  packages/package-3 npm run my-script (prefixed: true),
+  "packages/package-1 npm run my-script (prefixed: true)",
+  "packages/package-3 npm run my-script (prefixed: true)",
 ]
 `;
 
 exports[`RunCommand > in a basic repo > runs package prefix with --stream and expect it to be prefixed 1`] = `
 [
-  packages/package-1 npm run my-script (prefixed: true),
-  packages/package-3 npm run my-script (prefixed: true),
+  "packages/package-1 npm run my-script (prefixed: true)",
+  "packages/package-3 npm run my-script (prefixed: true)",
 ]
 `;

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -52,6 +52,17 @@ const ranInPackagesStreaming = (testDir: string) =>
     return arr;
   }, []);
 
+// remove quotes around top-level strings
+expect.addSnapshotSerializer({
+  test(val) {
+    return typeof val === 'string';
+  },
+  serialize(val, config, indentation, depth) {
+    // top-level strings don't need quotes, but nested ones do (object properties, etc)
+    return depth ? `"${val}"` : val;
+  },
+});
+
 const createArgv = (cwd: string, script?: string, ...args: any[]) => {
   args.unshift('run');
   const parserArgs = args.join(' ');
@@ -286,15 +297,15 @@ describe('RunCommand', () => {
 
       expect(ranInPackagesStreaming(testDir)).toMatchInlineSnapshot(`
         [
-          packages/package-cycle-1 npm run env (prefixed: true),
-          packages/package-cycle-2 npm run env (prefixed: true),
-          packages/package-cycle-extraneous-1 npm run env (prefixed: true),
-          packages/package-cycle-extraneous-2 npm run env (prefixed: true),
-          packages/package-dag-1 npm run env (prefixed: true),
-          packages/package-dag-2a npm run env (prefixed: true),
-          packages/package-dag-2b npm run env (prefixed: true),
-          packages/package-dag-3 npm run env (prefixed: true),
-          packages/package-standalone npm run env (prefixed: true),
+          "packages/package-cycle-1 npm run env (prefixed: true)",
+          "packages/package-cycle-2 npm run env (prefixed: true)",
+          "packages/package-cycle-extraneous-1 npm run env (prefixed: true)",
+          "packages/package-cycle-extraneous-2 npm run env (prefixed: true)",
+          "packages/package-dag-1 npm run env (prefixed: true)",
+          "packages/package-dag-2a npm run env (prefixed: true)",
+          "packages/package-dag-2b npm run env (prefixed: true)",
+          "packages/package-dag-3 npm run env (prefixed: true)",
+          "packages/package-standalone npm run env (prefixed: true)",
         ]
       `);
     });

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -101,7 +101,52 @@ describe('npm modern lock file', () => {
     }
 
     // expect(Array.from((loadJsonFile as any).registry.keys())).toStrictEqual(['/packages/package-1', '/packages/package-2', '/']);
-    expect(readJsonSync(rootLockFilePath)).toMatchSnapshot();
+    expect(readJsonSync(rootLockFilePath)).toEqual({
+      dependencies: {
+        '@my-workspace/package-1': {
+          requires: { 'tiny-tarball': '^1.0.0' },
+          version: 'file:packages/package-1',
+        },
+        '@my-workspace/package-2': {
+          requires: { '@my-workspace/package-1': '^2.4.0' },
+          version: 'file:packages/package-2',
+        },
+      },
+      lockfileVersion: 2,
+      name: 'my-workspace',
+      packages: {
+        '': {
+          license: 'MIT',
+          name: 'my-workspace',
+          workspaces: ['./packages/package-1', './packages/package-2'],
+        },
+        'node_modules/package-1': {
+          link: true,
+          resolved: 'packages/package-1',
+        },
+        'node_modules/package-2': {
+          link: true,
+          resolved: 'packages/package-2',
+        },
+        'packages/package-1': {
+          license: 'MIT',
+          name: '@my-workspace/package-1',
+          'tiny-tarball': {
+            integrity: 'sha1-u/EC1a5zr+LFUyleD7AiMCFvZbE=',
+            resolved: 'https://registry.npmjs.org/tiny-tarball/-/tiny-tarball-1.0.0.tgz',
+            version: '1.0.0',
+          },
+          version: '2.4.0',
+        },
+        'packages/package-2': {
+          dependencies: { '@my-workspace/package-1': '^2.4.0' },
+          license: 'MIT',
+          name: '@my-workspace/package-2',
+          version: '2.4.0',
+        },
+      },
+      requires: true,
+    });
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add Vitest snapshot serializer to all unit tests that use snapshots

## Motivation and Context

Fixes an issue with Vitest `--no-thread` which made unit tests work when run all at once but failed when ran one at a time. Basically the issue seemed to be that when run all at once it shared the global scope and were not equivalent, however adding the escape quote serializer to all unit tests makes them use the same serializer everywhere making them pass in all cases. 

## How Has This Been Tested?

ran multiple time in single mode and in all at once mode

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
