### PR TITLE
fix(publish): --canary --dry-run command should create valid tags

### DIFF
--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -438,14 +438,7 @@ test('publish --canary --include-merged-tags calls git describe correctly', asyn
 
   await new PublishCommand(createArgv(cwd, '--canary', '--include-merged-tags'));
 
-  expect(describeRef).toHaveBeenCalledWith(
-    {
-      match: 'v*.*.*',
-      cwd,
-    },
-    true,
-    undefined
-  );
+  expect(describeRef).toHaveBeenCalledWith({ match: 'v*.*.*', cwd }, true);
 });
 
 test('publish --canary without _any_ tags', async () => {

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -484,8 +484,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
               match: `${node.name}@*`,
               cwd,
             },
-            includeMergedTags,
-            this.options.dryRun
+            includeMergedTags
           )
             // an unpublished package will have no reachable git tag
             .then(makeVersion(node.version))
@@ -503,8 +502,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
             match: `${this.tagPrefix}*.*.*`,
             cwd,
           },
-          includeMergedTags,
-          this.options.dryRun
+          includeMergedTags
         )
           // a repo with no tags should default to whatever lerna.json claims
           .then(makeVersion(this.project.version))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a continuation of previous PR #801
Running the command `lerna publish --canary --dry-run` shouldn't throw and have valid described tags

## Motivation and Context

This is a continuation of previous PR #801, the output wasn't quite right and wasn't producing a valid version from a SHA, this PR fixes that. 

as pointed out on a blog post, running `lerna publish --canary --dry-run` command was throwing an error with a git ref diff comparing with `undefined^undefined` because the git command was not actually run but only printed to the screen, however we do need to run this command for a proper publish dry-run

It no longer throws an error and the version field is now valid

![image](https://github.com/lerna-lite/lerna-lite/assets/643976/d56f9546-7a5e-415f-8868-79277cc48307)


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
