### PR TITLE
feat(version): custom tag-version-separator for independent projects

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1350,6 +1350,10 @@
           "type": "boolean",
           "description": "During `lerna version`, when true, commit and tag version changes."
         },
+        "tagVersionSeparator": {
+          "type": "string",
+          "description": "Customize the tag version separator used when creating tags for independent versioning, defaults to \"@\"."
+        },
         "noPush": {
           "type": "boolean",
           "description": "During `lerna version`, when true, do not push tagged commit to git remote."

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -181,6 +181,12 @@ export default {
         hidden: true,
         type: 'boolean',
       },
+      'tag-version-separator': {
+        describe: 'Customize the tag version separator used when creating tags for independent versioning, defaults to "@".',
+        type: 'string',
+        requiresArg: true,
+        defaultDescription: '@',
+      },
       // TODO: (major) make --no-granular-pathspec the default
       'no-granular-pathspec': {
         describe: 'Do not stage changes file-by-file, but globally.',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -295,6 +295,9 @@ export interface VersionCommandOption {
   /** Defaults to 'v', customize the tag prefix. To remove entirely, pass an empty string. */
   tagVersionPrefix?: string;
 
+  /** Customize the tag version separator used when creating tags for independent versioning. */
+  tagVersionSeparator?: string;
+
   /** Do not manually update (read/write back to the lock file) the project root lock file. */
   noManuallyUpdateRootLockfile?: boolean;
 

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -24,6 +24,9 @@ export interface DescribeRefOptions {
 
   /* Glob passed to `--match` flag */
   match?: string;
+
+  /** Separator used within independent version tags, defaults to @ */
+  separator?: string;
 }
 
 /* When annotated release tags are missing */
@@ -223,6 +226,9 @@ export interface UpdateCollectorOptions {
   forceConventionalGraduate?: boolean;
 
   excludeDependents?: boolean;
+
+  // Separator used within independent version tags, defaults to @
+  tagVersionSeparator?: string;
 
   /** optionally exclude sub-packages when versioning */
   independentSubpackages?: boolean;

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -31,6 +31,7 @@ export function collectUpdates(
     independentSubpackages,
     isIndependent,
     describeTag,
+    tagVersionSeparator,
   } = commandOptions;
 
   // If --conventional-commits and --conventional-graduate are both set, ignore --force-publish but consider --force-conventional-graduate
@@ -48,9 +49,9 @@ export function collectUpdates(
   if (hasTags(execOpts, tagPattern)) {
     const describeOptions: DescribeRefOptions = {
       ...execOpts,
+      match: tagPattern,
+      separator: tagVersionSeparator,
     };
-
-    describeOptions.match = tagPattern;
 
     // describe the last annotated tag in the current branch
     const { sha, refCount, lastTagName } = describeRefSync(describeOptions, commandOptions.includeMergedTags);

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -89,8 +89,9 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--exact`](#--exact)
     - [`--independent-subpackages`](#--independent-subpackages)
     - [`--force-publish`](#--force-publish)
-    - [`--git-tag-command <cmd>`](#--git-tag-command-cmd)
     - [`--dry-run`](#--dry-run)
+    - [`--git-tag-command <cmd>`](#--git-tag-command-cmd)
+    - [`--tag-version-separator`](#--tag-version-separator)
     - [`--git-remote <name>`](#--git-remote-name)
     - [`--ignore-changes`](#--ignore-changes)
     - [`--ignore-scripts`](#--ignore-scripts)
@@ -536,6 +537,13 @@ This can also be configured in `lerna.json`.
     }
   }
 }
+```
+
+### `--tag-version-separator`
+Customize the tag version separator used when creating tags for independent versioning, defaults to "@".
+
+```sh
+lerna version --tag-version-separator "__"
 ```
 
 ### `--git-remote <name>`

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -846,7 +846,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
   }
 
   async gitCommitAndTagVersionForUpdates() {
-    const tags = this.packagesToVersion.map((pkg) => `${pkg.name}@${this.updatesVersions?.get(pkg.name)}`);
+    const tagVersionSeparator = this.options.tagVersionSeparator || '@';
+    const tags = this.packagesToVersion.map((pkg) => `${pkg.name}${tagVersionSeparator}${this.updatesVersions?.get(pkg.name)}`);
     const subject = this.options.message || 'chore: Publish new release';
     const message = tags.reduce((msg, tag) => `${msg}${OS_EOL} - ${tag}`, `${subject}${OS_EOL}`);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follows original Lerna [PR 3951](https://github.com/lerna/lerna/pull/3951)

> Allows users to customize the tag version separator for independent projects in cases where they do not want to use the default of `@`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
