### PR TITLE
fix(version): describeTag in lerna config version cmd/root, fix #826

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -328,6 +328,9 @@
             "contents": {
               "$ref": "#/$defs/commandOptions/shared/contents"
             },
+            "describeTag": {
+              "$ref": "#/$defs/globals/describeTag"
+            },
             "distTag": {
               "$ref": "#/$defs/commandOptions/publish/distTag"
             },
@@ -572,7 +575,7 @@
               "$ref": "#/$defs/commandOptions/version/changelogHeaderMessage"
             },
             "describeTag": {
-              "$ref": "#/$defs/commandOptions/shared/describeTag"
+              "$ref": "#/$defs/globals/describeTag"
             },
             "dryRun": {
               "$ref": "#/$defs/commandOptions/version/dryRun"
@@ -824,6 +827,9 @@
         }
       }
     },
+    "describeTag": {
+      "$ref": "#/$defs/globals/describeTag"
+    },
     "npmClient": {
       "$ref": "#/$defs/globals/npmClient"
     },
@@ -1059,6 +1065,11 @@
   },
   "$defs": {
     "globals": {
+      "describeTag": {
+        "type": "string",
+        "description": "During `lerna publish` (not `from-git` mode) and `lerna version`, the package updated since the last release will be found based on the describeTag.",
+        "default": ""
+      },
       "npmClient": {
         "type": "string",
         "description": "The npm client to use when running commands (either npm, pnpm or yarn). Defaults to npm if unspecified.",
@@ -1470,11 +1481,6 @@
         "conventionalGraduate": {
           "anyOf": [{ "type": "string" }, { "type": "boolean" }, { "type": "array", "items": { "type": "string" } }],
           "description": "Detect currently prereleased packages that would change to a non-prerelease version. Relevant for `lerna changed` and `lerna version`."
-        },
-        "describeTag": {
-          "type": "string",
-          "description": "During `lerna publish` (not `from-git` mode) and `lerna version`, the package updated since the last release will be found based on the describeTag.",
-          "default": ""
         },
         "forceConventionalGraduate": {
           "type": "boolean",

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -135,6 +135,9 @@ export interface LernaConfig {
     version?: VersionCommandOption;
     run?: RunCommandOption;
   };
+  /** custom tag pattern, default is `*@*` (independent mode) or `""` (non-independent mode) */
+  describeTag?: string;
+
   packages?: string[];
   loglevel?: 'silent' | 'error' | 'warn' | 'notice' | 'http' | 'timing' | 'info' | 'verbose' | 'silly';
 

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -991,12 +991,30 @@ describe('VersionCommand', () => {
   });
 
   describe('"describeTag" config', () => {
-    it('set "describeTag" in lerna.json', async () => {
+    it('set "describeTag" in lerna.json root config', async () => {
       const testDir = await initFixture('normal');
 
       await outputJson(join(testDir, 'lerna.json'), {
         version: 'independent',
         describeTag: '*custom-tag*',
+      });
+      await new VersionCommand(createArgv(testDir));
+
+      expect((collectUpdates as Mock).mock.calls[0][3].describeTag).toBe('*custom-tag*');
+
+      expect((collectUpdates as Mock).mock.calls[0][3].isIndependent).toBe(true);
+    });
+
+    it('set "describeTag" in lerna.json version command', async () => {
+      const testDir = await initFixture('normal');
+
+      await outputJson(join(testDir, 'lerna.json'), {
+        version: 'independent',
+        command: {
+          version: {
+            describeTag: '*custom-tag*',
+          },
+        },
       });
       await new VersionCommand(createArgv(testDir));
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -178,7 +178,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
 
   async initialize() {
     const isIndependent = this.project.isIndependent();
-    const describeTag = this.project.config.describeTag;
+    const describeTag = this.options.describeTag;
 
     if (!isIndependent) {
       this.logger.info('current project version', this.project.version ?? '');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We should be able to add `describeTag` from anywhere in the `lerna.json` config, it could be either from the root or the version command.

`lerna.json` root
```json
{
  "version": "1.0.0",
  "describeTag": "*custom-tag*"
}
```
or `lerna.json` version command
```json
{
  "version": "1.0.0",
  "command": {
    "version": {
      "describeTag": "*custom-tag*"
    }
  }
}
```

## Motivation and Context

As described in Discussion #820 and later confirmed and moved to a new issue #826

## How Has This Been Tested?

Added unit test and also tested manually with VSCode debugger in dry-run mode with `describeTag` set in both root & version command in `lerna.json` and they both detect the option

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
