### PR TITLE
feat(version): add --premajor-version-bump option to force patch bumps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
-      "args": ["run", "${relativeFile}", "--no-threads", "--no-watch"],
+      "args": ["run", "${relativeFile}", "--pool", "forks", "--no-watch"],
       "smartStep": true,
       "console": "integratedTerminal"
     },

--- a/__fixtures__/independent-premajor/lerna.json
+++ b/__fixtures__/independent-premajor/lerna.json
@@ -1,0 +1,4 @@
+{
+  "version": "independent",
+  "packages": ["packages/*"]
+}

--- a/__fixtures__/independent-premajor/package.json
+++ b/__fixtures__/independent-premajor/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "independent",
+  "repository": {
+    "url": "https://github.com/lerna/independent-packages"
+  }
+}

--- a/__fixtures__/independent-premajor/packages/package-1/package.json
+++ b/__fixtures__/independent-premajor/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "0.0.0",
+  "repository": {
+    "url": "https://github.com/lerna/independent-package-1"
+  }
+}

--- a/__fixtures__/independent-premajor/packages/package-2/package.json
+++ b/__fixtures__/independent-premajor/packages/package-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-2",
+  "version": "0.2.0",
+  "dependencies": {
+    "package-1": "^0.0.0"
+  },
+  "repository": {
+    "url": "https://github.com/lerna/independent-package-2"
+  }
+}

--- a/__fixtures__/independent-premajor/packages/package-3/package.json
+++ b/__fixtures__/independent-premajor/packages/package-3/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-3",
+  "version": "0.3.0",
+  "devDependencies": {
+    "package-2": "^0.2.0"
+  },
+  "repository": {
+    "url": "https://github.com/lerna/independent-package-3"
+  }
+}

--- a/__fixtures__/independent-premajor/packages/package-4/package.json
+++ b/__fixtures__/independent-premajor/packages/package-4/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^0.0.0"
+  },
+  "repository": {
+    "url": "https://github.com/lerna/independent-package-4"
+  }
+}

--- a/__fixtures__/independent-premajor/packages/package-5/package.json
+++ b/__fixtures__/independent-premajor/packages/package-5/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "package-5",
+  "dependencies": {
+    "package-3": "^0.3.0"
+  },
+  "private": true,
+  "version": "0.5.0",
+  "repository": {
+    "url": "https://github.com/lerna/independent-package-5"
+  }
+}

--- a/__fixtures__/independent-premajor/packages/package-6/package.json
+++ b/__fixtures__/independent-premajor/packages/package-6/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-6",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/lerna/independent-package-6"
+  }
+}

--- a/__fixtures__/independent/packages/package-6/package.json
+++ b/__fixtures__/independent/packages/package-6/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-6",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/lerna/independent-package-6"
+  }
+}

--- a/__fixtures__/normal-premajor/lerna.json
+++ b/__fixtures__/normal-premajor/lerna.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.1.0",
+  "packages": [
+    "packages/*"
+  ]
+}

--- a/__fixtures__/normal-premajor/package.json
+++ b/__fixtures__/normal-premajor/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "normal-premajor",
+  "repository": {
+    "url": "https://github.com/lerna/normal-premajor-packages"
+  }
+}

--- a/__fixtures__/normal-premajor/packages/package-1/package.json
+++ b/__fixtures__/normal-premajor/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/lerna/normal-package-1"
+  }
+}

--- a/__fixtures__/normal-premajor/packages/package-2/package.json
+++ b/__fixtures__/normal-premajor/packages/package-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-2",
+  "version": "0.1.0",
+  "dependencies": {
+    "package-1": "^0.1.0"
+  },
+  "repository": {
+    "url": "https://github.com/lerna/normal-package-2"
+  }
+}

--- a/__fixtures__/normal-premajor/packages/package-3/package.json
+++ b/__fixtures__/normal-premajor/packages/package-3/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "package-3",
+  "version": "0.1.0",
+  "peerDependencies": {
+    "package-2": "^0.1.0"
+  },
+  "devDependencies": {
+    "package-2": "^0.1.0"
+  },
+  "repository": {
+    "url": "https://github.com/lerna/normal-package-3"
+  }
+}

--- a/__fixtures__/normal-premajor/packages/package-4/package.json
+++ b/__fixtures__/normal-premajor/packages/package-4/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-4",
+  "version": "0.1.0",
+  "dependencies": {
+    "package-1": "^0.0.0"
+  },
+  "repository": {
+    "url": "https://github.com/lerna/normal-package-4"
+  }
+}

--- a/__fixtures__/normal-premajor/packages/package-5/package.json
+++ b/__fixtures__/normal-premajor/packages/package-5/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "package-5",
+  "dependencies": {
+    "package-1": "^0.1.0"
+  },
+  "optionalDependencies": {
+    "package-3": "^0.1.0"
+  },
+  "private": true,
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/lerna/normal-package-5"
+  }
+}

--- a/__fixtures__/prerelease-independent/packages/package-6/package.json
+++ b/__fixtures__/prerelease-independent/packages/package-6/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-6",
+  "version": "0.1.0"
+}

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -676,6 +676,9 @@
             "tagVersionPrefix": {
               "$ref": "#/$defs/commandOptions/version/tagVersionPrefix"
             },
