### PR TITLE
fix(version): allow generateReleaseNotes w/o changelog

### DIFF
--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -412,7 +412,7 @@ When run with this flag, `lerna version` will create an official GitHub or GitLa
 
 ### `--create-release-discussion <name>`
 
-Create a discussion for this release, this will create both a Release and a Discussion.
+Create a discussion for this release, this will create both a Release and a Discussion. Conventional commits is required for this option to work.
 
 ```sh
 lerna version --conventional-commits --create-release github --create-release-discussion announcement
@@ -422,10 +422,16 @@ lerna version --conventional-commits --create-release github --create-release-di
 
 ### `--generate-release-notes`
 
-When run with this flag, `lerna version` will create an official GitHub release by automatically generating the name and body for the new release.
+When run with this flag, `lerna version` will create an official GitHub release by automatically generating the name and body for the new release. Conventional commits is required for this option to work.
 
 ```sh
 lerna version --conventional-commits --create-release github --generate-release-notes
+```
+
+You could also skip the changelog creation since GitHub automatically generates the name and body for the new release.
+
+```sh
+lerna version --conventional-commits --no-changelog --create-release github --generate-release-notes
 ```
 
 > **Note** this option is currently only available for GitHub Releases, more info can be found in this GitHub documentation page [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
@@ -468,7 +474,7 @@ To authenticate with GitLab, the following environment variables can be defined.
 - `GL_TOKEN` (required): Your GitLab authentication token (under User Settings > Access Tokens).
 - `GL_API_URL`: An absolute URL to the API, including the version. (Default: https://gitlab.com/api/v4)
 
-> **Note** When using this option, you cannot pass [`--no-changelog`](#--no-changelog).
+> **Note** When using this option, you cannot pass [`--no-changelog`](#--no-changelog) except when used with [`--generate-release-notes`](#--generate-release-notes).
 
 ### `--exact`
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -428,7 +428,7 @@ When run with this flag, `lerna version` will create an official GitHub release 
 lerna version --conventional-commits --create-release github --generate-release-notes
 ```
 
-You could also skip the changelog creation since GitHub automatically generates the name and body for the new release.
+Since GitHub automatically generates the name and body for the new release, you could skip the changelog creation if you wish.
 
 ```sh
 lerna version --conventional-commits --no-changelog --create-release github --generate-release-notes

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -386,7 +386,7 @@ it('should create a github release discussion when enabled', async () => {
   });
 });
 
-it('should create a github release and generate release notes', async () => {
+it('should create a github release and generate release notes with changelog', async () => {
   process.env.GH_TOKEN = 'TOKEN';
   const createReleaseMock = vi.fn(() => Promise.resolve(true));
   (createReleaseClient as Mock).mockImplementation(() => Promise.resolve({ repos: { createRelease: createReleaseMock } }));
@@ -396,6 +396,29 @@ it('should create a github release and generate release notes', async () => {
   (recommendVersion as Mock).mockResolvedValueOnce('1.1.0');
 
   const command = new VersionCommand(createArgv(cwd, '--create-release', 'github', '--conventional-commits', '--generate-release-notes'));
+  await command;
+  await command.execute();
+
+  expect(createReleaseMock).toHaveBeenCalledWith({
+    owner: 'lerna',
+    repo: 'lerna',
+    tag_name: 'v1.1.0',
+    draft: false,
+    generate_release_notes: true,
+    prerelease: false,
+  });
+});
+
+it('should create a github release and generate release notes with --no-changelog', async () => {
+  process.env.GH_TOKEN = 'TOKEN';
+  const createReleaseMock = vi.fn(() => Promise.resolve(true));
+  (createReleaseClient as Mock).mockImplementation(() => Promise.resolve({ repos: { createRelease: createReleaseMock } }));
+
+  const cwd = await initFixture('normal');
+
+  (recommendVersion as Mock).mockResolvedValueOnce('1.1.0');
+
+  const command = new VersionCommand(createArgv(cwd, '--create-release', 'github', '--conventional-commits', '--generate-release-notes', '--no-changelog'));
   await command;
   await command.execute();
 

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -23,9 +23,15 @@ export async function createReleaseClient(type: 'github' | 'gitlab'): Promise<Gi
 export function createRelease(
   {
     client,
+    type,
     generateReleaseNotes,
     releaseDiscussion,
-  }: { client: GitCreateReleaseClientOutput; generateReleaseNotes?: boolean; releaseDiscussion?: string },
+  }: {
+    client: GitCreateReleaseClientOutput;
+    type: 'github' | 'gitlab';
+    generateReleaseNotes?: boolean;
+    releaseDiscussion?: string;
+  },
   { tags, releaseNotes }: ReleaseCommandProps,
   { gitRemote, execOpts, skipBumpOnlyReleases }: ReleaseOptions,
   dryRun = false
@@ -47,7 +53,7 @@ export function createRelease(
 
       // when the `GH_TOKEN` (or `GITHUB_TOKEN`) environment variable is not set,
       // we'll create a link to GitHub web interface form with the fields pre-populated
-      if (!GH_TOKEN && !GITHUB_TOKEN) {
+      if (type === 'github' && !GH_TOKEN && !GITHUB_TOKEN) {
         const releaseUrl = newGithubReleaseUrl({
           user: repo.owner,
           repo: repo.name,

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -158,7 +158,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       );
     }
 
-    if (this.releaseClient && this.options.changelog === false) {
+    if (this.releaseClient && this.options.changelog === false && this.options.generateReleaseNotes !== true) {
       throw new ValidationError('ERELEASE', 'To create a release, you cannot pass --no-changelog');
     }
 
@@ -382,6 +382,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
         await createRelease(
           {
             client: this.releaseClient,
+            type: this.options.createRelease!,
             generateReleaseNotes: this.options.generateReleaseNotes,
             releaseDiscussion: this.options.createReleaseDiscussion,
           },
@@ -711,6 +712,13 @@ export class VersionCommand extends Command<VersionCommandOption> {
           return pkg;
         })
       );
+    } else if (this.options.generateReleaseNotes && !changelog) {
+      actions.push((pkg: Package) => {
+        this.releaseNotes.push({
+          name: pkg.name,
+          pkg,
+        });
+      });
     }
 
     const mapUpdate = pPipe(...actions);
@@ -793,6 +801,12 @@ export class VersionCommand extends Command<VersionCommandOption> {
             });
           })
         );
+      } else if (this.options.generateReleaseNotes && !changelog) {
+        chain.then(() => {
+          this.releaseNotes.push({
+            name: 'fixed',
+          });
+        });
       }
 
       chain = chain.then(() =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We should be able to pass `--no-changelog` when executing the new `--generate-release-notes` option, so the full command below should be valid
```sh
lerna version --conventional-commits --no-changelog --create-release github --generate-release-notes
```

## Motivation and Context

Related to issue #793 

Since `--generate-release-notes` is automatically created by GitHub itself, it shouldn't matter if we're not updating our changelog since they are not being used by GitHub to create the release anyway
> GitHub creates a release by automatically generating the name and body for the new release

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
