### PR TITLE
fix: support changelog-presets using async factory funcs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,30 +26,6 @@
       packageNames: ['nx'],
       allowedVersions: '15.4.8', // newer version seems to cause problems with Vitest
     },
-    {
-      packageNames: ['conventional-changelog-angular'],
-      allowedVersions: '6.0.0',
-    },
-    {
-      packageNames: ['conventional-changelog-core'],
-      allowedVersions: '5.0.2',
-    },
-    {
-      packageNames: ['conventional-changelog-writer'],
-      allowedVersions: '6.0.1',
-    },
-    {
-      packageNames: ['conventional-changelog-conventionalcommits'],
-      allowedVersions: '6.1.0',
-    },
-    {
-      packageNames: ['conventional-recommended-bump'],
-      allowedVersions: '7.0.1',
-    },
-    {
-      packageNames: ['@types/conventional-recommended-bump'],
-      allowedVersions: '6.1.1',
-    },
 
     // Node 18 deps
     {
@@ -69,6 +45,11 @@
       allowedVersions: '<7.0.0',
     },
   ],
-  ignoreDeps: [],
+  ignoreDeps: [
+    'conventional-changelog-core',
+    'conventional-changelog-writer',
+    'conventional-changelog-conventionalcommits',
+    'conventional-recommended-bump',
+  ],
   schedule: ['every 2 weeks on Thursday'],
 }

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -40,7 +40,7 @@
     "@octokit/plugin-enterprise-rest": "^6.0.1",
     "@octokit/rest": "^19.0.13",
     "chalk": "^5.3.0",
-    "conventional-changelog-angular": "^6.0.0",
+    "conventional-changelog-angular": "^7.0.0",
     "conventional-changelog-core": "^5.0.2",
     "conventional-changelog-writer": "^6.0.1",
     "conventional-commits-parser": "^5.0.0",

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset-async.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset-async.ts
@@ -1,0 +1,19 @@
+// https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
+import parserOpts from './parser-opts';
+import writerOpts from './writer-opts';
+import whatBump from './what-bump';
+
+module.exports = createPreset;
+
+export async function createPreset(_config) {
+  return {
+    conventionalChangelog: {
+      parserOpts,
+      writerOpts,
+    },
+    recommendedBumpOpts: {
+      parserOpts,
+      whatBump,
+    },
+  };
+}

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -240,6 +240,21 @@ describe('conventional-commits', () => {
       expect(bump).toBe('1.1.0');
     });
 
+    it('supports async function presets', async () => {
+      const cwd = await initFixture('fixed');
+      const [pkg1] = await Project.getPackages(cwd);
+
+      // make a change in package-1
+      await pkg1.set('changed', 1).serialize();
+      await gitAdd(cwd, pkg1.manifestLocation);
+      await gitCommit(cwd, 'feat: changed 1');
+
+      const bump = await recommendVersion(pkg1, 'fixed', {
+        changelogPreset: './scripts/local-preset-async.js',
+      });
+      expect(bump).toBe('1.1.0');
+    });
+
     it('supports custom tagPrefix in fixed mode', async () => {
       const cwd = await initFixture('fixed');
 

--- a/packages/version/src/conventional-commits/get-changelog-config.ts
+++ b/packages/version/src/conventional-commits/get-changelog-config.ts
@@ -9,7 +9,10 @@ export class GetChangelogConfig {
   static cfgCache = new Map<string, any>();
 
   static isFunction(config: ChangelogConfig) {
-    return Object.prototype.toString.call(config) === '[object Function]';
+    return (
+      Object.prototype.toString.call(config) === '[object Function]' ||
+      Object.prototype.toString.call(config) === '[object AsyncFunction]'
+    );
   }
 
   static async resolveConfigPromise(presetPackageName: string, presetConfig: ChangelogPresetConfig): Promise<ChangelogConfig> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,8 +669,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       conventional-changelog-angular:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^7.0.0
+        version: 7.0.0
       conventional-changelog-core:
         specifier: ^5.0.2
         version: 5.0.2
@@ -853,20 +853,15 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
-    engines: {node: '>=6.9.0'}
-
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -2594,7 +2589,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: false
 
   /chownr@2.0.0:
@@ -2752,9 +2747,9 @@ packages:
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
-  /conventional-changelog-angular@6.0.0:
-    resolution: {integrity: sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==}
-    engines: {node: '>=14'}
+  /conventional-changelog-angular@7.0.0:
+    resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
+    engines: {node: '>=16'}
     dependencies:
       compare-func: 2.0.0
     dev: false
@@ -2777,7 +2772,7 @@ packages:
       get-pkg-repo: 4.2.1
       git-raw-commits: 3.0.0
       git-remote-origin-url: 2.0.0
-      git-semver-tags: 5.0.0
+      git-semver-tags: 5.0.1
       normalize-package-data: 3.0.3
       read-pkg: 3.0.0
       read-pkg-up: 3.0.0
@@ -2842,7 +2837,7 @@ packages:
       conventional-commits-filter: 3.0.0
       conventional-commits-parser: 4.0.0
       git-raw-commits: 3.0.0
-      git-semver-tags: 5.0.0
+      git-semver-tags: 5.0.1
       meow: 8.1.2
     dev: false
 
@@ -3889,25 +3884,12 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
-
-  /function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: true
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3996,13 +3978,13 @@ packages:
       pify: 2.3.0
     dev: false
 
-  /git-semver-tags@5.0.0:
-    resolution: {integrity: sha512-fZ+tmZ1O5aXW/T5nLzZLbxWAHdQTLLXalOECMNAmhoEQSfqZjtaeMjpsXH4C5qVhrICTkVQeQFujB1lKzIHljA==}
+  /git-semver-tags@5.0.1:
+    resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
       meow: 8.1.2
-      semver: 6.3.1
+      semver: 7.5.4
     dev: false
 
   /git-up@7.0.0:
@@ -4163,7 +4145,7 @@ packages:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
     dev: true
 
   /hasown@2.0.0:
@@ -4354,12 +4336,6 @@ packages:
     dependencies:
       ci-info: 3.8.0
     dev: false
-
-  /is-core-module@2.13.0:
-    resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
-    dependencies:
-      has: 1.0.3
-    dev: true
 
   /is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
@@ -5170,7 +5146,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.3
+      resolve: 1.22.8
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: false
@@ -5990,19 +5966,10 @@ packages:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
     dependencies:
-      is-core-module: 2.13.0
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-    dev: true
-
-  /resolve@1.22.3:
-    resolution: {integrity: sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==}
-    hasBin: true
-    dependencies:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: false
+    dev: true
 
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
@@ -6011,7 +5978,6 @@ packages:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -6126,6 +6092,7 @@ packages:
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+    dev: true
 
   /semver@7.3.4:
     resolution: {integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support newer version of `conventional-changelog-conventionalcommits`

## Motivation and Context

As per Lerna PR 3873](https://github.com/lerna/lerna/pull/3873)

> new 7.x.x versions of conventional changelog presets use async factory functions createPreset (see https://github.com/conventional-changelog/conventional-changelog/pull/1045)

Fixes

> Using `conventionalcommits` as `changelogPreset` causes lerna version to do nothing

> ```json
> {
>   "changelogPreset": "conventional-changelog-conventionalcommits"
> }
> ```
> 
> Up until the v7 release of conventional-changelog, this worked as expected. After upgrading to v7+, the `lerna version` process exits immediately (with zero exit code) after loading the conventionalcommits package, rather than proceeding with the versioning process.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