+            "premajorVersionBump": {
+              "$ref": "#/$defs/commandOptions/version/premajorVersionBump"
+            },
 
             "npmClient": {
               "$ref": "#/$defs/globals/npmClient"
@@ -1002,6 +1005,9 @@
     },
     "tagVersionPrefix": {
       "$ref": "#/$defs/commandOptions/version/tagVersionPrefix"
+    },
+    "premajorVersionBump": {
+      "$ref": "#/$defs/commandOptions/version/premajorVersionBump"
     },
 
     "registry": {
@@ -1407,6 +1413,11 @@
         "tagVersionPrefix": {
           "type": "string",
           "description": "During `lerna version`, customize the tag prefix. To remove entirely, pass an empty string."
+        },
+        "premajorVersionBump": {
+          "type": "string",
+          "description": "During `lerna version`, with 'force-patch', ensure premajor version releases are bumped as patch for non-breaking changes.",
+          "enum": ["default", "force-patch"]
         }
       },
       "watch": {

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -267,6 +267,13 @@ export default {
         describe: 'do we want to skip creating a release (github/gitlab) when the version is a "version bump only"?',
         type: 'boolean',
       },
+      'premajor-version-bump': {
+        describe: 'Controls how pre-major version packages are bumped by lerna.',
+        type: 'string',
+        choices: ['default', 'force-patch'],
+        requiresArg: true,
+        defaultDescription: 'default',
+      },
       y: {
         describe: 'Skip all confirmation prompts.',
         alias: 'yes',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -301,6 +301,14 @@ export interface VersionCommandOption {
   /** Additional arguments to pass to the npm client when performing 'npm install'. */
   npmClientArgs?: string[];
 
+  /**
+   * This option allows you to control how lerna handles bumping versions for packages with a
+   * `premajor` version (packages that have not had a major release, e.g. `"version": "0.2.4"`)
+   * when non-breaking changes are detected.
+   * Breaking changes in `premajor` packages will always trigger a `minor` bump.
+   */
+  premajorVersionBump?: 'default' | 'force-patch';
+
   /** @deprecated @alias `skipBumpOnlyReleases` renamed previous flag from `skipBumpOnlyRelease` to `skipBumpOnlyReleases`. */
   skipBumpOnlyRelease?: boolean;
 

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -113,6 +113,7 @@ export interface QueryGraphConfig {
 
   /** Whether or not to reject dependency cycles */
   rejectCycles?: boolean;
+  premajorVersionBump?: 'default' | 'force-patch';
 }
 
 export interface TopologicalConfig extends QueryGraphConfig {

--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -472,6 +472,7 @@ test('publish --canary without _any_ tags (independent)', async () => {
       "package-2": 2.0.1-alpha.0+SHA,
       "package-3": 3.0.1-alpha.0+SHA,
       "package-4": 4.0.1-alpha.0+SHA,
+      "package-6": 0.1.1-alpha.0+SHA,
     }
   `);
 });

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -252,6 +252,7 @@ describe('PublishCommand', () => {
       expect((npmPublish as typeof npmPublishMock).order()).toEqual([
         'package-1',
         'package-4',
+        'package-6',
         'package-2',
         'package-3',
         // package-5 is private

--- a/packages/publish/src/__tests__/publish-from-package.spec.ts
+++ b/packages/publish/src/__tests__/publish-from-package.spec.ts
@@ -104,6 +104,7 @@ describe('publish from-package', () => {
     expect((npmPublish as typeof npmPublishMock).order()).toEqual([
       'package-1',
       'package-4',
+      'package-6',
       'package-2',
       'package-3',
       // package-5 is private
@@ -123,6 +124,7 @@ describe('publish from-package', () => {
       'package-3',
       'package-4',
       // package-5 is private
+      'package-6',
     ]);
   });
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -104,6 +104,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--no-manually-update-root-lockfile`](#--no-manually-update-root-lockfile)
     - [`--npm-client-args`](#--npm-client-args)
     - [`--preid`](#--preid)
+    - [`--premajor-version-bump`](#--premajor-version-bump)
     - [`--remote-client <type>`](#--remote-client-type)
     - [`--signoff-git-commit`](#--signoff-git-commit)
     - [`--sign-git-commit`](#--sign-git-commit)
@@ -716,6 +717,28 @@ lerna version prepatch --preid next
 
 When run with this flag, `lerna version` will increment `premajor`, `preminor`, `prepatch`, or `prerelease` semver
 bumps using the specified [prerelease identifier](http://semver.org/#spec-item-9).
+
+
+### `--premajor-version-bump`
+
+This option allows you to control how lerna handles bumping versions for packages with a
+`premajor` version (packages that have not had a major release, e.g. `"version": "0.2.4"`)
+when non-breaking changes are detected.
+Breaking changes in `premajor` packages will always trigger a `minor` bump.
+
+```sh
+lerna version --conventional-commits
+# OR
+lerna version --conventional-commits --premajor-version-bump default
+# all non-breaking changes trigger a bump based on the configured conventional commits preset
+# for the default preset, a non-breaking feat would be a minor bump
+# 0.1.0 --> 0.2.0
+
+lerna version --conventional-commits --premajor-version-bump force-patch
+# ensures that all non-breaking premajor version bumps are handled as patches
+# in this case, a non-breaking feat would always be a patch bump
+# 0.1.0 --> 0.1.1
+```
 
 ### `--remote-client <type>`
 

--- a/packages/version/src/__tests__/__snapshots__/version-build-metadata.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-build-metadata.spec.ts.snap
@@ -69,8 +69,9 @@ chore: Publish new release
  - package-3@4.0.0+21AF26D3--117B344092BD
  - package-4@4.1.0+21AF26D3--117B344092BD
  - package-5@5.0.1+21AF26D3--117B344092BD
+ - package-6@0.2.0+21AF26D3--117B344092BD
 
-HEAD -> main, tag: package-5@5.0.1+21AF26D3--117B344092BD, tag: package-4@4.1.0+21AF26D3--117B344092BD, tag: package-3@4.0.0+21AF26D3--117B344092BD, tag: package-2@2.1.0+21AF26D3--117B344092BD, tag: package-1@1.0.1+21AF26D3--117B344092BD
+HEAD -> main, tag: package-6@0.2.0+21AF26D3--117B344092BD, tag: package-5@5.0.1+21AF26D3--117B344092BD, tag: package-4@4.1.0+21AF26D3--117B344092BD, tag: package-3@4.0.0+21AF26D3--117B344092BD, tag: package-2@2.1.0+21AF26D3--117B344092BD, tag: package-1@1.0.1+21AF26D3--117B344092BD
 
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
@@ -116,6 +117,13 @@ index SHA..SHA 100644
 @@ -7 +7 @@
 -  "version": "5.0.0"
 +  "version": "5.0.1+21AF26D3--117B344092BD"
+diff --git a/packages/package-6/package.json b/packages/package-6/package.json
+index SHA..SHA 100644
+--- a/packages/package-6/package.json
++++ b/packages/package-6/package.json
+@@ -3 +3 @@
+-  "version": "0.1.0",
++  "version": "0.2.0+21AF26D3--117B344092BD",
 `;
 
 exports[`--build-metadata with prompt > updates build metadata 1`] = `
@@ -171,8 +179,9 @@ chore: Publish new release
  - package-3@3.1.0+001
  - package-4@4.1.0+001
  - package-5@5.1.0+001
+ - package-6@0.2.0+001
 
-HEAD -> main, tag: package-5@5.1.0+001, tag: package-4@4.1.0+001, tag: package-3@3.1.0+001, tag: package-2@2.1.0+001, tag: package-1@1.1.0+001
+HEAD -> main, tag: package-6@0.2.0+001, tag: package-5@5.1.0+001, tag: package-4@4.1.0+001, tag: package-3@3.1.0+001, tag: package-2@2.1.0+001, tag: package-1@1.1.0+001
 
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
@@ -218,6 +227,13 @@ index SHA..SHA 100644
 @@ -7 +7 @@
 -  "version": "5.0.0"
 +  "version": "5.1.0+001"
+diff --git a/packages/package-6/package.json b/packages/package-6/package.json
+index SHA..SHA 100644
+--- a/packages/package-6/package.json
++++ b/packages/package-6/package.json
+@@ -3 +3 @@
+-  "version": "0.1.0",
++  "version": "0.2.0+001",
 `;
 
 exports[`--build-metadata without prompt > accepts build metadata for explicit version 1`] = `

--- a/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
@@ -195,8 +195,9 @@ exports[`VersionCommand > independent mode > versions changed packages > commit 
  - package-3@4.0.0
  - package-4@4.1.0
  - package-5@5.0.1
+ - package-6@0.2.0
 
-HEAD -> main, tag: package-5@5.0.1, tag: package-4@4.1.0, tag: package-3@4.0.0, tag: package-2@2.1.0, tag: package-1@1.0.1
+HEAD -> main, tag: package-6@0.2.0, tag: package-5@5.0.1, tag: package-4@4.1.0, tag: package-3@4.0.0, tag: package-2@2.1.0, tag: package-1@1.0.1
 
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
@@ -241,17 +242,25 @@ index SHA..SHA 100644
 +    "package-3": "^4.0.0"
 @@ -7 +7 @@
 -  "version": "5.0.0"
-+  "version": "5.0.1""
++  "version": "5.0.1"
+diff --git a/packages/package-6/package.json b/packages/package-6/package.json
+index SHA..SHA 100644
+--- a/packages/package-6/package.json
++++ b/packages/package-6/package.json
+@@ -3 +3 @@
+-  "version": "0.1.0",
++  "version": "0.2.0","
 `;
 
 exports[`VersionCommand > independent mode > versions changed packages > console output 1`] = `
 "
-Changes (5 packages):
+Changes (6 packages):
  - package-1: 1.0.0 => 1.0.1
  - package-2: 2.0.0 => 2.1.0
  - package-3: 3.0.0 => 4.0.0
  - package-4: 4.0.0 => 4.1.0
  - package-5: 5.0.0 => 5.0.1 (private)
+ - package-6: 0.1.0 => 0.2.0
 "
 `;
 

--- a/packages/version/src/__tests__/__snapshots__/version-conventional-commits.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-conventional-commits.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`--conventional-commits > accepts --build-metadata option 1`] = `
+exports[`version --conventional-commits > accepts --build-metadata option 1`] = `
 v1.0.1+exp.sha.SHA
 
 HEAD -> main, tag: v1.0.1+exp.sha.SHA
@@ -19,7 +19,7 @@ packages/package-5/CHANGELOG.md
 packages/package-5/package.json
 `;
 
-exports[`--conventional-commits > fixed mode > should guess prerelease version bumps and generate CHANGELOG 1`] = `
+exports[`version --conventional-commits > fixed mode > should guess prerelease version bumps and generate CHANGELOG 1`] = `
 v2.0.0-alpha.0
 
 HEAD -> main, tag: v2.0.0-alpha.0
@@ -38,7 +38,7 @@ packages/package-5/CHANGELOG.md
 packages/package-5/package.json
 `;
 
-exports[`--conventional-commits > fixed mode > should use conventional-commits utility to guess version bump and generate CHANGELOG 1`] = `
+exports[`version --conventional-commits > fixed mode > should use conventional-commits utility to guess version bump and generate CHANGELOG 1`] = `
 v2.0.0
 
 HEAD -> main, tag: v2.0.0
@@ -57,7 +57,7 @@ packages/package-5/CHANGELOG.md
 packages/package-5/package.json
 `;
 
-exports[`--conventional-commits > independent > accepts --build-metadata option 1`] = `
+exports[`version --conventional-commits > independent > accepts --build-metadata option 1`] = `
 chore: Publish new release
 
  - package-1@1.0.1+001
@@ -65,8 +65,9 @@ chore: Publish new release
  - package-3@4.0.0+001
  - package-4@4.1.0+001
  - package-5@5.0.1+001
+ - package-6@0.2.0+001
 
-HEAD -> main, tag: package-5@5.0.1+001, tag: package-4@4.1.0+001, tag: package-3@4.0.0+001, tag: package-2@2.1.0+001, tag: package-1@1.0.1+001
+HEAD -> main, tag: package-6@0.2.0+001, tag: package-5@5.0.1+001, tag: package-4@4.1.0+001, tag: package-3@4.0.0+001, tag: package-2@2.1.0+001, tag: package-1@1.0.1+001
 
 packages/package-1/CHANGELOG.md
 packages/package-1/package.json
@@ -78,9 +79,63 @@ packages/package-4/CHANGELOG.md
 packages/package-4/package.json
 packages/package-5/CHANGELOG.md
 packages/package-5/package.json
+packages/package-6/CHANGELOG.md
+packages/package-6/package.json
 `;
 
-exports[`--conventional-commits > independent > should graduate prerelease version bumps and generate CHANGELOG 1`] = `
+exports[`version --conventional-commits > independent > should bump premajorVersionBump default as minor 1`] = `
+chore: Publish new release
+
+ - package-1@0.1.0
+ - package-2@0.3.0
+ - package-3@0.4.0
+ - package-4@1.1.0
+ - package-5@0.6.0
+ - package-6@0.2.0
+
+HEAD -> main, tag: package-6@0.2.0, tag: package-5@0.6.0, tag: package-4@1.1.0, tag: package-3@0.4.0, tag: package-2@0.3.0, tag: package-1@0.1.0
+
+packages/package-1/CHANGELOG.md
+packages/package-1/package.json
+packages/package-2/CHANGELOG.md
+packages/package-2/package.json
+packages/package-3/CHANGELOG.md
+packages/package-3/package.json
+packages/package-4/CHANGELOG.md
+packages/package-4/package.json
+packages/package-5/CHANGELOG.md
+packages/package-5/package.json
+packages/package-6/CHANGELOG.md
+packages/package-6/package.json
+`;
+
+exports[`version --conventional-commits > independent > should bump premajorVersionBump force-patch as patch 1`] = `
+chore: Publish new release
+
+ - package-1@0.1.0
+ - package-2@0.2.1
+ - package-3@0.3.1
+ - package-4@1.1.0
+ - package-5@0.5.1
+ - package-6@0.1.1
+
+HEAD -> main, tag: package-6@0.1.1, tag: package-5@0.5.1, tag: package-4@1.1.0, tag: package-3@0.3.1, tag: package-2@0.2.1, tag: package-1@0.1.0
+
+packages/package-1/CHANGELOG.md
+packages/package-1/package.json
+packages/package-2/CHANGELOG.md
+packages/package-2/package.json
+packages/package-3/CHANGELOG.md
+packages/package-3/package.json
+packages/package-4/CHANGELOG.md
+packages/package-4/package.json
+packages/package-5/CHANGELOG.md
+packages/package-5/package.json
+packages/package-6/CHANGELOG.md
+packages/package-6/package.json
+`;
+
+exports[`version --conventional-commits > independent > should graduate prerelease version bumps and generate CHANGELOG 1`] = `
 chore: Publish new release
 
  - package-1@1.0.1
@@ -88,8 +143,9 @@ chore: Publish new release
  - package-3@4.0.0
  - package-4@4.1.0
  - package-5@5.0.1
+ - package-6@0.2.0
 
-HEAD -> main, tag: package-5@5.0.1, tag: package-4@4.1.0, tag: package-3@4.0.0, tag: package-2@2.1.0, tag: package-1@1.0.1
+HEAD -> main, tag: package-6@0.2.0, tag: package-5@5.0.1, tag: package-4@4.1.0, tag: package-3@4.0.0, tag: package-2@2.1.0, tag: package-1@1.0.1
 
 packages/package-1/CHANGELOG.md
 packages/package-1/package.json
@@ -101,9 +157,11 @@ packages/package-4/CHANGELOG.md
 packages/package-4/package.json
 packages/package-5/CHANGELOG.md
 packages/package-5/package.json
+packages/package-6/CHANGELOG.md
+packages/package-6/package.json
 `;
 
-exports[`--conventional-commits > independent > should guess prerelease version bumps and generate CHANGELOG 1`] = `
+exports[`version --conventional-commits > independent > should guess prerelease version bumps and generate CHANGELOG 1`] = `
 chore: Publish new release
 
  - package-1@1.0.1-alpha.0
@@ -111,9 +169,57 @@ chore: Publish new release
  - package-3@4.0.0-beta.0
  - package-4@4.1.0-alpha.0
  - package-5@5.0.1-alpha.0
+ - package-6@0.2.0-alpha.0
 
-HEAD -> main, tag: package-5@5.0.1-alpha.0, tag: package-4@4.1.0-alpha.0, tag: package-3@4.0.0-beta.0, tag: package-2@2.1.0-alpha.0, tag: package-1@1.0.1-alpha.0
+HEAD -> main, tag: package-6@0.2.0-alpha.0, tag: package-5@5.0.1-alpha.0, tag: package-4@4.1.0-alpha.0, tag: package-3@4.0.0-beta.0, tag: package-2@2.1.0-alpha.0, tag: package-1@1.0.1-alpha.0
 
+packages/package-1/CHANGELOG.md
+packages/package-1/package.json
+packages/package-2/CHANGELOG.md
+packages/package-2/package.json
+packages/package-3/CHANGELOG.md
+packages/package-3/package.json
+packages/package-4/CHANGELOG.md
+packages/package-4/package.json
+packages/package-5/CHANGELOG.md
+packages/package-5/package.json
+packages/package-6/CHANGELOG.md
+packages/package-6/package.json
+`;
+
+exports[`version --conventional-commits > independent > should use conventional-commits utility to guess version bump and generate CHANGELOG 1`] = `
+chore: Publish new release
+
+ - package-1@1.0.1
+ - package-2@2.1.0
+ - package-3@4.0.0
+ - package-4@4.1.0
+ - package-5@5.0.1
+ - package-6@0.2.0
+
+HEAD -> main, tag: package-6@0.2.0, tag: package-5@5.0.1, tag: package-4@4.1.0, tag: package-3@4.0.0, tag: package-2@2.1.0, tag: package-1@1.0.1
+
+packages/package-1/CHANGELOG.md
+packages/package-1/package.json
+packages/package-2/CHANGELOG.md
+packages/package-2/package.json
+packages/package-3/CHANGELOG.md
+packages/package-3/package.json
+packages/package-4/CHANGELOG.md
+packages/package-4/package.json
+packages/package-5/CHANGELOG.md
+packages/package-5/package.json
+packages/package-6/CHANGELOG.md
+packages/package-6/package.json
+`;
+
+exports[`version --conventional-commits > should bump premajorVersionBump force-patch as patch 1`] = `
+v0.1.1
+
+HEAD -> main, tag: v0.1.1
+
+CHANGELOG.md
+lerna.json
 packages/package-1/CHANGELOG.md
 packages/package-1/package.json
 packages/package-2/CHANGELOG.md
@@ -126,17 +232,13 @@ packages/package-5/CHANGELOG.md
 packages/package-5/package.json
 `;
 
-exports[`--conventional-commits > independent > should use conventional-commits utility to guess version bump and generate CHANGELOG 1`] = `
-chore: Publish new release
+exports[`version --conventional-commits > should bump premajorVersionBump semver as minor 1`] = `
+v0.2.0
 
- - package-1@1.0.1
- - package-2@2.1.0
- - package-3@4.0.0
- - package-4@4.1.0
- - package-5@5.0.1
+HEAD -> main, tag: v0.2.0
 
-HEAD -> main, tag: package-5@5.0.1, tag: package-4@4.1.0, tag: package-3@4.0.0, tag: package-2@2.1.0, tag: package-1@1.0.1
-
+CHANGELOG.md
+lerna.json
 packages/package-1/CHANGELOG.md
 packages/package-1/package.json
 packages/package-2/CHANGELOG.md

--- a/packages/version/src/__tests__/version-build-metadata.spec.ts
+++ b/packages/version/src/__tests__/version-build-metadata.spec.ts
@@ -169,6 +169,7 @@ describe('--build-metadata with prompt', () => {
     (promptSelectOne as any).chooseBump('major');
     (promptSelectOne as any).chooseBump('minor');
     (promptSelectOne as any).chooseBump('patch');
+    (promptSelectOne as any).chooseBump('minor');
 
     await new VersionCommand(createArgv(testDir, '--build-metadata', '21AF26D3--117B344092BD'));
 

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -342,6 +342,7 @@ describe('VersionCommand', () => {
       (promptSelectOne as any).chooseBump('major');
       (promptSelectOne as any).chooseBump('minor');
       (promptSelectOne as any).chooseBump('patch');
+      (promptSelectOne as any).chooseBump('minor');
 
       const testDir = await initFixture('independent');
       await new VersionCommand(createArgv(testDir)); // --independent is only valid in InitCommand

--- a/packages/version/src/__tests__/version-conventional-commits.spec.ts
+++ b/packages/version/src/__tests__/version-conventional-commits.spec.ts
@@ -63,7 +63,7 @@ const createArgv = (cwd, ...args) => {
   return argv as unknown as VersionCommandOption;
 };
 
-describe('--conventional-commits', () => {
+describe('version --conventional-commits', () => {
   describe('independent', () => {
     const versionBumps = new Map([
       ['package-1', '1.0.1'],
@@ -71,6 +71,25 @@ describe('--conventional-commits', () => {
       ['package-3', '4.0.0'],
       ['package-4', '4.1.0'],
       ['package-5', '5.0.1'],
+      ['package-6', '0.2.0'],
+    ]);
+
+    const premajorVersionBumpsForcePatch = new Map([
+      ['package-1', '0.1.0'],
+      ['package-2', '0.2.1'],
+      ['package-3', '0.3.1'],
+      ['package-4', '1.1.0'],
+      ['package-5', '0.5.1'],
+      ['package-6', '0.1.1'],
+    ]);
+
+    const premajorVersionBumpsDefault = new Map([
+      ['package-1', '0.1.0'],
+      ['package-2', '0.3.0'],
+      ['package-3', '0.4.0'],
+      ['package-4', '1.1.0'],
+      ['package-5', '0.6.0'],
+      ['package-6', '0.2.0'],
     ]);
 
     const prereleaseVersionBumps = new Map([
@@ -79,6 +98,7 @@ describe('--conventional-commits', () => {
       ['package-3', '4.0.0-beta.0'],
       ['package-4', '4.1.0-alpha.0'],
       ['package-5', '5.0.1-alpha.0'],
+      ['package-6', '0.2.0-alpha.0'],
     ]);
 
     it('should use conventional-commits utility to guess version bump and generate CHANGELOG', async () => {
@@ -92,13 +112,18 @@ describe('--conventional-commits', () => {
       expect(changedFiles).toMatchSnapshot();
 
       versionBumps.forEach((version, name) => {
-        expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name }), 'independent', {
-          changelogPreset: undefined,
-          rootPath: cwd,
-          tagPrefix: 'v',
-          prereleaseId: undefined,
-          buildMetadata: undefined,
-        });
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name }),
+          'independent',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prereleaseId: undefined,
+            buildMetadata: undefined,
+          },
+          'default'
+        );
         expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version }), 'independent', {
           changelogPreset: undefined,
           rootPath: cwd,
@@ -119,13 +144,18 @@ describe('--conventional-commits', () => {
 
       prereleaseVersionBumps.forEach((version, name) => {
         const prereleaseId = (semver as any).prerelease(version)[0];
-        expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name }), 'independent', {
-          changelogPreset: undefined,
-          rootPath: cwd,
-          tagPrefix: 'v',
-          prereleaseId,
-          buildMetadata: undefined,
-        });
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name }),
+          'independent',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prereleaseId,
+            buildMetadata: undefined,
+          },
+          'default'
+        );
         expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version }), 'independent', {
           changelogPreset: undefined,
           rootPath: cwd,
@@ -142,13 +172,18 @@ describe('--conventional-commits', () => {
 
       prereleaseVersionBumps.forEach((version, name) => {
         const prereleaseId = (semver as any).prerelease(version)[0];
-        expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name }), 'independent', {
-          changelogPreset: undefined,
-          rootPath: cwd,
-          tagPrefix: 'v',
-          prereleaseId,
-          conventionalBumpPrerelease: true,
-        });
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name }),
+          'independent',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prereleaseId,
+            conventionalBumpPrerelease: true,
+          },
+          'default'
+        );
         expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version }), 'independent', {
           changelogPreset: undefined,
           rootPath: cwd,
@@ -165,13 +200,18 @@ describe('--conventional-commits', () => {
 
       prereleaseVersionBumps.forEach((version, name) => {
         const prereleaseId = (semver as any).prerelease(version)[0];
-        expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name }), 'independent', {
-          changelogPreset: undefined,
-          rootPath: cwd,
-          tagPrefix: 'v',
-          prereleaseId,
-          conventionalBumpPrerelease: true,
-        });
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name }),
+          'independent',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prereleaseId,
+            conventionalBumpPrerelease: true,
+          },
+          'default'
+        );
         expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version }), 'independent', {
           changelogPreset: undefined,
           rootPath: cwd,
@@ -190,13 +230,18 @@ describe('--conventional-commits', () => {
       expect(changedFiles).toMatchSnapshot();
 
       versionBumps.forEach((version, name) => {
-        expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name }), 'independent', {
-          changelogPreset: undefined,
-          rootPath: cwd,
-          tagPrefix: 'v',
-          prerelease: undefined,
-          buildMetadata: undefined,
-        });
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name }),
+          'independent',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prerelease: undefined,
+            buildMetadata: undefined,
+          },
+          'default'
+        );
         expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version }), 'independent', {
           changelogPreset: undefined,
           rootPath: cwd,
@@ -235,7 +280,7 @@ describe('--conventional-commits', () => {
 
       await new VersionCommand(createArgv(cwd, '--conventional-commits', '--changelog-preset', 'foo-bar'));
 
-      expect(recommendVersion).toHaveBeenCalledWith(expect.any(Object), 'independent', changelogOpts);
+      expect(recommendVersion).toHaveBeenCalledWith(expect.any(Object), 'independent', changelogOpts, 'default');
       expect(updateChangelog).toHaveBeenCalledWith(expect.any(Object), 'independent', changelogOpts);
     });
 
@@ -272,11 +317,80 @@ describe('--conventional-commits', () => {
       const changedFiles = await showCommit(cwd, '--name-only');
       expect(changedFiles).toMatchSnapshot();
 
-      expect(recommendVersion).toHaveBeenCalledWith(expect.any(Object), 'independent', {
-        ...changelogOpts,
-        buildMetadata,
-      });
+      expect(recommendVersion).toHaveBeenCalledWith(
+        expect.any(Object),
+        'independent',
+        {
+          ...changelogOpts,
+          buildMetadata,
+        },
+        'default'
+      );
       expect(updateChangelog).toHaveBeenCalledWith(expect.any(Object), 'independent', changelogOpts);
+    });
+
+    it('should bump premajorVersionBump force-patch as patch', async () => {
+      premajorVersionBumpsForcePatch.forEach((bump) => (recommendVersion as Mock).mockResolvedValueOnce(bump));
+
+      const cwd = await initFixture('independent-premajor');
+
+      await new VersionCommand(createArgv(cwd, '--conventional-commits', '--premajor-version-bump', 'force-patch'));
+
+      const changedFiles = await showCommit(cwd, '--name-only');
+      expect(changedFiles).toMatchSnapshot();
+
+      premajorVersionBumpsForcePatch.forEach((version, name) => {
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name }),
+          'independent',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prereleaseId: undefined,
+            buildMetadata: undefined,
+          },
+          'force-patch'
+        );
+        expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version }), 'independent', {
+          changelogPreset: undefined,
+          rootPath: cwd,
+          tagPrefix: 'v',
+          prereleaseId: undefined,
+        });
+      });
+    });
+
+    it('should bump premajorVersionBump default as minor', async () => {
+      premajorVersionBumpsDefault.forEach((bump) => (recommendVersion as Mock).mockResolvedValueOnce(bump));
+
+      const cwd = await initFixture('independent-premajor');
+
+      await new VersionCommand(createArgv(cwd, '--conventional-commits', '--premajor-version-bump', 'default'));
+
+      const changedFiles = await showCommit(cwd, '--name-only');
+      expect(changedFiles).toMatchSnapshot();
+
+      premajorVersionBumpsDefault.forEach((version, name) => {
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name }),
+          'independent',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prereleaseId: undefined,
+            buildMetadata: undefined,
+          },
+          'default'
+        );
+        expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version }), 'independent', {
+          changelogPreset: undefined,
+          rootPath: cwd,
+          tagPrefix: 'v',
+          prereleaseId: undefined,
+        });
+      });
     });
   });
 
