### PR TITLE
chore(version): throw when using `workspace:` without allow peer bump

### DIFF
--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join, resolve as pathResolve, relative } from 'node:
 import { writePackage } from 'write-package';
 
 import { CommandType, NpaResolveResult, RawManifest } from './models/index.js';
+import { ValidationError } from './validation-error.js';
 
 // symbol used to 'hide' internal state
 const PKG = Symbol('pkg');
@@ -313,6 +314,8 @@ export class Package {
       // prettier-ignore
       if (allowPeerDependenciesUpdate && /^(workspace:)?[~^*]?[\d.]*([-]+[\w.\-+]+)*$/i.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);
+      } else if (this.peerDependencies[depName].startsWith('workspace:') && !allowPeerDependenciesUpdate) {
+        throw new ValidationError('ENOTALLOWED', 'Peer dependencies that use `workspace:` protocol without enabling `--allow-peer-dependencies-update` are not supported.');
       }
       // when peer bump is disabled, we could end up with peerDependencies not being reviewed
       // and some might still have the `workspace:` prefix so make sure to remove any of these prefixes

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -141,7 +141,7 @@ describe("workspace protocol 'workspace:' specifiers", () => {
 
     await gitTag(cwd, 'v1.0.0');
     await setupChanges(cwd);
-    await new PublishCommand(createArgv(cwd, '--bump', 'major', '--yes'));
+    await new PublishCommand(createArgv(cwd, '--bump', 'major', '--yes', '--allow-peer-dependencies-update'));
 
     expect((writePkg as any).updatedVersions()).toEqual({
       'package-1': '2.0.0',
@@ -161,8 +161,7 @@ describe("workspace protocol 'workspace:' specifiers", () => {
       'package-2': '^2.0.0', // workspace:^
     });
     expect((writePkg as any).updatedManifest('package-3').peerDependencies).toMatchObject({
-      // peer deps without the allow peer bump flag will not be bumped
-      'package-2': '^1.0.0', // workspace:^
+      'package-2': '^2.0.0', // workspace:^
     });
     expect((writePkg as any).updatedManifest('package-4').optionalDependencies).toMatchObject({
       'package-3': '~2.0.0', // workspace:~
@@ -174,11 +173,11 @@ describe("workspace protocol 'workspace:' specifiers", () => {
     });
     expect((writePkg as any).updatedManifest('package-5').peerDependencies).toMatchObject({
       // peer dependencies will not be bumped by default without a flag
-      'package-4': '>=1.0.0', // workspace:^1.0.0
-      'package-6': '~1.0.0', // workspace:~1.0.0
+      'package-4': '>=1.0.0', // workspace:>=1.0.0, range shouldn't be bumped
+      'package-6': '~2.0.0', // workspace:~1.0.0
     });
     expect((writePkg as any).updatedManifest('package-6').dependencies).toMatchObject({
-      'package-1': '>=1.0.0', // workspace:>=1.0.0
+      'package-1': '>=1.0.0', // workspace:>=1.0.0, range shouldn't be bumped
     });
     expect((writePkg as any).updatedManifest('package-6').peerDependencies).toMatchObject({
       'package-1': '>=1.0.0', // workspace:>=1.0.0, not bumped without a flag
@@ -188,8 +187,8 @@ describe("workspace protocol 'workspace:' specifiers", () => {
       'package-1': '^2.0.0', // ^1.0.0
     });
     expect((writePkg as any).updatedManifest('package-7').peerDependencies).toMatchObject({
-      'package-2': '^1.0.0', // not bumped without a flag
-      'package-3': '>=1.0.0',
+      'package-2': '^2.0.0',
+      'package-3': '>=1.0.0', // workspace:>=1.0.0, range shouldn't be bumped
     });
   });
 
@@ -199,7 +198,7 @@ describe("workspace protocol 'workspace:' specifiers", () => {
 
     await gitTag(cwd, 'v1.0.0');
     await setupChanges(cwd);
-    await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes'));
+    await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--allow-peer-dependencies-update'));
 
     expect(logErrorSpy).toHaveBeenCalledWith(
       'publish',

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -168,6 +168,8 @@ By default peer dependencies versions will not be bumped unless this flag is ena
 
 > **Note** peer dependency that includes a semver range with an operator (ie `>=2.0.0`) will never be mutated even if this flag is enabled.
 
+> **Note** peer dependencies that use `workspace:` protocol without enabling `--allow-peer-dependencies-update` are not supported.
+
 > **Note** Please use with caution when enabling this option, it is not recommended for most users since the npm standard is to never mutate (bump) any `peerDependencies` when publishing new version in an automated fashion, at least not without a user intervention, as explained by core Lerna maintainer:
 
 > > _Changes to a peer version range are always semver major, and should be as broad as possible._

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -948,7 +948,9 @@ describe('VersionCommand', () => {
 
       it(`should call runInstallLockFileOnly() when --sync-workspace-lock is provided and expect lockfile to be added to git`, async () => {
         const cwd = await initFixture('lockfile-pnpm');
-        await new VersionCommand(createArgv(cwd, '--bump', 'major', '--yes', '--sync-workspace-lock', '--npm-client', 'pnpm'));
+        await new VersionCommand(
+          createArgv(cwd, '--bump', 'major', '--yes', '--allow-peer-dependencies-update', '--sync-workspace-lock', '--npm-client', 'pnpm')
+        );
 
         const changedFiles = await showCommit(cwd, '--name-only');
         expect(changedFiles).toContain('pnpm-lock.yaml');
@@ -966,7 +968,7 @@ describe('VersionCommand', () => {
 
       it(`should call runInstallLockFileOnly() when --sync-workspace-lock is provided and expect lockfile to be added to git even without npmClient`, async () => {
         const cwd = await initFixture('lockfile-pnpm');
-        await new VersionCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--sync-workspace-lock'));
+        await new VersionCommand(createArgv(cwd, '--bump', 'minor', '--allow-peer-dependencies-update', '--yes', '--sync-workspace-lock'));
 
         const changedFiles = await showCommit(cwd, '--name-only');
         expect(changedFiles).toContain('pnpm-lock.yaml');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Peer dependencies that use `workspace:` protocol without enabling `--allow-peer-dependencies-update` are not supported.

## Motivation and Context

Related to issue #869, there is no point in using `workspace:` protocol without enabling `--allow-peer-dependencies-update`, user should either use a fixed version OR allow bumping the peer dependencies

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
