### PR TITLE
feat(version): add `--generate-release-notes` for GitHub release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
     "version": {
       "conventionalCommits": true,
       "createRelease": "github",
-      "changelogIncludeCommitsClientLogin": " - by @%l",
+      "generateReleaseNotes": true,
       "changelogHeaderMessage": "## Automate your Workspace Versioning, Publishing & Changelogs with [Lerna-Lite](https://github.com/lerna-lite/lerna-lite) 📦🚀",
       "message": "chore(release): publish new version %v"
     }

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1314,6 +1314,10 @@
           "type": "string",
           "description": "Create a GitHub Discussion from the new release (note that createRelease must be enabled for this to work)."
         },
+        "generateReleaseNotes": {
+          "type": "boolean",
+          "description": "Whether to automatically generate the name and body for this release."
+        },
         "message": {
           "type": "string",
           "description": "For `lerna version`, the custom commit message to use when creating the version commit."

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1316,7 +1316,7 @@
         },
         "generateReleaseNotes": {
           "type": "boolean",
-          "description": "Whether to automatically generate the name and body for this release."
+          "description": "Provides an alternative to create a GitHub release by letting GitHub automatically generate the name and body for the new release."
         },
         "message": {
           "type": "string",

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -123,6 +123,10 @@ export default {
         describe: 'Create a GitHub Discussion from the new release (note that createRelease must be enabled for this to work).',
         type: 'string',
       },
+      'generate-release-notes': {
+        describe: 'Whether to automatically generate the name and body for this release.',
+        type: 'boolean',
+      },
       'ignore-changes': {
         describe: [
           'Ignore changes in files matched by glob(s) when detecting changed packages.',

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -124,7 +124,8 @@ export default {
         type: 'string',
       },
       'generate-release-notes': {
-        describe: 'Whether to automatically generate the name and body for this release.',
+        describe:
+          'Provides an alternative to create a GitHub release by letting GitHub automatically generate the name and body for the new release.',
         type: 'boolean',
       },
       'ignore-changes': {

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -193,7 +193,7 @@ export interface VersionCommandOption {
   /** Create a GitHub Discussion from the new release (note that createRelease must be enabled for this to work and it only works with GitHub at the moment). */
   createReleaseDiscussion?: string;
 
-  /** Whether to automatically generate the name and body for this release. */
+  /** Provides an alternative to create a GitHub release by letting GitHub automatically generate the name and body for the new release. */
   generateReleaseNotes?: boolean;
 
   /** Specify cross-dependency version numbers exactly rather than with a caret (^). */

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -193,6 +193,9 @@ export interface VersionCommandOption {
   /** Create a GitHub Discussion from the new release (note that createRelease must be enabled for this to work and it only works with GitHub at the moment). */
   createReleaseDiscussion?: string;
 
+  /** Whether to automatically generate the name and body for this release. */
+  generateReleaseNotes?: boolean;
+
   /** Specify cross-dependency version numbers exactly rather than with a caret (^). */
   exact?: boolean;
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -83,6 +83,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--changelog-header-message <msg>`](#--changelog-header-message-msg)
     - [`--create-release <type>`](#--create-release-type)
     - [`--create-release-discussion <name>`](#--create-release-discussion-name)
+    - [`--generate-release-notes`](#--generate-release-notes)
     - [`--skip-bump-only-releases`](#--skip-bump-only-releases)
     - [`--describe-tag <pattern>`](#--describe-tag-pattern)
     - [`--exact`](#--exact)
@@ -417,8 +418,17 @@ Create a discussion for this release, this will create both a Release and a Disc
 lerna version --conventional-commits --create-release github --create-release-discussion announcement
 ```
 
-> **Note** currently only available for GitHub Releases following this GitHub blog post [You can now link discussions to new releases](https://github.blog/changelog/2021-04-06-releases-support-comments-and-reactions-with-discussion-linking/)
+> **Note** this option is currently only available for GitHub Releases following this GitHub blog post [You can now link discussions to new releases](https://github.blog/changelog/2021-04-06-releases-support-comments-and-reactions-with-discussion-linking/)
 
+### `--generate-release-notes`
+
+When run with this flag, `lerna version` will create an official GitHub release by automatically generating the name and body for the new release.
+
+```sh
+lerna version --conventional-commits --create-release github --generate-release-notes
+```
+
+> **Note** this option is currently only available for GitHub Releases, more info can be found in this GitHub documentation page [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
 
 ### `--skip-bump-only-releases`
 

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -21,7 +21,11 @@ export async function createReleaseClient(type: 'github' | 'gitlab'): Promise<Gi
 
 /** Create a release on a remote client (github or gitlab) */
 export function createRelease(
-  { client, releaseDiscussion }: { client: GitCreateReleaseClientOutput; releaseDiscussion?: string },
+  {
+    client,
+    generateReleaseNotes,
+    releaseDiscussion,
+  }: { client: GitCreateReleaseClientOutput; generateReleaseNotes?: boolean; releaseDiscussion?: string },
   { tags, releaseNotes }: ReleaseCommandProps,
   { gitRemote, execOpts, skipBumpOnlyReleases }: ReleaseOptions,
   dryRun = false
@@ -61,8 +65,6 @@ export function createRelease(
         owner: repo.owner,
         repo: repo.name,
         tag_name: tag,
-        name: tag,
-        body: notes,
         draft: false,
         prerelease: prereleaseParts.length > 0,
       };
@@ -70,6 +72,15 @@ export function createRelease(
       // also optionally create a Discussion with the release (currently only works with GitHub)
       if (releaseDiscussion) {
         releaseOptions.discussion_category_name = releaseDiscussion;
+      }
+
+      // whether to automatically generate the `name` and `body` for this release
+      // else we'll add the notes as the release description body & tag as the name
+      if (generateReleaseNotes) {
+        releaseOptions.generate_release_notes = generateReleaseNotes;
+      } else {
+        releaseOptions.name = tag;
+        releaseOptions.body = notes;
       }
 
       if (dryRun) {

--- a/packages/version/src/models/index.ts
+++ b/packages/version/src/models/index.ts
@@ -69,10 +69,11 @@ export interface GitClientReleaseOption {
   owner: string;
   repo: string;
   tag_name: string;
-  name: string;
+  name?: string;
   body?: string;
   draft?: boolean;
   prerelease?: boolean;
+  generate_release_notes?: boolean;
   discussion_category_name?: string;
 }
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -143,6 +143,10 @@ export class VersionCommand extends Command<VersionCommandOption> {
       throw new ValidationError('ERELEASE', 'To create a release, you must enable --conventional-commits');
     }
 
+    if (this.options.generateReleaseNotes && !this.options.createRelease) {
+      throw new ValidationError('ERELEASE', 'To generate release notes, you must define --create-release');
+    }
+
     if (this.options.createReleaseDiscussion && !this.options.createRelease) {
       throw new ValidationError('ERELEASE', 'To create a release discussion, you must define --create-release');
     }
@@ -376,7 +380,11 @@ export class VersionCommand extends Command<VersionCommandOption> {
       this.logger.info('execute', 'Creating releases...');
       try {
         await createRelease(
-          { client: this.releaseClient, releaseDiscussion: this.options.createReleaseDiscussion },
+          {
+            client: this.releaseClient,
+            generateReleaseNotes: this.options.generateReleaseNotes,
+            releaseDiscussion: this.options.createReleaseDiscussion,
+          },
           { tags: this.tags, releaseNotes: this.releaseNotes },
           {
             gitRemote: this.options.gitRemote,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provides an alternative to create a GitHub release by letting GitHub automatically generate the name and body for the new release. More info from GitHub docs [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)

## Motivation and Context

add a new option `lerna version --generate-release-notes`, closes #793

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