@@ -299,13 +413,18 @@ describe('--conventional-commits', () => {
       ['package-1', 'package-2', 'package-3', 'package-4', 'package-5'].forEach((name) => {
         const location = join(cwd, 'packages', name);
 
-        expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name, location }), 'fixed', {
-          changelogPreset: undefined,
-          rootPath: cwd,
-          tagPrefix: 'v',
-          prereleaseId: undefined,
-          buildMetadata: undefined,
-        });
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name, location }),
+          'fixed',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prereleaseId: undefined,
+            buildMetadata: undefined,
+          },
+          'default'
+        );
 
         expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version: '2.0.0' }), 'fixed', {
           changelogPreset: undefined,
@@ -349,13 +468,18 @@ describe('--conventional-commits', () => {
       ['package-1', 'package-2', 'package-3', 'package-4', 'package-5'].forEach((name) => {
         const location = join(cwd, 'packages', name);
 
-        expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name, location }), 'fixed', {
-          changelogPreset: undefined,
-          rootPath: cwd,
-          tagPrefix: 'v',
-          prereleaseId: 'alpha',
-          buildMetadata: undefined,
-        });
+        expect(recommendVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ name, location }),
+          'fixed',
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: 'v',
+            prereleaseId: 'alpha',
+            buildMetadata: undefined,
+          },
+          'default'
+        );
 
         expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version: '2.0.0-alpha.0' }), 'fixed', {
           changelogPreset: undefined,
@@ -391,10 +515,15 @@ describe('--conventional-commits', () => {
 
       await new VersionCommand(createArgv(cwd, '--conventional-commits', '--changelog-preset', 'baz-qux', '--tag-version-prefix', 'dragons-are-awesome'));
 
-      expect(recommendVersion).toHaveBeenCalledWith(expect.any(Object), 'fixed', {
-        ...changelogOpts,
-        buildMetadata: undefined,
-      });
+      expect(recommendVersion).toHaveBeenCalledWith(
+        expect.any(Object),
+        'fixed',
+        {
+          ...changelogOpts,
+          buildMetadata: undefined,
+        },
+        'default'
+      );
       expect(updateChangelog).toHaveBeenCalledWith(expect.any(Object), 'fixed', changelogOpts);
     });
 
@@ -458,10 +587,89 @@ describe('--conventional-commits', () => {
     const changedFiles = await showCommit(cwd, '--name-only');
     expect(changedFiles).toMatchSnapshot();
 
-    expect(recommendVersion).toHaveBeenCalledWith(expect.any(Object), 'fixed', {
-      ...changelogOpts,
-      buildMetadata,
-    });
+    expect(recommendVersion).toHaveBeenCalledWith(
+      expect.any(Object),
+      'fixed',
+      {
+        ...changelogOpts,
+        buildMetadata,
+      },
+      'default'
+    );
     expect(updateChangelog).toHaveBeenCalledWith(expect.any(Object), 'fixed', changelogOpts);
+  });
+
+  it('should bump premajorVersionBump force-patch as patch', async () => {
+    const packages = ['package-1', 'package-2', 'package-3', 'package-4', 'package-5'];
+    for (let i = 0; i < packages.length; i++) {
+      (recommendVersion as Mock).mockResolvedValueOnce('0.1.1');
+    }
+
+    const cwd = await initFixture('normal-premajor');
+
+    await new VersionCommand(createArgv(cwd, '--conventional-commits', '--premajor-version-bump', 'force-patch'));
+
+    const changedFiles = await showCommit(cwd, '--name-only');
+    expect(changedFiles).toMatchSnapshot();
+
+    packages.forEach((name) => {
+      const location = join(cwd, 'packages', name);
+
+      expect(recommendVersion).toHaveBeenCalledWith(
+        expect.objectContaining({ name, location }),
+        'fixed',
+        {
+          changelogPreset: undefined,
+          rootPath: cwd,
+          tagPrefix: 'v',
+          prereleaseId: undefined,
+          buildMetadata: undefined,
+        },
+        'force-patch'
+      );
+
+      expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version: '0.1.1' }), 'fixed', {
+        changelogPreset: undefined,
+        rootPath: cwd,
+        tagPrefix: 'v',
+        prereleaseId: undefined,
+      });
+    });
+  });
+
+  it('should bump premajorVersionBump semver as minor', async () => {
+    const packages = ['package-1', 'package-2', 'package-3', 'package-4', 'package-5'];
+    packages.forEach(() => (recommendVersion as Mock).mockResolvedValueOnce('0.2.0'));
+
+    const cwd = await initFixture('normal-premajor');
+
+    await new VersionCommand(createArgv(cwd, '--conventional-commits', '--premajor-version-bump', 'force-patch'));
+
+    const changedFiles = await showCommit(cwd, '--name-only');
+    expect(changedFiles).toMatchSnapshot();
+
+    packages.forEach((name) => {
+      const location = join(cwd, 'packages', name);
+
+      expect(recommendVersion).toHaveBeenCalledWith(
+        expect.objectContaining({ name, location }),
+        'fixed',
+        {
+          changelogPreset: undefined,
+          rootPath: cwd,
+          tagPrefix: 'v',
+          prereleaseId: undefined,
+          buildMetadata: undefined,
+        },
+        'force-patch'
+      );
+
+      expect(updateChangelog).toHaveBeenCalledWith(expect.objectContaining({ name, version: '0.2.0' }), 'fixed', {
+        changelogPreset: undefined,
+        rootPath: cwd,
+        tagPrefix: 'v',
+        prereleaseId: undefined,
+      });
+    });
   });
 });

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -166,13 +166,14 @@ describe.each([
       ['package-3', '4.0.0'],
       ['package-4', '4.1.0'],
       ['package-5', '5.0.1'],
+      ['package-6', '0.2.0'],
     ]);
 
     versionBumps.forEach((bump) => (recommendVersion as Mock).mockResolvedValueOnce(bump));
 
     await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits'));
 
