### PR TITLE
fix(publish): always bump & publish peer deps with `workspace:` protocol

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,7 +37,7 @@
       "request": "launch",
       "runtimeExecutable": "node",
       "runtimeArgs": ["--nolazy", "-r", "tsm"],
-      "args": ["packages/cli/dist/cli.js", "publish", "from-package", "--dry-run"],
+      "args": ["packages/cli/dist/cli.js", "publish", "from-package", "--dry-run", "--yes"],
       "cwd": "${workspaceRoot}",
       "console": "integratedTerminal",
       "internalConsoleOptions": "openOnSessionStart",

--- a/lerna.json
+++ b/lerna.json
@@ -5,13 +5,14 @@
   "npmClient": "pnpm",
   "command": {
     "publish": {
-      "cleanupTempFiles": true,
+      "cleanupTempFiles": false,
       "removePackageFields": [
         "devDependencies",
         "scripts"
       ]
     },
     "version": {
+      "allowPeerDependenciesUpdate": false,
       "conventionalCommits": true,
       "createRelease": "github",
       "changelogIncludeCommitsClientLogin": " - by @%l",

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1200,7 +1200,7 @@
         },
         "graphType": {
           "type": "string",
-          "enum": ["all", "dependencies", "allDependencies", "allPlusPeerDependencies"],
+          "enum": ["all", "dependencies", "allDependencies"],
           "description": "DEPRECATED: For `lerna publish`, if you want to ignore devDependencies when considering the package graph you can set this property equal to 'dependencies'.",
           "default": "all",
           "deprecated": true

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -320,10 +320,7 @@ export class Command<T extends AvailableCommandOption> {
     if (this.commandName !== 'info') {
       chain = chain.then(() => this.project.getPackages());
       chain = chain.then((packages) => {
-        this.packageGraph = new PackageGraph(
-          packages || [],
-          (this.options as VersionCommandOption).allowPeerDependenciesUpdate ? 'allPlusPeerDependencies' : 'allDependencies'
-        );
+        this.packageGraph = new PackageGraph(packages || [], 'allDependencies');
       });
     }
 

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -121,7 +121,7 @@ export interface ProfileData {
 
 export interface QueryGraphConfig {
   /** "dependencies" excludes devDependencies from graph */
-  graphType?: 'all' | 'allDependencies' | 'allPlusPeerDependencies' | 'dependencies';
+  graphType?: 'all' | 'allDependencies' | 'dependencies';
 
   /** Treatment of local sibling dependencies, default "auto" */
   localDependencies?: 'auto' | 'force' | 'explicit';

--- a/packages/core/src/package-graph/package-graph.ts
+++ b/packages/core/src/package-graph/package-graph.ts
@@ -13,14 +13,14 @@ import { NpaResolveResult } from '../models/index.js';
 export class PackageGraph extends Map<string, PackageGraphNode> {
   /**
    * @param {Package[]} packages - An array of Packages to build the graph out of.
-   * @param {'allDependencies' | 'allPlusPeerDependencies' | 'dependencies'} [graphType]
+   * @param {'allDependencies' | 'dependencies'} [graphType]
    *    Pass "dependencies" to create a graph of only dependencies,
    *    excluding the devDependencies that would normally be included.
    * @param {boolean|'auto'|'force'|'explicit'} [localDependencies] Treatment of local sibling dependencies, default "auto"
    */
   constructor(
     packages: Package[],
-    graphType: 'allDependencies' | 'allPlusPeerDependencies' | 'dependencies' = 'allDependencies',
+    graphType: 'allDependencies' | 'dependencies' = 'allDependencies',
     localDependencies: boolean | 'auto' | 'force' | 'explicit' | 'forceLocal' = 'auto'
   ) {
     // For backward compatibility
@@ -57,7 +57,7 @@ export class PackageGraph extends Map<string, PackageGraphNode> {
               {},
               currentNode.pkg.devDependencies,
               currentNode.pkg.optionalDependencies,
-              graphType === 'allPlusPeerDependencies' ? currentNode.pkg.peerDependencies : {},
+              currentNode.pkg.peerDependencies,
               currentNode.pkg.dependencies
             );
 

--- a/packages/core/src/utils/query-graph.ts
+++ b/packages/core/src/utils/query-graph.ts
@@ -47,11 +47,7 @@ export class QueryGraph {
     { graphType = 'allDependencies', localDependencies = 'auto', rejectCycles } = {} as QueryGraphConfig
   ) {
     // Create dependency graph
-    this.graph = new PackageGraph(
-      packages,
-      graphType as 'allDependencies' | 'allPlusPeerDependencies' | 'dependencies',
-      localDependencies
-    );
+    this.graph = new PackageGraph(packages, graphType as 'allDependencies' | 'dependencies', localDependencies);
 
     // Evaluate cycles
     this.cycles = this.graph.collapseCycles(rejectCycles);

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -576,8 +576,6 @@ The library is doing a strict match and it will transform and publish the follow
 }
 ```
 
-> **Note** peer dependencies that use `workspace:` protocol without enabling `--allow-peer-dependencies-update` are **not supported** and it will cause problem when you omit the flag. Peer dependencies are completely ignored by default and any `workspace:` added to peer dependencies will be published **as is** unless you enable the `--allow-peer-dependencies-update` option (see Lerna-Lite [version#--allow-peer-dependencies-update](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#--allow-peer-dependencies-update) for more info).
-
 ## FAQ
 
 ### Recovering from a network error

--- a/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-5/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-5/package.json
@@ -2,7 +2,7 @@
   "name": "package-5",
   "version": "1.0.0",
   "dependencies": {
-    "package-4": "workspace:^1.0.0",
+    "package-4": "workspace:>=1.0.0",
     "package-6": "workspace:~1.0.0"
   },
   "peerDependencies": {

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -112,7 +112,7 @@ describe("workspace protocol 'workspace:' specifiers", () => {
     });
     expect((writePkg as any).updatedManifest('package-5').dependencies).toMatchObject({
       // all fixed versions are bumped when minor
-      'package-4': '^1.1.0', // workspace:^1.0.0
+      'package-4': '>=1.0.0', // workspace:>=1.0.0, semver range are never bumped
       'package-6': '~1.1.0', // workspace:~1.0.0
     });
     expect((writePkg as any).updatedManifest('package-5').peerDependencies).toMatchObject({
@@ -168,7 +168,7 @@ describe("workspace protocol 'workspace:' specifiers", () => {
     });
     expect((writePkg as any).updatedManifest('package-5').dependencies).toMatchObject({
       // all fixed versions are bumped when major
-      'package-4': '^2.0.0', // workspace:^1.0.0
+      'package-4': '>=1.0.0', // workspace:>=1.0.0, semver range are never bumped
       'package-6': '~2.0.0', // workspace:~1.0.0
     });
     expect((writePkg as any).updatedManifest('package-5').peerDependencies).toMatchObject({

--- a/packages/publish/src/lib/log-packed.ts
+++ b/packages/publish/src/lib/log-packed.ts
@@ -61,7 +61,7 @@ export function logPacked(pkg: Package & { packed: Tarball }, dryRun = false) {
     )
   );
 
-  // in dry-run mode, show tarball temp location and dependencies, devDependencies
+  // in dry-run mode, show tarball temp location and dependencies, devDependencies and/or peerDependencies
   if (dryRun) {
     log.notice('', `--- ${chalk.bgMagenta('DRY-RUN')} details ---`);
     log.notice('', `temp location: ${tarball.tarFilePath}`);
@@ -73,6 +73,10 @@ export function logPacked(pkg: Package & { packed: Tarball }, dryRun = false) {
     if (pkg.devDependencies) {
       log.notice('devDependencies:', '');
       log.notice('', columnify(pkg.devDependencies, { columnSplitter: ' | ', showHeaders: false }));
+    }
+    if (pkg.peerDependencies) {
+      log.notice('peerDependencies:', '');
+      log.notice('', columnify(pkg.peerDependencies, { columnSplitter: ' | ', showHeaders: false }));
     }
   }
 

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -806,13 +806,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
        * Therefore until we remove graphType altogether in v6, we provide a way for users to opt into the old default behavior
        * by setting the `graphType` option to `dependencies`.
        */
-      // prettier-ignore
-      graphType:
-        this.options.graphType === 'dependencies'
-          ? 'dependencies'
-          : this.options.allowPeerDependenciesUpdate
-            ? 'allPlusPeerDependencies'
-            : 'allDependencies',
+      graphType: this.options.graphType === 'dependencies' ? 'dependencies' : 'allDependencies',
     });
   }
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -169,7 +169,7 @@ By default peer dependencies versions will not be bumped unless this flag is ena
 
 > **Note** peer dependency that includes a semver range with an operator (ie `>=2.0.0`) will never be mutated even if this flag is enabled.
 
-> **Note** peer dependencies that use `workspace:` protocol without enabling `--allow-peer-dependencies-update` are **not supported** and it will cause problem if you omit the flag.
+> **Note** peer dependencies that use `workspace:` protocol will be bump **even** without enabling `--allow-peer-dependencies-update` because that protocol always expect a version replacement with current version.
 
 > **Note** Please use with caution when enabling this option, it is not recommended for most users since the npm standard is to never mutate (bump) any `peerDependencies` when publishing new version in an automated fashion, at least not without a user intervention, as explained by core Lerna maintainer:
 
@@ -177,7 +177,7 @@ By default peer dependencies versions will not be bumped unless this flag is ena
 > > _Until we can get fancier, we should never automatically modify them to match the new version being published (which is the current incorrect behavior)._
 
 #### Examples
-For the example shown below, we will consider the packages to have the following versions (`"A": "1.2.0"`, `"B": "0.4.0"` anc `"C": 2.0.0"`). The examples shown below includes very basic demo of what `workspace:` can do, for more info on that subject please read [`workspace:` protocol](#workspace-protocol).
+For the example shown below, we will consider the packages to have the following versions (`"A": "1.2.0"`, `"B": "0.4.0"`, `"C": 2.0.0"`). The examples shown below includes very basic demo of what `workspace:` can do, for more info on that subject please read [`workspace:` protocol](#workspace-protocol).
 
 ##### with flag enabled
 with the new flag both deps would be updated and bumped, for example if we do a `minor` bump
@@ -190,15 +190,16 @@ with the new flag both deps would be updated and bumped, for example if we do a 
     "C": "workspace:^"        // will bump the version to "workspace:^2.1.0" and publish as "^2.1.0"
    },
   "peerDependencies": {
-    "A": "workspace:^1.2.0",  // will update the version to "workspace:^1.3.0" and publish as "^1.3.0"
-    "B": ">=0.2.0",           // will not be updated because range with operator (>=) are skipped
-    "C": "workspace:^"        // will keep the version to "workspace:^" but publish as "^2.1.0"
+    "D": "workspace:^1.2.0",  // will update the version to "workspace:^1.3.0" and publish as "^1.3.0"
+    "E": ">=0.2.0",           // will not be updated because range with operator (>=) are skipped
+    "F": "workspace:^"        // will keep the version to "workspace:^" but publish as "^2.1.0"
   }
 }
 ```
 
 ##### without flag
-without the flag peer dependencies are completely ignored and it will only update other dependencies that it finds and peer dependencies will be published untouched and **as is**
+without the flag peer dependencies are completely ignored **except** for `workspace:` which are always bumped even without the flag and the reason is because `workspace:` are always expected to be transformed.
+
 ```js
 {
   "name": "B",
@@ -208,9 +209,10 @@ without the flag peer dependencies are completely ignored and it will only updat
     "C": "workspace:^"
    },
   "peerDependencies": {
-    "A": "workspace:^1.2.0",  // will NOT bump the version and will publish "workspace:^1.2.0"
-    "B": ">=0.2.0",           // will NOT bump the version and will publish as ">=0.2.0"
-    "C": "workspace:^"        // will NOT bump the version and will publish "workspace:^"
+    "D": "workspace:^1.2.0",  // will update the version to "workspace:^1.3.0" and publish as "^1.3.0"
+    "E": ">=0.2.0",           // will NOT bump the version and will publish as ">=0.2.0"
+    "F": "workspace:^",       // will keep the version to "workspace:^" but publish as "^2.1.0"
+    "G": "^1.2.0"             // will NOT bump because the flag is disabled and workspace: was not found
   }
 }
 ```
@@ -933,5 +935,3 @@ Will apply the following updates to your `package.json` (assuming a `minor` vers
 ```
 
 > **Note** semver range with an operator (ie `workspace:>=2.0.0`) are also supported but will never be mutated.
-
-> **Note** peer dependencies that use `workspace:` protocol without enabling `--allow-peer-dependencies-update` are **not supported** and it will cause problem if you omit the flag because peer dependencies are completely ignored by Lerna-Lite unless you enable the `--allow-peer-dependencies-update` option.

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -743,7 +743,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       runTopologically(this.packagesToVersion, mapUpdate, {
         concurrency: this.concurrency,
         rejectCycles: this.options.rejectCycles,
-        graphType: this.options.allowPeerDependenciesUpdate ? 'allPlusPeerDependencies' : 'allDependencies',
+        graphType: 'allDependencies',
       })
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Never publish anything with `workspace:` protocol in their dependencies even with peer dependencies.

## Motivation and Context

fixes #869

- it should never publish any `workspace:` even when `allowPeerDependenciesUpdate` is disabled, `workspace:` are meant to always be bumped since it represent a replacement by the actual version. The main difference other regular dependencies that don't have use `workspace:` will not be bumped without the `allowPeerDependenciesUpdate` flag. So in summary this PR changes the behavior to the following:
  - peer deps with `workspace:` protocol will always be bumped
  - peer deps with `workspace:` protocol and semver with ranges (e.g. `workspace:>1.0.0 <2.0.0`) will continue to be ignored
  - peer deps without `workspace:` will **not** be bumped (same as before)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
