### PR TITLE
fix(publish): lerna publish --canary --dry-run shouldn't throw

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "preview:version": "lerna version --dry-run --yes",
     "major-release": "pnpm build:full && lerna publish 2.0.0",
     "preview:release": "lerna publish --dry-run --yes",
+    "preview:release:canary": "lerna publish --dry-run --yes --canary",
     "preview:roll-new-release": "pnpm build:full && lerna version --yes --dry-run && lerna publish from-package --dry-run --yes",
     "new-version": "lerna version",
     "new-publish": "lerna publish from-package",

--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -79,7 +79,7 @@ describe('collectUpdates()', () => {
       }),
     ]);
     expect(hasTags).toHaveBeenLastCalledWith(execOpts, '');
-    expect(describeRefSync).toHaveBeenLastCalledWith({ cwd: '/test', match: '' }, undefined, false);
+    expect(describeRefSync).toHaveBeenLastCalledWith({ cwd: '/test', match: '' }, undefined);
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
       independentSubpackages: undefined,
     });
@@ -102,7 +102,7 @@ describe('collectUpdates()', () => {
       }),
     ]);
     expect(hasTags).toHaveBeenLastCalledWith(execOpts, '*@*');
-    expect(describeRefSync).toHaveBeenLastCalledWith(execOpts, undefined, false);
+    expect(describeRefSync).toHaveBeenLastCalledWith(execOpts, undefined);
     expect(makeDiffPredicate).toHaveBeenLastCalledWith('v1.0.0', execOpts, undefined, {
       independentSubpackages: undefined,
     });
@@ -479,7 +479,7 @@ describe('collectUpdates()', () => {
       isIndependent: true,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*custom-tag*' }, true, false);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*custom-tag*' }, true);
   });
 
   it('no use "describeTag" in independent mode', async () => {
@@ -491,7 +491,7 @@ describe('collectUpdates()', () => {
       isIndependent: true,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*@*' }, true, false);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*@*' }, true);
   });
 
   it('use "describeTag" in non-independent mode', async () => {
@@ -504,7 +504,7 @@ describe('collectUpdates()', () => {
       isIndependent: false,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*custom-tag*' }, true, false);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*custom-tag*' }, true);
   });
 
   it('no use "describeTag" in non-independent mode', async () => {
@@ -516,7 +516,7 @@ describe('collectUpdates()', () => {
       isIndependent: false,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '' }, true, false);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '' }, true);
   });
 
   it('use "describeTag" with empty value in independent mode', async () => {
@@ -529,6 +529,6 @@ describe('collectUpdates()', () => {
       isIndependent: true,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*@*' }, true, false);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*@*' }, true);
   });
 });

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -54,7 +54,7 @@ export function collectUpdates(
     describeOptions.match = tagPattern;
 
     // describe the last annotated tag in the current branch
-    const { sha, refCount, lastTagName } = describeRefSync(describeOptions, commandOptions.includeMergedTags, dryRun);
+    const { sha, refCount, lastTagName } = describeRefSync(describeOptions, commandOptions.includeMergedTags);
     // TODO: warn about dirty tree?
 
     if (refCount === '0' && forced.size === 0 && !committish) {

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -20,8 +20,7 @@ export function collectUpdates(
   filteredPackages: Package[],
   packageGraph: PackageGraph,
   execOpts: ExecOpts,
-  commandOptions: UpdateCollectorOptions,
-  dryRun = false
+  commandOptions: UpdateCollectorOptions
 ) {
   const {
     forcePublish,

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -452,22 +452,16 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     // find changed packages since last release, if any
     chain = chain.then(() =>
-      collectUpdates(
-        this.packageGraph?.rawPackageList ?? [],
-        this.packageGraph,
-        this.execOpts,
-        {
-          bump: 'prerelease',
-          canary: true,
-          ignoreChanges,
-          forcePublish,
-          includeMergedTags,
-          isIndependent,
-          describeTag,
-          // private packages are never published, don't bother describing their refs.
-        } as UpdateCollectorOptions,
-        this.options.dryRun
-      ).filter((node) => !node.pkg.private)
+      collectUpdates(this.packageGraph?.rawPackageList ?? [], this.packageGraph, this.execOpts, {
+        bump: 'prerelease',
+        canary: true,
+        ignoreChanges,
+        forcePublish,
+        includeMergedTags,
+        isIndependent,
+        describeTag,
+        // private packages are never published, don't bother describing their refs.
+      } as UpdateCollectorOptions).filter((node) => !node.pkg.private)
     );
 
     // prettier-ignore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

running the command `lerna publish --canary --dry-run` shouldn't throw

## Motivation and Context

as pointed out on a blog post, running `lerna publish --canary --dry-run` command was throwing an error with a git ref diff comparing with `undefined^undefined` because the git command was not actually run but only printed to the screen, however we do need to run this command for a proper publish dry-run

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
