### PR TITLE
docs: add note about `--remove-package-fields` when publish fails

### DIFF
--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -296,6 +296,8 @@ lerna version --remove-package-fields 'devDependencies' 'scripts'
 
 > **Note** lifecycle scripts (`prepublish`, `prepublishOnly`, `prepack`, `postpack`) are executed after the field removal process and for that reason if any of these scripts are found, it will leave them in place and skip the removal whenever found.
 
+> **Note** this option will actually temporarily modify the actual `package.json` just before the publish process starts and will then revert the change after the publish process is completed. If for whatever reason, your publish process fails, it is possible that your each package, are now in an invalid state (e.g. `scripts` could be removed), so it very important to review your `package.json` after a publish failure.
+
 Removal of complex object value(s) are also supported via the dot notation as shown below.
 
 ```sh


### PR DESCRIPTION

## Description

adding a note in relation to the issue #850

## Motivation and Context

in rare occasion when a publish fails and user is using `--remove-package-fields`, it could leave the `package.json` (of each package) in an invalid state (e.g. `scripts` are now removed). So I'm adding this note to advise users of this limitation

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
