### PR TITLE
fix: CJS fallbacks should be at the end not at beginning

### DIFF
--- a/packages/changed/package.json
+++ b/packages/changed/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,9 +13,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -31,6 +28,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,9 +9,6 @@
     "/dist"
   ],
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -29,6 +26,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/filter-packages/package.json
+++ b/packages/filter-packages/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/listable/package.json
+++ b/packages/listable/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",

--- a/packages/watch/package.json
+++ b/packages/watch/package.json
@@ -9,9 +9,6 @@
     "access": "public"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -27,6 +24,9 @@
       ]
     }
   },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",


### PR DESCRIPTION
## Description

better hybrid CJS/ESM support

## Motivation and Context

when defining the old CJS `main` and `module`, these properties should come after `exports` (new ESM prop) so that newer NodeJS will try `exports` first (we shouldn't try the fallback first), while for old NodeJS it will automatically use the fallbacks since `exports` won't work, see this TypeScript for more info (https://www.typescriptlang.org/docs/handbook/esm-node.html)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
