### PR TITLE
fix: strict-ssl mapping for node-fetch-registry during unpublished projects lookup

### DIFF
--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -75,6 +75,7 @@ export interface Manifest {
 }
 
 export interface FetchConfig {
+  [key: string]: unknown;
   fetchRetries: number;
   log: log.Logger;
   registry: string;

--- a/packages/publish/src/__tests__/get-unpublished-packages.spec.ts
+++ b/packages/publish/src/__tests__/get-unpublished-packages.spec.ts
@@ -95,3 +95,19 @@ test('getUnpublishedPackages with private package', async () => {
     ]
   `);
 });
+
+test('getUnpublishedPackages with strict-ssl = false', async () => {
+  const cwd = await initFixture('public-private');
+  const packages = await Project.getPackages(cwd);
+  const packageGraph = new PackageGraph(packages);
+
+  const opts = { 'strict-ssl': false };
+  const pkgs = await getUnpublishedPackages(packageGraph, opts as FetchConfig);
+
+  expect((pacote as any).packument).toHaveBeenCalledWith('package-1', { 'strict-ssl': false, strictSSL: false });
+  expect(pkgs).toEqual([
+    expect.objectContaining({
+      name: 'package-1',
+    }),
+  ]);
+});

--- a/packages/publish/src/lib/get-unpublished-packages.ts
+++ b/packages/publish/src/lib/get-unpublished-packages.ts
@@ -18,8 +18,10 @@ export function getUnpublishedPackages(packageGraph: PackageGraph, opts: FetchCo
   // @ts-ignore
   const graphNodesToCheck = Array.from(packageGraph.values()).filter(({ pkg }) => !pkg.private);
 
-  const mapper = (pkg) =>
-    pacote.packument(pkg?.name ?? '', opts).then(
+  const mapper = (pkg) => {
+    // libnpmpublish / npm-registry-fetch check strictSSL rather than strict-ssl
+    opts['strictSSL'] = opts['strict-ssl'];
+    return pacote.packument(pkg?.name ?? '', opts).then(
       (packument) => {
         if (packument.versions === undefined || packument.versions[pkg.version] === undefined) {
           return pkg;
@@ -30,6 +32,7 @@ export function getUnpublishedPackages(packageGraph: PackageGraph, opts: FetchCo
         return pkg;
       }
     );
+  };
 
   chain = chain.then(() => pMap(graphNodesToCheck, mapper, { concurrency: 4 }));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION

## Description

As per [Lerna PR 3747](https://github.com/lerna/lerna/pull/3747)

> There is a missing mapping of strict-ssl for unpublished projects lookup.
This results into falsy unpublished projects.

## Motivation and Context

We are using lerna to automatically determine which packages are unpublished. We have encountered the issue it tries to publish packages again and again regardless if they are already published.
With debugging I have found out there is an issue using the given strict-ssl attribute. It is not passed to pacote correctly.

In general it is the same issue like here as Lerna [issue 2952](https://github.com/lerna/lerna/pull/2952)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
