### PR TITLE
feat: add `GITHUB_TOKEN` as valid alias to `GH_TOKEN`

### DIFF
--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -435,17 +435,17 @@ lerna version --describe-tag "*lerna-project*"
 ##### GitHub Auth Token
 To authenticate with GitHub, the following environment variables can be defined.
 
-- `GH_TOKEN` or `GITHUB_TOKEN` (required) - Your GitHub authentication token (under Settings > Developer settings > Personal access tokens), please give it the `repo:public_repo` scope when creating the token (for more info, refer to [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)).
-- `GHE_API_URL` - When using GitHub Enterprise, an absolute URL to the API.
-- `GHE_VERSION` - When using GitHub Enterprise, the currently installed GHE version. [Supports the following versions](https://github.com/octokit/plugin-enterprise-rest.js).
+- `GH_TOKEN` or `GITHUB_TOKEN`: Your GitHub authentication token (under Settings > Developer settings > Personal access tokens), please give it the `repo:public_repo` scope when creating the token (for more info, refer to [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)).
+- `GHE_API_URL`: When using GitHub Enterprise, an absolute URL to the API.
+- `GHE_VERSION`: When using GitHub Enterprise, the currently installed GHE version. [Supports the following versions](https://github.com/octokit/plugin-enterprise-rest.js).
 
-> **Note** even though `GH_TOKEN` (or `GITHUB_TOKEN`) is the preferred way to automate the creation of a GitHub Release (especially in a CI environment), we are also providing a more manual mode when the `GH_TOKEN` could not be found or read. In this mode, we will create a link that once click will open the GitHub web interface form with the fields pre-populated. This mode is enabled automatically when the `GH_TOKEN` environment variable is not set and `--create-release github` is provided.
+> **Note** even though `GH_TOKEN` (or `GITHUB_TOKEN`) is the preferred way to automate the creation of a GitHub Release (especially in a CI environment), we are also providing a more manual mode when the `GH_TOKEN` could not be found or read. For that use case (when token cannot be read), we will create a link that once clicked it will open the GitHub web interface form with the fields pre-populated. This mode is enabled automatically when `--create-release github` is enabled without providing a valid `GH_TOKEN` environment variable.
 
 ##### GitLab Auth Token
 To authenticate with GitLab, the following environment variables can be defined.
 
-- `GL_TOKEN` (required) - Your GitLab authentication token (under User Settings > Access Tokens).
-- `GL_API_URL` - An absolute URL to the API, including the version. (Default: https://gitlab.com/api/v4)
+- `GL_TOKEN` (required): Your GitLab authentication token (under User Settings > Access Tokens).
+- `GL_API_URL`: An absolute URL to the API, including the version. (Default: https://gitlab.com/api/v4)
 
 > **Note** When using this option, you cannot pass [`--no-changelog`](#--no-changelog).
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -341,7 +341,7 @@ Specify if we want to include commit remote client login (ie GitHub login userna
 
 This option is only available when using `--conventional-commits` with changelogs enabled. You must also provide 1 of these 2 options [`--create-release <type>`](#--create-release-type) or [`--remote-client <type>`](#--remote-client-type)
 
-> **Note** this will execute one or more client remote API calls (GH is limited to 100 per query), which at the moment is only supporting the GitHub client type. This option will also require a valid `GH_TOKEN` with read access permissions to the GitHub API so that it can execute the query to fetch all commit details since the last release, for more info refer to the [`Remote Client Auth Tokens`](#remote-client-auth-tokens) below.
+> **Note** this will execute one or more client remote API calls (GH is limited to 100 per query), which at the moment is only supporting the GitHub client type. This option will also require a valid `GH_TOKEN` (or `GITHUB_TOKEN`) with read access permissions to the GitHub API so that it can execute the query to fetch all commit details since the last release, for more info refer to the [`Remote Client Auth Tokens`](#remote-client-auth-tokens) below.
 
 > **Note** for this option to work properly, you must make sure that your local commits, on the current branch, are in sync with the remote server. It will then try to match all commits with their respective remote server commits and from there extract their associated remote client user login.
 
@@ -411,7 +411,7 @@ lerna version --conventional-commits --create-release github --create-release-di
 
 When this option is enabled and a package version is only being bumped without any conventional commits detected, the GitHub/GitLab release will be skipped. This will avoid creating releases with only "Version bump only for package x" in the release notes, however please note that each changelog are still going to be updated with the "version bump only" text.
 
-> **Note** first implemented as `--skip-bump-only-release` but later renamed to a plural option `--skip-bump-only-releases` which is a better option name to represent multiple releases can be skipped. 
+> **Note** first implemented as `--skip-bump-only-release` but later renamed to a plural option `--skip-bump-only-releases` which is a better option name to represent multiple releases can be skipped.
 
 ```sh
 lerna version --create-release github --skip-bump-only-releases
@@ -435,11 +435,11 @@ lerna version --describe-tag "*lerna-project*"
 ##### GitHub Auth Token
 To authenticate with GitHub, the following environment variables can be defined.
 
-- `GH_TOKEN` (required) - Your GitHub authentication token (under Settings > Developer settings > Personal access tokens), please give it the `repo:public_repo` scope when creating the token (for more info, refer to [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)).
+- `GH_TOKEN` or `GITHUB_TOKEN` (required) - Your GitHub authentication token (under Settings > Developer settings > Personal access tokens), please give it the `repo:public_repo` scope when creating the token (for more info, refer to [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)).
 - `GHE_API_URL` - When using GitHub Enterprise, an absolute URL to the API.
 - `GHE_VERSION` - When using GitHub Enterprise, the currently installed GHE version. [Supports the following versions](https://github.com/octokit/plugin-enterprise-rest.js).
 
-> **Note** even though `GH_TOKEN` is the preferred way to automate the creation of a GitHub Release (especially in a CI environment), we actually provide a more manual mode which is when the `GH_TOKEN` is not found. In this mode, we will create a link that once click will open the GitHub web interface form with the fields pre-populated. This mode is enabled automatically when the `GH_TOKEN` environment variable is not set and `--create-release github` is provided.
+> **Note** even though `GH_TOKEN` (or `GITHUB_TOKEN`) is the preferred way to automate the creation of a GitHub Release (especially in a CI environment), we are also providing a more manual mode when the `GH_TOKEN` could not be found or read. In this mode, we will create a link that once click will open the GitHub web interface form with the fields pre-populated. This mode is enabled automatically when the `GH_TOKEN` environment variable is not set and `--create-release github` is provided.
 
 ##### GitLab Auth Token
 To authenticate with GitLab, the following environment variables can be defined.
@@ -714,7 +714,7 @@ lerna version --conventional-commits --remote-client github
 lerna version --conventional-commits --remote-client gitlab
 ```
 
-For remote client authentication tokens, like `GH_TOKEN`, refer to [`Remote Client Auth Tokens`](#remote-client-auth-tokens)
+For remote client authentication tokens, like `GH_TOKEN` (or `GITHUB_TOKEN`), refer to [`Remote Client Auth Tokens`](#remote-client-auth-tokens)
 
 ### `--signoff-git-commit`
 

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -158,7 +158,7 @@ describe.each([
   });
 
   it('creates a release for every independent version', async () => {
-    process.env.GH_TOKEN = 'TOKEN';
+    process.env.GITHUB_TOKEN = 'TOKEN';
     const cwd = await initFixture('independent');
     const versionBumps = new Map([
       ['package-1', '1.0.1'],
@@ -208,7 +208,7 @@ describe.each([
   });
 
   it('creates a single fixed release in dry-run mode', async () => {
-    process.env.GH_TOKEN = 'TOKEN';
+    process.env.GITHUB_TOKEN = 'TOKEN';
     const logSpy = vi.spyOn(npmlog, 'info');
 
     const cwd = await initFixture('normal');
@@ -250,7 +250,7 @@ describe('--create-release [unrecognized]', () => {
   });
 });
 
-describe('create --github-release without providing GH_TOKEN', () => {
+describe('create --github-release without providing GH_TOKEN or GITHUB_TOKEN', () => {
   beforeEach(() => {
     process.env = {};
   });
@@ -323,7 +323,7 @@ describe.each([
   });
 
   it('creates a release for every independent version but skip "version bump only" packages when --skip-bump-only-releases is enabled', async () => {
-    process.env.GH_TOKEN = 'TOKEN';
+    process.env.GITHUB_TOKEN = 'TOKEN';
     const cwd = await initFixture('independent');
     const versionBumps = new Map([
       ['package-1', '1.0.1'],
@@ -411,7 +411,7 @@ it('should create a github release discussion when enabled', async () => {
 });
 
 it('should log an error when createRelease throws', async () => {
-  process.env.GH_TOKEN = 'TOKEN';
+  process.env.GITHUB_TOKEN = 'TOKEN';
   (createReleaseClient as Mock).mockImplementation(() => Promise.resolve({ repos: { createRelease: vi.fn(() => Promise.reject('some error')) } }));
   (createRelease as Mock).mockImplementationOnce(() => {
     throw new Error('some error');

--- a/packages/version/src/git-clients/__tests__/github-client.spec.ts
+++ b/packages/version/src/git-clients/__tests__/github-client.spec.ts
@@ -14,8 +14,16 @@ describe('createGitHubClient', () => {
     process.env = {};
   });
 
-  it('doesnt error if GH_TOKEN env var is set', () => {
+  it('does not error if GH_TOKEN env var is set', () => {
     process.env.GH_TOKEN = 'TOKEN';
+
+    expect(async () => {
+      await createGitHubClient();
+    }).not.toThrow();
+  });
+
+  it('does not error if GITHUB_TOKEN env var is set', () => {
+    process.env.GITHUB_TOKEN = 'TOKEN';
 
     expect(async () => {
       await createGitHubClient();
@@ -24,6 +32,15 @@ describe('createGitHubClient', () => {
 
   it('initializes GHE plugin when GHE_VERSION env var is set', async () => {
     process.env.GH_TOKEN = 'TOKEN';
+    process.env.GHE_VERSION = '2.18';
+
+    await createGitHubClient();
+
+    expect(Octokit.plugin).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('initializes GHE plugin when GHE_VERSION env var is set with GITHUB_TOKEN', async () => {
+    process.env.GITHUB_TOKEN = 'TOKEN';
     process.env.GHE_VERSION = '2.18';
 
     await createGitHubClient();

--- a/packages/version/src/git-clients/__tests__/gitlab-client.spec.ts
+++ b/packages/version/src/git-clients/__tests__/gitlab-client.spec.ts
@@ -8,6 +8,7 @@ import { createGitLabClient } from '../index';
 describe('createGitLabClient', () => {
   const oldEnv = Object.assign({}, process.env);
   delete process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
 
   afterEach(() => {
     process.env = oldEnv;

--- a/packages/version/src/git-clients/github-client.ts
+++ b/packages/version/src/git-clients/github-client.ts
@@ -7,11 +7,11 @@ import log from 'npmlog';
 export async function createGitHubClient() {
   log.silly('createGitHubClient', '');
 
-  const { GH_TOKEN, GHE_API_URL, GHE_VERSION } = process.env;
+  const { GH_TOKEN, GITHUB_TOKEN, GHE_API_URL, GHE_VERSION } = process.env;
   const options: { auth?: string; baseUrl?: string } = {};
 
-  if (GH_TOKEN) {
-    options.auth = `token ${GH_TOKEN}`;
+  if (GH_TOKEN || GITHUB_TOKEN) {
+    options.auth = `token ${GH_TOKEN || GITHUB_TOKEN}`;
   }
 
   if (GHE_VERSION) {

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -26,7 +26,7 @@ export function createRelease(
   { gitRemote, execOpts, skipBumpOnlyReleases }: ReleaseOptions,
   dryRun = false
 ) {
-  const { GH_TOKEN } = process.env;
+  const { GH_TOKEN, GITHUB_TOKEN } = process.env;
   const repo = parseGitRepo(gitRemote, execOpts);
 
   return Promise.all(
@@ -41,9 +41,9 @@ export function createRelease(
 
       const prereleaseParts = semver.prerelease(tag.replace(`${name}@`, '')) || [];
 
-      // when the `GH_TOKEN` environment variable is not set,
+      // when the `GH_TOKEN` (or `GITHUB_TOKEN`) environment variable is not set,
       // we'll create a link to GitHub web interface form with the fields pre-populated
-      if (!GH_TOKEN) {
+      if (!GH_TOKEN && !GITHUB_TOKEN) {
         const releaseUrl = newGithubReleaseUrl({
           user: repo.owner,
           repo: repo.name,
@@ -52,7 +52,7 @@ export function createRelease(
           title: tag,
           body: notes,
         });
-        log.verbose('github', 'GH_TOKEN environment variable is not set');
+        log.verbose('github', 'GH_TOKEN (or GITHUB_TOKEN) environment variable could not be found');
         log.info('github', `🏷️ (GitHub Release web interface) - 🔗 ${releaseUrl}`);
         return Promise.resolve();
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add `GITHUB_TOKEN` as a valid alias to `GH_TOKEN`, in other words both environment variable will work (it will first read and use `GH_TOKEN`, if not found it will try `GITHUB_TOKEN`)

## Motivation and Context

Many libraries and even GitHub Actions prefer to use `GITHUB_TOKEN` (for example [release-it](https://github.com/release-it/release-it#github-releases)) as environment variable instead of Lerna's `GH_TOKEN` which seems less popular, so this PR is now allowing both tokens to work and user can chose the variable name they prefer. This might help for compatibility since many use the name `GITHUB_TOKEN`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
