### PR TITLE
Revert "chore(deps): update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
         run: pnpm test:coverage
 
       - name: Upload test coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         if: |
           contains(matrix.node, 20) &&
           !contains(github.event.head_commit.message, 'chore(release)')


### PR DESCRIPTION
Reverts lerna-lite/lerna-lite#726 it looks like the v4 was actually supposed to be a Beta version and so code in production now throws and a revert is necessary 

> Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`