### PR TITLE
fix(version): skipBumpOnlyReleases reimplementation, fixes #703

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
       "runtimeExecutable": "node",
       "runtimeArgs": ["--nolazy", "-r", "tsm"],
       "args": [
-        "packages/cli/src/cli.ts",
+        "packages/cli/dist/cli.js",
         "version",
         "--dry-run",
         "--changelog-include-commits-client-login",

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Below are the main reasons as to why this fork was created:
    - [lerna version --changelog-header-message "msg"](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#--changelog-header-message-msg) it could be used to add sponsor badges in changelogs
    - [lerna version --changelog-include-commits-client-login](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#--changelog-include-commits-client-login-msg) to add PR contributors
    - [lerna version --allow-peer-dependencies-update](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#--allow-peer-dependencies-update) if you want your peer deps to also be updated
-   - [lerna version --skip-bump-only-release](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#--skip-bump-only-release) to avoid cluttering your GitHub releases in `independent` mode
+   - [lerna version --skip-bump-only-releases](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#--skip-bump-only-releases) to avoid cluttering your GitHub releases in `independent` mode
    - [lerna publish --remove-package-fields](https://github.com/lerna-lite/lerna-lite/tree/main/packages/publish#--remove-package-fields-fields) (remove certain fields from `package.json` before publishing)
       - ie: Lerna-Lite itself uses it to remove `scripts` and `devDependencies`
 

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -661,6 +661,9 @@
             "skipBumpOnlyRelease": {
               "$ref": "#/$defs/commandOptions/version/skipBumpOnlyRelease"
             },
+            "skipBumpOnlyReleases": {
+              "$ref": "#/$defs/commandOptions/version/skipBumpOnlyReleases"
+            },
             "syncWorkspaceLock": {
               "$ref": "#/$defs/commandOptions/version/syncWorkspaceLock"
             },
@@ -1384,6 +1387,10 @@
           "description": "During `lerna version`, when true, pass the `--force` flag to `git tag`."
         },
         "skipBumpOnlyRelease": {
+          "type": "boolean",
+          "description": "(deprecated) renamed to plural name \"--skip-bump-only-releases\". Skip GitHub/GitLab release creation when the version is a \"Version bump only for package x\""
+        },
+        "skipBumpOnlyReleases": {
           "type": "boolean",
           "description": "Skip GitHub/GitLab release creation when the version is a \"Version bump only for package x\""
         },

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -295,8 +295,11 @@ export interface VersionCommandOption {
   /** Additional arguments to pass to the npm client when performing 'npm install'. */
   npmClientArgs?: string[];
 
-  /** Defaults to false, should we skip GitHub/GitLab release creation when the version is a "Version bump only for package x" */
+  /** @deprecated @alias `skipBumpOnlyReleases` renamed previous flag from `skipBumpOnlyRelease` to `skipBumpOnlyReleases`. */
   skipBumpOnlyRelease?: boolean;
+
+  /** Defaults to false, should we skip GitHub/GitLab release creation when the version is a "Version bump only for package x" */
+  skipBumpOnlyReleases?: boolean;
 
   /** Runs `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient`. */
   syncWorkspaceLock?: boolean;

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -48,6 +48,7 @@ function shallowCopy(json: any) {
 export class Package {
   _id = '';
   name: string;
+  isBumpOnlyVersion = false;
   licensePath = '';
   localDependencies = new Map<string, any>();
 
@@ -170,7 +171,7 @@ export class Package {
     }
 
     // if provided by pkg.publishConfig.directory value
-    if (this[PKG].publishConfig && this[PKG].publishConfig.directory) {
+    if (this[PKG].publishConfig?.directory) {
       return join(this.location, this[PKG].publishConfig.directory);
     }
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -82,7 +82,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--changelog-header-message <msg>`](#--changelog-header-message-msg)
     - [`--create-release <type>`](#--create-release-type)
     - [`--create-release-discussion <name>`](#--create-release-discussion-name)
-    - [`--skip-bump-only-release`](#--skip-bump-only-release)
+    - [`--skip-bump-only-releases`](#--skip-bump-only-releases)
     - [`--describe-tag <pattern>`](#--describe-tag-pattern)
     - [`--exact`](#--exact)
     - [`--independent-subpackages`](#--independent-subpackages)
@@ -394,7 +394,7 @@ lerna version --conventional-commits --create-release gitlab
 
 When run with this flag, `lerna version` will create an official GitHub or GitLab release based on the changed packages. Requires `--conventional-commits` to be passed so that changelogs can be generated.
 
-> **Note** to avoid creating too many "Version bump only for package x" when using independent mode, you could enable the option `--skip-bump-only-release`
+> **Note** to avoid creating too many "Version bump only for package x" when using independent mode, you could enable the option `--skip-bump-only-releases`
 
 ### `--create-release-discussion <name>`
 
@@ -407,15 +407,17 @@ lerna version --conventional-commits --create-release github --create-release-di
 > **Note** currently only available for GitHub Releases following this GitHub blog post [You can now link discussions to new releases](https://github.blog/changelog/2021-04-06-releases-support-comments-and-reactions-with-discussion-linking/)
 
 
-### `--skip-bump-only-release`
+### `--skip-bump-only-releases`
 
 When this option is enabled and a package version is only being bumped without any conventional commits detected, the GitHub/GitLab release will be skipped. This will avoid creating releases with only "Version bump only for package x" in the release notes, however please note that each changelog are still going to be updated with the "version bump only" text.
 
+> **Note** first implemented as `--skip-bump-only-release` but later renamed to a plural option `--skip-bump-only-releases` which is a better option name to represent multiple releases can be skipped. 
+
 ```sh
-lerna version --create-release github --skip-bump-only-release
+lerna version --create-release github --skip-bump-only-releases
 
 # or the same for gitlab
-lerna version --create-release gitlab --skip-bump-only-release
+lerna version --create-release gitlab --skip-bump-only-releases
 ```
 
 ### `--describe-tag <pattern>`

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -608,6 +608,7 @@ describe('conventional-commits', () => {
         changelogPreset: './scripts/local-preset',
       });
 
+      expect(pkg2.isBumpOnlyVersion).toBeTruthy();
       expect(leafChangelog.newEntry.trimRight()).toMatchInlineSnapshot(`
         <a name="1.0.1"></a>
         ## <small>1.0.1 (YYYY-MM-DD)</small>

--- a/packages/version/src/conventional-commits/make-bump-only-filter.ts
+++ b/packages/version/src/conventional-commits/make-bump-only-filter.ts
@@ -10,6 +10,9 @@ export function makeBumpOnlyFilter(pkg: Package) {
   return (newEntry: string) => {
     // When force publishing, it is possible that there will be no actual changes, only a version bump.
     if (!newEntry.split('\n').some((line) => line.startsWith('*'))) {
+      // keep ref of a "bump only" in the package itself
+      pkg.isBumpOnlyVersion = true;
+
       // Add a note to indicate that only a version bump has occurred.
       // TODO: actually list the dependencies that were bumped
       const message = `**Note:** Version bump only for package ${pkg.name}`;

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -23,19 +23,19 @@ export async function createReleaseClient(type: 'github' | 'gitlab'): Promise<Gi
 export function createRelease(
   { client, releaseDiscussion }: { client: GitCreateReleaseClientOutput; releaseDiscussion?: string },
   { tags, releaseNotes }: ReleaseCommandProps,
-  { gitRemote, execOpts, skipBumpOnlyRelease }: ReleaseOptions,
+  { gitRemote, execOpts, skipBumpOnlyReleases }: ReleaseOptions,
   dryRun = false
 ) {
   const { GH_TOKEN } = process.env;
   const repo = parseGitRepo(gitRemote, execOpts);
 
   return Promise.all(
-    releaseNotes.map(({ notes, name }) => {
+    releaseNotes.map(({ notes, name, pkg }) => {
       const tag = name === 'fixed' ? tags[0] : tags.find((t) => t.startsWith(`${name}@`));
 
       // when using independent mode, it could happen that a few version bump only releases are created
       // and since these aren't very useful for most users, user could choose to skip creating these releases when detecting a version bump only
-      if (!tag || (skipBumpOnlyRelease && notes?.includes('**Note:** Version bump only for package'))) {
+      if (!tag || (skipBumpOnlyReleases && pkg?.isBumpOnlyVersion)) {
         return Promise.resolve();
       }
 

--- a/packages/version/src/models/index.ts
+++ b/packages/version/src/models/index.ts
@@ -1,4 +1,4 @@
-import { ExecOpts } from '@lerna-lite/core';
+import { ExecOpts, Package } from '@lerna-lite/core';
 import { GitRawCommitsOptions, ParserOptions } from 'conventional-changelog-core';
 import { Options as WriterOptions } from 'conventional-changelog-writer';
 import { Options as RecommendedBumpOptions } from 'conventional-recommended-bump';
@@ -37,6 +37,7 @@ export interface ChangelogConfig {
 export interface ReleaseNote {
   name: string;
   notes?: string;
+  pkg?: Package;
 }
 
 export type RemoteCommit = {
@@ -109,5 +110,5 @@ export interface ReleaseCommandProps {
 export interface ReleaseOptions {
   gitRemote: string;
   execOpts: ExecOpts;
-  skipBumpOnlyRelease?: boolean;
+  skipBumpOnlyReleases?: boolean;
 }

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -375,7 +375,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
         await createRelease(
           { client: this.releaseClient, releaseDiscussion: this.options.createReleaseDiscussion },
           { tags: this.tags, releaseNotes: this.releaseNotes },
-          { gitRemote: this.options.gitRemote, execOpts: this.execOpts, skipBumpOnlyRelease: this.options.skipBumpOnlyRelease },
+          { gitRemote: this.options.gitRemote, execOpts: this.execOpts, skipBumpOnlyReleases: this.options.skipBumpOnlyReleases ?? this.options.skipBumpOnlyRelease },
           this.options.dryRun
         );
       } catch (err: any) {
@@ -684,6 +684,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
             this.releaseNotes.push({
               name: pkg.name,
               notes: newEntry,
+              pkg,
             });
           }
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -375,7 +375,11 @@ export class VersionCommand extends Command<VersionCommandOption> {
         await createRelease(
           { client: this.releaseClient, releaseDiscussion: this.options.createReleaseDiscussion },
           { tags: this.tags, releaseNotes: this.releaseNotes },
-          { gitRemote: this.options.gitRemote, execOpts: this.execOpts, skipBumpOnlyReleases: this.options.skipBumpOnlyReleases ?? this.options.skipBumpOnlyRelease },
+          {
+            gitRemote: this.options.gitRemote,
+            execOpts: this.execOpts,
+            skipBumpOnlyReleases: this.options.skipBumpOnlyReleases ?? this.options.skipBumpOnlyRelease,
+          },
           this.options.dryRun
         );
       } catch (err: any) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reimplement `skipBumpOnlyRelease` to make it work properly in `independent` mode and also renamed to a plural name `skipBumpOnlyReleases` which better represent the fact that it can skip multiple bump only versions.

## Motivation and Context

Previous implementation was expecting that the changelog entry was only the current changes, however it turns out that it was the entire package changelog. A better implementation is to keep a boolean ref on each package and use it when it's time to create the release.

- fixes #703

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
