### PR TITLE
chore(version): remove deprecated singular `--skip-bump-only-release`

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -652,9 +652,6 @@
             "forceGitTag": {
               "$ref": "#/$defs/commandOptions/version/forceGitTag"
             },
-            "skipBumpOnlyRelease": {
-              "$ref": "#/$defs/commandOptions/version/skipBumpOnlyRelease"
-            },
             "skipBumpOnlyReleases": {
               "$ref": "#/$defs/commandOptions/version/skipBumpOnlyReleases"
             },
@@ -1372,10 +1369,6 @@
         "forceGitTag": {
           "type": "boolean",
           "description": "During `lerna version`, when true, pass the `--force` flag to `git tag`."
-        },
-        "skipBumpOnlyRelease": {
-          "type": "boolean",
-          "description": "(deprecated) renamed to plural name \"--skip-bump-only-releases\". Skip GitHub/GitLab release creation when the version is a \"Version bump only for package x\""
         },
         "skipBumpOnlyReleases": {
           "type": "boolean",

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -309,9 +309,6 @@ export interface VersionCommandOption {
    */
   premajorVersionBump?: 'default' | 'force-patch';
 
-  /** @deprecated @alias `skipBumpOnlyReleases` renamed previous flag from `skipBumpOnlyRelease` to `skipBumpOnlyReleases`. */
-  skipBumpOnlyRelease?: boolean;
-
   /** Defaults to false, should we skip GitHub/GitLab release creation when the version is a "Version bump only for package x" */
   skipBumpOnlyReleases?: boolean;
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -424,8 +424,6 @@ lerna version --conventional-commits --create-release github --create-release-di
 
 When this option is enabled and a package version is only being bumped without any conventional commits detected, the GitHub/GitLab release will be skipped. This will avoid creating releases with only "Version bump only for package x" in the release notes, however please note that each changelog are still going to be updated with the "version bump only" text.
 
-> **Note** first implemented as `--skip-bump-only-release` but later renamed to a plural option `--skip-bump-only-releases` which is a better option name to represent multiple releases can be skipped.
-
 ```sh
 lerna version --create-release github --skip-bump-only-releases
 

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -289,40 +289,6 @@ describe.each([
     });
   });
 
-  // @deprecated since it was renamed to pluralized option name, this test and singular option name will be removed in next major
-  it('creates a release for every independent version but skip "version bump only" packages when --skip-bump-only-release is enabled', async () => {
-    process.env.GH_TOKEN = 'TOKEN';
-    const cwd = await initFixture('independent');
-    const versionBumps = new Map([
-      ['package-1', '1.0.1'],
-      ['package-2', '2.0.1'],
-      ['package-3', '4.0.1'],
-      ['package-4', '4.0.1'],
-      ['package-5', '5.0.1'],
-    ]);
-
-    versionBumps.forEach((bump) => (recommendVersion as Mock).mockResolvedValueOnce(bump));
-
-    await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--skip-bump-only-release'));
-
-    expect(client.releases.size).toBe(5);
-    versionBumps.forEach((version, name) => {
-      if (name === 'package-4') {
-        expect(client.releases.get(`${name}@${version}`)).toBeFalsy();
-      } else {
-        expect(client.releases.get(`${name}@${version}`)).toEqual({
-          owner: 'lerna',
-          repo: 'lerna',
-          tag_name: `${name}@${version}`,
-          name: `${name}@${version}`,
-          body: `${name} - ${version}`,
-          draft: false,
-          prerelease: false,
-        });
-      }
-    });
-  });
-
   it('creates a release for every independent version but skip "version bump only" packages when --skip-bump-only-releases is enabled', async () => {
     process.env.GITHUB_TOKEN = 'TOKEN';
     const cwd = await initFixture('independent');

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -381,7 +381,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
           {
             gitRemote: this.options.gitRemote,
             execOpts: this.execOpts,
-            skipBumpOnlyReleases: this.options.skipBumpOnlyReleases ?? this.options.skipBumpOnlyRelease,
+            skipBumpOnlyReleases: this.options.skipBumpOnlyReleases,
           },
           this.options.dryRun
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove deprecated option

## Motivation and Context

The singular option `--skip-bump-only-release` was not representing the fact that it's always used in independent mode and is focusing multiple version releases

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