-    expect(client.releases.size).toBe(5);
+    expect(client.releases.size).toBe(6);
     versionBumps.forEach((version, name) => {
       expect(client.releases.get(`${name}@${version}`)).toEqual({
         owner: 'lerna',
@@ -304,7 +305,7 @@ describe.each([
 
     await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--skip-bump-only-release'));
 
-    expect(client.releases.size).toBe(4);
+    expect(client.releases.size).toBe(5);
     versionBumps.forEach((version, name) => {
       if (name === 'package-4') {
         expect(client.releases.get(`${name}@${version}`)).toBeFalsy();
@@ -337,7 +338,7 @@ describe.each([
 
     await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--skip-bump-only-releases'));
 
-    expect(client.releases.size).toBe(4);
+    expect(client.releases.size).toBe(5);
     versionBumps.forEach((version, name) => {
       if (name === 'package-4') {
         expect(client.releases.get(`${name}@${version}`)).toBeFalsy();
@@ -370,7 +371,7 @@ describe.each([
 
     await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits'));
 
-    expect(client.releases.size).toBe(5);
+    expect(client.releases.size).toBe(6);
     versionBumps.forEach((version, name) => {
       expect(client.releases.get(`${name}@${version}`)).toEqual({
         owner: 'lerna',

--- a/packages/version/src/conventional-commits/recommend-version.ts
+++ b/packages/version/src/conventional-commits/recommend-version.ts
@@ -20,7 +20,8 @@ export async function recommendVersion(
     prereleaseId?: string;
     conventionalBumpPrerelease?: boolean;
     buildMetadata?: string;
-  }
+  },
+  premajorVersionBump?: 'default' | 'force-patch'
 ): Promise<string | null> {
   const { changelogPreset, rootPath, tagPrefix, prereleaseId, conventionalBumpPrerelease, buildMetadata } = recommendationOptions;
 
@@ -90,8 +91,14 @@ export async function recommendVersion(
           // breaking changes. This matches the behavior of `^` operator
           // as implemented by `npm`.
           //
+          // In node-semver, it is however also documented that
+          // "Many authors treat a 0.x version as if the x were the major "breaking-change" indicator."
+          // and all other features or bug fixes as semver-patch bumps
+          // this can be enabled in lerna through `premajorVersionBump = "force-patch"`
           if (releaseType === 'major') {
             releaseType = 'minor';
+          } else if (premajorVersionBump === 'force-patch') {
+            releaseType = 'patch';
           }
         }
         log.verbose(type, 'increment %s by %s - %s', pkg.version, releaseType, pkg.name);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per original Lerna [PR 3876](https://github.com/lerna/lerna/pull/3876)

> * Added `premajorVersionBump` (`--premajor-version-bump`) option for `lerna version --conventional-commits`, can be configured with either `"semver"` or `"node-semver"`
> * This functionality controls how premajor version packages are bumped by lerna when using `--conventional-commits` with `lerna version`.
> * `"semver"` is the default and bumps premajor version packages as `minor` for `feat/fix` and is aligned with how lerna handles bumps for premajor version packages today.
> * `"node-semver"` bumps `feat/fix` updates as `patch`.

## Motivation and Context

As per Lerna PR
> **Short summary** Add an option to control version bumps for `premajor` version when `lerna version --conventional-commits` is used since `node-semver` documents it as common to handle minor version bumps as breaking changes and `npm` is configured to not automatically bump `premajor` version releases to `minor` when using `^` in `package.json`. The recommendation from `semver` is to try to bump the package to `1.0.0` as fast as possible but there does not appear to be a strict guideline that states that you must do this to be compliant with semver.
> 
> This PR is based on the feature request I made in #3863 which @fahslaj suggested I make a PR for so long as it remains backwards compatible.
> 
> Original proposal from feature request 3863
> https://github.com/lerna/lerna/blob/914dd964d7a4a127be3d4f2703322ab1b31594f6/libs/core/src/lib/conventional-commits/recommend-version.ts#L76-L94

## How Has This Been Tested?

As per Lerna PR
> 1. I've updated `independent` and `independent-prerelease` fixtures to include an additional package with "0.1.0" version  to ensure that there's coverage of premajor version package bumps in the current state before adding my feature.
> 2. I've added two additional fixtures for testing the new `preMajorVersionBump` option that I added in `independent` and `fixed` mode.
> 3. I've added two additional tests for `version-conventional-commits.spec.ts` to validate the new feature as well as backwards compatibility. (Not 100% sure if the 2nd test with `"--premajor-version-bump semver"` being explicitly set is needed though)
> 
> Note: I had to update existing tests to support the additional packages with the additional premajor version package in the fixtures. Tests were also updated ensure the default `premajorVersionBump` argument passed to `recommendVersion` is accounted for as part of the `expect(recommendVersion).toHaveBeenCalledWith` test to continue to work since I've added the feature by passing the option to this function.
> 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
