### PR TITLE
fix(versions): support `changelogPreset.header`, fixes #852

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,7 @@
         "packages/cli/dist/cli.js",
         "version",
         "--dry-run",
+        "--yes",
         "--changelog-include-commits-client-login",
         "--conventional-commits"
       ],

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -1,4 +1,4 @@
-import { RemoteClientType } from './interfaces.js';
+import { ChangelogPresetOptions, RemoteClientType } from './interfaces.js';
 
 export interface ChangedCommandOption {
   /** use conventional-changelog to determine version bump and generate CHANGELOG. */
@@ -185,7 +185,7 @@ export interface VersionCommandOption {
   changelogIncludeCommitsClientLogin?: boolean | string;
 
   /** Defaults 'angular', custom conventional-changelog preset. */
-  changelogPreset?: string;
+  changelogPreset?: string | ChangelogPresetOptions;
 
   /** Create an official GitHub or GitLab release for every version. */
   createRelease?: RemoteClientType;

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -16,6 +16,18 @@ export interface CommandOptions {
   rollVersion?: boolean;
 }
 
+export interface ChangelogPresetOptions {
+  name: string;
+  header?: string;
+  types?: Array<{ type: string; section: string; hidden?: boolean }>;
+  issuePrefixes?: string[];
+  issueUrlFormat?: string;
+  commitUrlFormat?: string;
+  compareUrlFormat?: string;
+  userUrlFormat?: string;
+  releaseCommitMessageFormat?: string;
+}
+
 export type CommandType = '' | 'changed' | 'exec' | 'info' | 'init' | 'list' | 'publish' | 'run' | 'version';
 
 export interface DescribeRefOptions {

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -276,6 +276,8 @@ If the preset exports a builder function (e.g. `conventional-changelog-conventio
 }
 ```
 
+> **Note** the option `changelogPreset.releaseCommitMessageFormat` is not supported and will throw, you can simply use [`--message`](#--message-msg) to have the same result.
+
 ### `--conventional-commits`
 
 ```sh

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -334,7 +334,7 @@ describe('VersionCommand', () => {
     });
 
     it('throws an error if changelogPreset is defined and includes releaseCommitMessageFormat', async () => {
-      const cwd = await initFixture('independent-changelog-preset-invalid');
+      const cwd = await initFixture('normal');
       const command = new VersionCommand({
         conventionalCommits: true,
         changelogPreset: { name: 'conventionalcommits', releaseCommitMessageFormat: 'test' },

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -332,6 +332,18 @@ describe('VersionCommand', () => {
       expect(command.changelogIncludeCommitsClientLogin).toBe(true);
       expect(getCommitsSinceLastRelease).toHaveBeenCalled();
     });
+
+    it('throws an error if changelogPreset is defined and includes releaseCommitMessageFormat', async () => {
+      const cwd = await initFixture('independent-changelog-preset-invalid');
+      const command = new VersionCommand({
+        conventionalCommits: true,
+        changelogPreset: { name: 'conventionalcommits', releaseCommitMessageFormat: 'test' },
+      } as unknown as VersionCommandOption);
+
+      await expect(command).rejects.toThrow(
+        'The Lerna config "changelogPreset.releaseCommitMessageFormat" is not supported, you should simply use "version.message" instead which will give you the same end result.'
+      );
+    });
   });
 
   describe('independent mode', () => {

--- a/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
+++ b/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
@@ -1,5 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`conventional-commits > updateChangelog() > creates changelog with changelogPreset when defined > leaf 1`] = `
+My Custom Header
+
+## 1.1.0 (YYYY-MM-DD)
+
+### ✨ Features
+
+* I should be placed in the CHANGELOG ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
+
+`;
+
+exports[`conventional-commits > updateChangelog() > creates changelog with changelogPreset when defined > root 1`] = `
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 1.1.0 (YYYY-MM-DD)
+
+### Features
+
+* I should be placed in the CHANGELOG ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
+
+`;
+
 exports[`conventional-commits > updateChangelog() > creates files if they do not exist > leaf 1`] = `
 # Change Log
 

--- a/packages/version/src/conventional-commits/get-changelog-config.ts
+++ b/packages/version/src/conventional-commits/get-changelog-config.ts
@@ -55,7 +55,7 @@ export class GetChangelogConfig {
     let config: ChangelogConfig | Promise<ChangelogConfig> = GetChangelogConfig.cfgCache.get(cacheKey);
 
     if (!config) {
-      let presetPackageName = presetName;
+      let presetPackageName = presetName as string;
 
       // https://github.com/npm/npm-package-arg#result-object
       const parsed: any = npa(presetPackageName, rootPath);

--- a/packages/version/src/conventional-commits/update-changelog.ts
+++ b/packages/version/src/conventional-commits/update-changelog.ts
@@ -1,4 +1,4 @@
-import { EOL, Package } from '@lerna-lite/core';
+import { ChangelogPresetOptions, EOL, Package } from '@lerna-lite/core';
 import conventionalChangelogCore, { Context } from 'conventional-changelog-core';
 import { Options as WriterOptions } from 'conventional-changelog-writer';
 import { writeFile } from 'fs/promises';
@@ -94,10 +94,9 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
 
     log.silly(type, 'writing new entry: %j', newEntry);
 
-    const changelogHeader = CHANGELOG_HEADER.replace(
-      /%s/g,
-      changelogHeaderMessage?.length > 0 ? changelogHeaderMessage + EOL : ''
-    );
+    const changelogHeader =
+      (changelogPreset as ChangelogPresetOptions)?.header ??
+      CHANGELOG_HEADER.replace(/%s/g, changelogHeaderMessage?.length > 0 ? changelogHeaderMessage + EOL : '');
 
     const content = [changelogHeader, newEntry, changelogContents]
       .join(BLANK_LINE)

--- a/packages/version/src/models/index.ts
+++ b/packages/version/src/models/index.ts
@@ -1,4 +1,4 @@
-import { ExecOpts, Package } from '@lerna-lite/core';
+import { ChangelogPresetOptions, ExecOpts, Package } from '@lerna-lite/core';
 import { GitRawCommitsOptions, ParserOptions } from 'conventional-changelog-core';
 import { Options as WriterOptions } from 'conventional-changelog-writer';
 import { Options as RecommendedBumpOptions } from 'conventional-recommended-bump';
@@ -17,7 +17,7 @@ export interface GitTagOption {
 
 export type VersioningStrategy = 'fixed' | 'independent';
 export type ChangelogType = 'fixed' | 'independent' | 'root';
-export type ChangelogPresetConfig = string | { name: string; [key: string]: unknown };
+export type ChangelogPresetConfig = string | ChangelogPresetOptions;
 
 export interface BaseChangelogOptions {
   changelogPreset?: ChangelogPresetConfig;
@@ -56,7 +56,7 @@ export type RemoteCommit = {
 
 export interface UpdateChangelogOption {
   changelogHeaderMessage?: string;
-  changelogPreset?: string;
+  changelogPreset?: ChangelogPresetConfig;
   changelogIncludeCommitsGitAuthor?: boolean | string;
   changelogIncludeCommitsClientLogin?: boolean | string;
   commitsSinceLastRelease?: RemoteCommit[];

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -9,22 +9,23 @@ import semver from 'semver';
 
 import {
   EOL,
+  type ChangelogPresetOptions,
   checkWorkingTree,
   collectPackages,
   collectUpdates,
   Command,
-  CommandType,
+  type CommandType,
   createRunner,
   logOutput,
-  Package,
-  PackageGraphNode,
-  ProjectConfig,
+  type Package,
+  type PackageGraphNode,
+  type ProjectConfig,
   promptConfirmation,
   runTopologically,
   throwIfUncommitted,
-  UpdateCollectorOptions,
+  type UpdateCollectorOptions,
   ValidationError,
-  VersionCommandOption,
+  type VersionCommandOption,
 } from '@lerna-lite/core';
 
 import { getCurrentBranch } from './lib/get-current-branch.js';
@@ -45,7 +46,7 @@ import {
   runInstallLockFileOnly,
   saveUpdatedLockJsonFile,
 } from './lib/update-lockfile-version.js';
-import { ChangelogPresetOptions, GitCreateReleaseClientOutput, ReleaseNote, RemoteCommit } from './models/index.js';
+import { GitCreateReleaseClientOutput, ReleaseNote, RemoteCommit } from './models/index.js';
 import {
   applyBuildMetadata,
   getCommitsSinceLastRelease,

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -45,7 +45,7 @@ import {
   runInstallLockFileOnly,
   saveUpdatedLockJsonFile,
 } from './lib/update-lockfile-version.js';
-import { GitCreateReleaseClientOutput, ReleaseNote, RemoteCommit } from './models/index.js';
+import { ChangelogPresetOptions, GitCreateReleaseClientOutput, ReleaseNote, RemoteCommit } from './models/index.js';
 import {
   applyBuildMetadata,
   getCommitsSinceLastRelease,
@@ -160,6 +160,17 @@ export class VersionCommand extends Command<VersionCommandOption> {
 
     if (this.releaseClient && this.options.changelog === false && this.options.generateReleaseNotes !== true) {
       throw new ValidationError('ERELEASE', 'To create a release, you cannot pass --no-changelog');
+    }
+
+    if (
+      this.options.conventionalCommits &&
+      typeof this.options.changelogPreset === 'object' &&
+      (this.options.changelogPreset as ChangelogPresetOptions)?.releaseCommitMessageFormat
+    ) {
+      throw new ValidationError(
+        'ENOTSUPPORTED',
+        'The Lerna config "changelogPreset.releaseCommitMessageFormat" is not supported, you should simply use "version.message" instead which will give you the same end result.'
+      );
     }
 
     this.gitOpts = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provide support to `changelogPreset.header`, however we will support `changelogPreset.releaseCommitMessageFormat` because `version.message` does the exact same thing and we will now throw when user tries to configure `changelogPreset.releaseCommitMessageFormat`

## Motivation and Context

Fixes #852 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
