### PR TITLE
feat(version): option to not ignore scripts on lock update, fixes #877

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -658,6 +658,9 @@
             "skipBumpOnlyReleases": {
               "$ref": "#/$defs/commandOptions/version/skipBumpOnlyReleases"
             },
+            "runScriptsOnLockfileUpdate": {
+              "$ref": "#/$defs/commandOptions/version/runScriptsOnLockfileUpdate"
+            },
             "syncWorkspaceLock": {
               "$ref": "#/$defs/commandOptions/version/syncWorkspaceLock"
             },
@@ -1392,6 +1395,10 @@
         "forceGitTag": {
           "type": "boolean",
           "description": "During `lerna version`, when true, pass the `--force` flag to `git tag`."
+        },
+        "runScriptsOnLockfileUpdate": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, runs lifecycle scripts when syncing the lock file after the version bump."
         },
         "skipBumpOnlyReleases": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -269,6 +269,10 @@ export default {
         describe: "Additional arguments to pass to the npm client when performing 'npm install'.",
         type: 'array',
       },
+      'run-scripts-on-lockfile-update': {
+        describe: 'Runs lifecycle scripts when syncing the lock file after the version bump.',
+        type: 'boolean',
+      },
       'no-sync-workspace-lock': {
         describe:
           'Do not run `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient`.',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -318,6 +318,9 @@ export interface VersionCommandOption {
    */
   premajorVersionBump?: 'default' | 'force-patch';
 
+  /** Default to false, runs lifecycle scripts when syncing the lock file after the version bump. */
+  runScriptsOnLockfileUpdate?: boolean;
+
   /** Defaults to false, should we skip GitHub/GitLab release creation when the version is a "Version bump only for package x" */
   skipBumpOnlyReleases?: boolean;
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -109,6 +109,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--premajor-version-bump`](#--premajor-version-bump)
     - [`--remote-client <type>`](#--remote-client-type)
     - [`--push-tags-one-by-one`](#--push-tags-one-by-one)
+    - [`--run-scripts-on-lockfile-update`](#--run-scripts-on-lockfile-update)
     - [`--signoff-git-commit`](#--signoff-git-commit)
     - [`--sign-git-commit`](#--sign-git-commit)
     - [`--sign-git-tag`](#--sign-git-tag)
@@ -784,6 +785,11 @@ lerna version --conventional-commits --remote-client gitlab
 ```
 
 For remote client authentication tokens, like `GH_TOKEN` (or `GITHUB_TOKEN`), refer to [`Remote Client Auth Tokens`](#remote-client-auth-tokens)
+
+### `--run-scripts-on-lockfile-update`
+
+By default, `lerna version` skips any lifecycle script when syncing the package-lock file after the version bump (when using NPM as `npmClient`).
+With this option it will run `prepare`, `postinstall`, etc.
 
 ### `--signoff-git-commit`
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -782,13 +782,14 @@ export class VersionCommand extends Command<VersionCommandOption> {
     } else if (this.options.syncWorkspaceLock) {
       // update lock file, with npm client defined when `--sync-workspace-lock` is enabled
       chain = chain.then(() =>
-        runInstallLockFileOnly(npmClient, this.project.manifest.location, this.options.npmClientArgs || []).then(
-          (lockfilePath) => {
-            if (lockfilePath) {
-              changedFiles.add(lockfilePath);
-            }
+        runInstallLockFileOnly(npmClient, this.project.manifest.location, {
+          npmClientArgs: this.options.npmClientArgs || [],
+          runScriptsOnLockfileUpdate: this.options.runScriptsOnLockfileUpdate,
+        }).then((lockfilePath) => {
+          if (lockfilePath) {
+            changedFiles.add(lockfilePath);
           }
-        )
+        })
       );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Option to not pass `--ignore-scripts` while updating the lock file after the version bump.

## Motivation and Context

- fixes #877 
- Lerna version should ignore running npm script by default unless the new CLI argument `--run-scripts-on-lockfile-update` is provided. By default, the new behavior is to ignore running the npm scripts when synching lock file after the Lerna version command.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
