### PR TITLE
fix(version): don't throw when invalid since date found to query GraphQL

### DIFF
--- a/packages/version/src/conventional-commits/__tests__/get-github-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/get-github-commits.spec.ts
@@ -12,7 +12,18 @@ import { getGithubCommits } from '../get-github-commits';
 const execOpts = { cwd: '/test' };
 
 describe('getGithubCommits method', () => {
-  it('logs a warning and returns an empty array of changes when git tag "since" date is invalid or undefined', async () => {
+  it('logs a warning and returns an empty array of changes when git tag "since" date is undefined', async () => {
+    const logSpy = vi.spyOn(log, 'warn');
+    const output = await getGithubCommits('durable', 'main', undefined as any, execOpts);
+
+    expect(output).toHaveLength(0);
+    expect(logSpy).toHaveBeenCalledWith(
+      'github',
+      'invalid "since" date provided to `getGithubCommits()` which is however required to properly fetch all GitHub commits info since the last release.'
+    );
+  });
+
+  it('logs a warning and returns an empty array of changes when git tag "since" date is empty', async () => {
     const logSpy = vi.spyOn(log, 'warn');
     const output = await getGithubCommits('durable', 'main', '', execOpts);
 

--- a/packages/version/src/conventional-commits/__tests__/get-github-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/get-github-commits.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { log } from '@lerna-lite/npmlog';
 
 vi.mock('../../git-clients', async () => ({
   ...(await vi.importActual<any>('../../git-clients')),
@@ -11,6 +12,17 @@ import { getGithubCommits } from '../get-github-commits';
 const execOpts = { cwd: '/test' };
 
 describe('getGithubCommits method', () => {
+  it('logs a warning and returns an empty array of changes when git tag "since" date is invalid or undefined', async () => {
+    const logSpy = vi.spyOn(log, 'warn');
+    const output = await getGithubCommits('durable', 'main', '', execOpts);
+
+    expect(output).toHaveLength(0);
+    expect(logSpy).toHaveBeenCalledWith(
+      'github',
+      'invalid "since" date provided to `getGithubCommits()` which is however required to properly fetch all GitHub commits info since the last release.'
+    );
+  });
+
   it('should return 2 commits from the GitHub Graphql API', async () => {
     const output = await getGithubCommits('durable', 'main', '2022-07-01T00:01:02-04:00', execOpts);
 

--- a/packages/version/src/conventional-commits/get-github-commits.ts
+++ b/packages/version/src/conventional-commits/get-github-commits.ts
@@ -37,6 +37,14 @@ export async function getGithubCommits(
   sinceDate: string,
   execOpts?: ExecOpts
 ): Promise<RemoteCommit[]> {
+  if (!sinceDate) {
+    log.warn(
+      'github',
+      'invalid "since" date provided to `getGithubCommits()` which is however required to properly fetch all GitHub commits info since the last release.'
+    );
+    return Promise.resolve([]);
+  }
+
   const repo = parseGitRepo(gitRemote, execOpts);
   const octokit = await createGitHubClient();
   const remoteCommits: Array<RemoteCommit> = [];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Avoid throwing and failing the versioning

## Motivation and Context

When using `changelogIncludeCommitsClientLogin`, avoid throwing error when last git tag doesn't provide a valid `since` date to query GraphQL, we should just return an empty info and warn the user that the date is invalid (without throwing)

ref, issue #867

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
