### PR TITLE
fix(publish): catch publish conflict 403 error from npm

### DIFF
--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -931,7 +931,10 @@ export class PublishCommand extends Command<PublishCommandOption> {
                 return pkg;
               })
               .catch((err) => {
-                if (err.code === 'EPUBLISHCONFLICT') {
+                if (
+                  err.code === 'EPUBLISHCONFLICT' ||
+                  (err.code === 'E403' && err.body?.error?.includes('You cannot publish over the previously published versions'))
+                ) {
                   tracker.warn('publish', `Package is already published: ${pkg.name}@${pkg.version}`);
                   tracker.completeWork(1);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna [PR 3753](https://github.com/lerna/lerna/pull/3753)

> Catches another possible form of publish conflict error from npm.

## Motivation and Context

As per Lerna PR

> Some permission setups on npm were causing a 403 error instead of the EPUBLISHCONFLICT code, and this ensures they are caught appropriately.

## How Has This Been Tested?

As per Lerna PR

> This has been tested manually by publishing packages to npm with conflicts, observing the error in Lerna, then testing it again with this change and observing Lerna properly swallow the error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
