### PR TITLE
fix(publish): fix version conflict recognition for github packages

### DIFF
--- a/packages/publish/src/lib/is-npm-js-publish-version-conflict.ts
+++ b/packages/publish/src/lib/is-npm-js-publish-version-conflict.ts
@@ -1,0 +1,40 @@
+/**
+ * The purpose of this function is to determine whether the error object passed
+ * in represents a version conflict when publishing a package to the npm registry.
+ *
+ * An example of a version conflict error is:
+ * ```json
+ * {
+ *   "name": "HttpErrorGeneral",
+ *   "headers": {
+ *   },
+ *   "statusCode": 403,
+ *   "code": "E403",
+ *   "method": "PUT",
+ *   "uri": "https://registry.npmjs.org/@hyperledger%2fcactus-cmd-api-server",
+ *   "body": {
+ *       "success": false,
+ *       "error": "You cannot publish over the previously published versions: 2.0.0-alpha.2."
+ *   },
+ *   "pkgid": "@hyperledger/cactus-cmd-api-server@2.0.0-alpha.2",
+ *   "message": "403 Forbidden - PUT https://registry.npmjs.org/@hyperledger%2fcactus-cmd-api-server - You cannot publish over the previously published versions: 2.0.0-alpha.2."
+ * }
+ * ```
+ *
+ * @param ex The exception object to check for a version conflict error.
+ * @returns {boolean} true if the error represents a version conflict, false otherwise
+ */
+export function isNpmJsPublishVersionConflict(ex: unknown): boolean {
+  if (!ex || typeof ex !== 'object' || !(ex instanceof Error)) {
+    return false;
+  } else if ('code' in ex && ex.code === 'EPUBLISHCONFLICT') {
+    return true;
+  } else if (
+    'code' in ex &&
+    ex.code === 'E403' &&
+    ex.message?.includes('You cannot publish over the previously published versions')
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/packages/publish/src/lib/is-npm-pkg-github-publish-version-conflict.ts
+++ b/packages/publish/src/lib/is-npm-pkg-github-publish-version-conflict.ts
@@ -1,0 +1,41 @@
+/**
+ * The purpose of this function is to determine whether the exception object
+ * passed in represents a version conflict when publishing a package to the
+ * GitHub npm registry.
+ *
+ * An example of a version conflict error is pasted below:
+ *
+ * ```json
+ * {
+ *     "name": "HttpErrorGeneral",
+ *     "headers": {
+ *     },
+ *     "statusCode": 409,
+ *     "code": "E409",
+ *     "method": "PUT",
+ *     "uri": "https://npm.pkg.github.com/hyperledger/@hyperledger%2fcacti-cactus-cmd-api-server",
+ *     "body": {
+ *         "error": "Cannot publish over existing version"
+ *     },
+ *     "pkgid": "@hyperledger/cacti-cactus-cmd-api-server@2.0.0-alpha.2",
+ *     "message": "409 Conflict - PUT https://npm.pkg.github.com/hyperledger/@hyperledger%2fcacti-cactus-cmd-api-server - Cannot publish over existing version"
+ * }
+ * ```
+ * @param ex The exception object to check for a version conflict error.
+ * @returns {boolean} true if the error represents a version conflict, false otherwise.
+ */
+export function isNpmPkgGitHubPublishVersionConflict(ex: unknown): boolean {
+  if (!ex || typeof ex !== 'object' || !(ex instanceof Error)) {
+    return false;
+  } else if ('code' in ex && ex.code === 'E409') {
+    return true;
+  } else if (
+    'body' in ex &&
+    typeof ex.body === 'object' &&
+    (ex.body as Record<string, unknown>).error === 'Cannot publish over existing version'
+  ) {
+    return true;
+  } else {
+    return ex.message.startsWith('409 Conflict - PUT https://npm.pkg.github.com');
+  }
+}

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -53,6 +53,8 @@ import { removeTempLicenses } from './lib/remove-temp-licenses.js';
 import { createTempLicenses } from './lib/create-temp-licenses.js';
 import { getPackagesWithoutLicense } from './lib/get-packages-without-license.js';
 import { Tarball } from './models/index.js';
+import { isNpmJsPublishVersionConflict } from './lib/is-npm-js-publish-version-conflict.js';
+import { isNpmPkgGitHubPublishVersionConflict } from './lib/is-npm-pkg-github-publish-version-conflict.js';
 
 export function factory(argv: PublishCommandOption) {
   return new PublishCommand(argv);
@@ -931,13 +933,12 @@ export class PublishCommand extends Command<PublishCommandOption> {
                 return pkg;
               })
               .catch((err) => {
-                if (
-                  err.code === 'EPUBLISHCONFLICT' ||
-                  (err.code === 'E403' && err.body?.error?.includes('You cannot publish over the previously published versions'))
-                ) {
+                const isNpmJsComConflict = isNpmJsPublishVersionConflict(err);
+                const isNpmPkgGitHubComConflict = isNpmPkgGitHubPublishVersionConflict(err);
+
+                if (isNpmJsComConflict || isNpmPkgGitHubComConflict) {
                   tracker.warn('publish', `Package is already published: ${pkg.name}@${pkg.version}`);
                   tracker.completeWork(1);
-
                   return pkg;
                 }
 


### PR DESCRIPTION
## Description, Motivation and Context

The version conflict recognition logic was not working for github
because it returns a different `code` for the same error compared to
what npmjs.org returns.

I've added two utility functions to check for the error code and
message to make the code more readable in the error handler of the
publish operation.

This way there is a robust detection supporting both npmjs.com and
npm.pkg.github.com registries, not just npmjs.org.

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>

## How Has This Been Tested?

I've added a new test case within the file
`packages/publish/src/__tests__/publish-from-git.spec.ts`
to cover specifically the GitHub npm registry's error code,
so now the test verifies both npmjs.org and github.com registries
error codes not just npmjs.org as before.

I've also tested it manually, on a mono-repo I maintain where
there is a mixture of github and npmjs.org packages (e.g.
we publish to 2 different registries as part of the publish).

Before the change it would crash because it didn't correctly
recognize the version conflict failure coming back from github.

Now after the change, it prints the message that "all packages
have been published already" indicating that it successfully
detected all conflict errors as handled.

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
