### PR TITLE
fix(version): create release when using custom tag-version-separator

### DIFF
--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -32,7 +32,7 @@ export function createRelease(
     generateReleaseNotes?: boolean;
     releaseDiscussion?: string;
   },
-  { tags, releaseNotes }: ReleaseCommandProps,
+  { tags, releaseNotes, tagVersionSeparator }: ReleaseCommandProps,
   { gitRemote, execOpts, skipBumpOnlyReleases }: ReleaseOptions,
   dryRun = false
 ) {
@@ -41,7 +41,7 @@ export function createRelease(
 
   return Promise.all(
     releaseNotes.map(({ notes, name, pkg }) => {
-      const tag = name === 'fixed' ? tags[0] : tags.find((t) => t.startsWith(`${name}@`));
+      const tag = name === 'fixed' ? tags[0] : tags.find((t) => t.startsWith(`${name}${tagVersionSeparator}`));
 
       // when using independent mode, it could happen that a few version bump only releases are created
       // and since these aren't very useful for most users, user could choose to skip creating these releases when detecting a version bump only
@@ -49,7 +49,7 @@ export function createRelease(
         return Promise.resolve();
       }
 
-      const prereleaseParts = semver.prerelease(tag.replace(`${name}@`, '')) || [];
+      const prereleaseParts = semver.prerelease(tag.replace(`${name}${tagVersionSeparator}`, '')) || [];
 
       // when the `GH_TOKEN` (or `GITHUB_TOKEN`) environment variable is not set,
       // we'll create a link to GitHub web interface form with the fields pre-populated

--- a/packages/version/src/models/index.ts
+++ b/packages/version/src/models/index.ts
@@ -105,6 +105,7 @@ export interface ReleaseClient {
 
 export interface ReleaseCommandProps {
   tags: string[];
+  tagVersionSeparator: string;
   releaseNotes: ReleaseNote[];
 }
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -386,7 +386,11 @@ export class VersionCommand extends Command<VersionCommandOption> {
             generateReleaseNotes: this.options.generateReleaseNotes,
             releaseDiscussion: this.options.createReleaseDiscussion,
           },
-          { tags: this.tags, releaseNotes: this.releaseNotes },
+          {
+            tags: this.tags,
+            tagVersionSeparator: this.options.tagVersionSeparator || '@',
+            releaseNotes: this.releaseNotes,
+          },
           {
             gitRemote: this.options.gitRemote,
             execOpts: this.execOpts,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follows original Lerna [PR 3979](https://github.com/lerna/lerna/pull/3979)
> After the [8.1.0](https://github.com/lerna/lerna/releases/tag/v8.1.0), the version command does not create a GitHub release when using a custom version seperator. This was because the `createRelease` function had a hard coded `@` in tag name filter.


## Motivation and Context

to fix issue with custom version tag separator not working without `@`

## How Has This Been Tested?

Per Lerna PR

> To test, I create a test repo made changes to a packages and commit them. I then ran:
> 
> ```
> node /tmp/lerna/dist/packages/lerna/dist/cli.js version --tag-version-separator '-' --conventional-commits --create-release github --yes
> ```
> 
> And was able to see the new GitHub release created with the appropriate tag
> 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
