### PR TITLE
fix(watch): avoid chokidar throttling on watch startup

### DIFF
--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -117,7 +117,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
       }
 
       // initialize chokidar watcher for each package found
-      this._watcher = chokidar.watch(...new Set(...packageLocations), chokidarOptions);
+      this._watcher = chokidar.watch([...new Set(packageLocations)], chokidarOptions);
 
       // add Chokidar watcher and watch for all events (add, addDir, unlink, unlinkDir)
       this._watcher.on('all', (_event, path) => this.changeEventListener(path)).on('error', (error) => this.onError(error));

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -117,7 +117,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
       }
 
       // initialize chokidar watcher for each package found
-      this._watcher = chokidar.watch(...new Set(packageLocations), chokidarOptions);
+      this._watcher = chokidar.watch(...new Set(...packageLocations), chokidarOptions);
 
       // add Chokidar watcher and watch for all events (add, addDir, unlink, unlinkDir)
       this._watcher.on('all', (_event, path) => this.changeEventListener(path)).on('error', (error) => this.onError(error));

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -117,7 +117,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
       }
 
       // initialize chokidar watcher for each package found
-      this._watcher = chokidar.watch(packageLocations, chokidarOptions);
+      this._watcher = chokidar.watch(...new Set(packageLocations), chokidarOptions);
 
       // add Chokidar watcher and watch for all events (add, addDir, unlink, unlinkDir)
       this._watcher.on('all', (_event, path) => this.changeEventListener(path)).on('error', (error) => this.onError(error));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Saw a PR on Vite project, in which the use of a `Set` removes deduplicate files to watch and makes the chokidar process start faster without watching for duplicate entries

## Motivation and Context

Just implementing the same as Vite's [PR](https://github.com/vitejs/vite/pull/15347) which seems like a good idea to avoid watching duplicate entries and also makes the chokidar watch start faster, it seems like a win-win approach

As per Vite's PR comment

> Vite dev server producing unexpected hmr updates on startup without changes. Chokidar is throttling directory reads on initial watch, producing add events, and vite responds with hmr updates to the add events. Deduping the array passed to `chokidar.watch` on server creation fixes the issue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
