### PR TITLE
chore: remove unused paths from tsconfig

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -37,23 +37,6 @@
     "sourceMap": true,
     "strict": true
   },
-  "paths": {
-    "@lerna-lite/helpers": ["helpers"],
-    "@lerna-lite/changed": ["packages/changed/src"],
-    "@lerna-lite/cli": ["packages/cli/src"],
-    "@lerna-lite/core": ["packages/core/src"],
-    "@lerna-lite/diff": ["packages/diff/src"],
-    "@lerna-lite/exec": ["packages/exec/src"],
-    "@lerna-lite/filter-packages": ["packages/filter-packages/src"],
-    "@lerna-lite/init": ["packages/init/src"],
-    "@lerna-lite/list": ["packages/list/src"],
-    "@lerna-lite/listable": ["packages/listable/src"],
-    "@lerna-lite/profiler": ["packages/profiler/src"],
-    "@lerna-lite/publish": ["packages/publish/src"],
-    "@lerna-lite/run": ["packages/run/src"],
-    "@lerna-lite/version": ["packages/version/src"],
-    "@lerna-lite/watch": ["packages/watch/src"]
-  },
   "include": ["**/*.ts"],
   "exclude": ["node_modules/**/*.*", "**/__helpers__/**", "**/__mocks__/**", "**/__tests__/**"]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

code cleaning

## Motivation and Context

`paths` in `tsconfig` should be within the `compilerOptions` not outside of it like the previous code was, but if I move these `paths` inside the  `compilerOptions` then it breaks. However these paths seems unnecessary since we use `references: [{ "path": ''' }]` in packages that depends on other Lerna-Lite packages, so we should be fine

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
