### PR TITLE
feat: add support for Yarn patch protocol

### DIFF
--- a/packages/core/src/package-graph/__tests__/package-graph.spec.ts
+++ b/packages/core/src/package-graph/__tests__/package-graph.spec.ts
@@ -189,6 +189,26 @@ describe('PackageGraph', () => {
       expect(node).toHaveProperty('localDependents', expect.any(Map));
     });
 
+    it('handles yarn patch protocol versions transparently and without hiccups', () => {
+      const pkg = new Package(
+        {
+          name: 'my-pkg',
+          version: '1.0.0',
+          dependencies: {
+            '@ionic-native/splash-screen':
+              'patch:@ionic-native/splash-screen@npm%3A5.36.0#~/.yarn/patches/@ionic-native-splash-screen-npm-5.36.0-531cbbe0f8.patch',
+          },
+        } as unknown as RawManifest,
+        '/path/to/my-pkg'
+      );
+      const node = new PackageGraph([pkg]).get('my-pkg');
+      expect(node?.externalDependencies.get('@ionic-native/splash-screen').rawSpec).toBe('5.36.0');
+      expect(node?.externalDependencies.get('@ionic-native/splash-screen').fetchSpec).toBe('5.36.0');
+      expect(node).toHaveProperty('externalDependencies', expect.any(Map));
+      expect(node).toHaveProperty('localDependencies', expect.any(Map));
+      expect(node).toHaveProperty('localDependents', expect.any(Map));
+    });
+
     it('computes prereleaseId from prerelease version', () => {
       const node = new PackageGraph([new Package({ name: 'my-pkg', version: '1.2.3-rc.4' } as unknown as RawManifest, '/path/to/my-pkg')]).get(
         'my-pkg'


### PR DESCRIPTION
## Description

Introduced logic that transparently handles the patch protocol version syntax by falling back
to the base version string.

https://github.com/lerna-lite/lerna-lite/issues/223
https://yarnpkg.com/cli/patch

Fixes #223

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>

## Motivation and Context

I have third-party packages in our monorepo that ship with issues that I need to patch in a yarn v4 build setup.

Without this change lerna-lite crashes if we are using it in a project that has any yarn patch protocol usage.

https://github.com/lerna-lite/lerna-lite/issues/223

## How Has This Been Tested?

1. Manually in the repo at https://github.com/hyperledger/cacti
1.1. We made changes to third party dependencies (code in the node_modules folder)
1.2. We committed said changes with `yarn patch`
1.3. The build was broken
1.4. Applied this fix to lerna-lite and now the build is working again.
2. Automated tests were added as well with our exact use-case see `package-graph.spec.ts`


## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
