### PR TITLE
feat(publish): enable throttling when publishing modules

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1250,6 +1250,18 @@
           "anyOf": [{ "type": "string" }, { "type": "boolean" }],
           "description": "Generate a json summary report after all packages have been successfully published, you can pass an optional path for where to save the file."
         },
+        "throttle": {
+          "type": "boolean",
+          "description": "Throttle module publication. This is implicit if a throttle size or delay is provided"
+        },
+        "throttle-size": {
+          "type": "number",
+          "description": "Bucket size used to throttle module publication."
+        },
+        "throttle-delay": {
+          "type": "number",
+          "description": "Delay between throttle bucket items publications (in seconds)."
+        },
         "verifyAccess": {
           "type": "boolean",
           "description": "During `lerna publish`, when true, verify package read-write access for current npm user."

--- a/packages/cli/src/cli-commands/cli-publish-commands.ts
+++ b/packages/cli/src/cli-commands/cli-publish-commands.ts
@@ -131,6 +131,18 @@ export default {
           'Generate a json summary report after all packages have been successfully published, you can pass an optional path for where to save the file.',
         type: 'string',
       },
+      throttle: {
+        describe: 'Throttle module publication. This is implicit if a throttle size or delay is provided',
+        type: 'boolean',
+      },
+      'throttle-size': {
+        describe: 'Bucket size used to throttle module publication.',
+        type: 'number',
+      },
+      'throttle-delay': {
+        describe: 'Delay between throttle bucket items publications (in seconds).',
+        type: 'number',
+      },
       'verify-access': {
         describe: 'Verify package read-write access for current npm user.',
         type: 'boolean',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -365,8 +365,13 @@ export interface PublishCommandOption extends VersionCommandOption {
   /** Publish prerelease packages with the specified npm dist-tag */
   preDistTag?: string;
 
+  /** Throttle module publication. This is implicit if a throttle size or delay is provided */
   throttle?: boolean;
+
+  /** Bucket size used to throttle module publication. */
   throttleSize?: number;
+
+  /** Delay between throttle bucket items publications (in seconds). */
   throttleDelay?: number;
 
   /** Explicit SHA to set as gitHead when packing tarballs, only allowed with "from-package" positional. */

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -365,6 +365,10 @@ export interface PublishCommandOption extends VersionCommandOption {
   /** Publish prerelease packages with the specified npm dist-tag */
   preDistTag?: string;
 
+  throttle?: boolean;
+  throttleSize?: number;
+  throttleDelay?: number;
+
   /** Explicit SHA to set as gitHead when packing tarballs, only allowed with "from-package" positional. */
   gitHead?: string;
 

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -94,6 +94,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
     - [`--registry <url>`](#--registry-url)
     - [`--tag-version-prefix`](#--tag-version-prefix)
     - [`--temp-tag`](#--temp-tag)
+    - [`--throttle`](#--throttle)
     - [`--summary-file <dir>`](#--summary-file)
     - [`--verify-access`](#--verify-access)
     - [`--yes`](#--yes)
@@ -418,6 +419,20 @@ You should NOT use this option if:
 
 1.  You are using a third-party registry that does not support `npm access ls-packages`
 2.  You are using an authentication token without read access, such as a [npm automation access token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-access-tokens)
+
+### `--throttle`
+
+This option class allows to throttle the timing at which modules are published to the configured registry.
+
+- `--throttle`: Enable throttling when publishing modules
+- `--throttle-size`: The amount of modules that may be published at once (defaults to `25`)
+- `--throttle-delay`: How long to wait after a module was successfully published (defaults to 30 seconds)
+
+This is usefull to avoid errors/retries when publishing to rate-limited repositories on huge monorepos:
+
+```bash
+lerna publish from-git --throttle --throttle-delay=$((3600*24))
+```
 
 ### `--yes`
 

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -157,7 +157,7 @@ describe('PublishCommand', () => {
     it('publishes changed packages', async () => {
       const testDir = await initFixture('normal');
 
-      await new PublishCommand(createArgv(testDir, '--cleanup-temp-files'));
+      await new PublishCommand(createArgv(testDir, '--cleanup-temp-files', '--throttle'));
       // await lernaPublish(testDir)();
 
       expect(promptConfirmation).toHaveBeenLastCalledWith('Are you sure you want to publish these packages?');

--- a/packages/publish/src/__tests__/throttle-queue.spec.ts
+++ b/packages/publish/src/__tests__/throttle-queue.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+
+import * as throttling from '../lib/throttle-queue';
+
+describe('verifyTailHeadQueueBehavior', () => {
+  test('immediately runs all provided resolving promises within queue size', async () => {
+    const count = 100;
+    const queue = new throttling.TailHeadQueue(count, 1000);
+    const queue_promises = Array(count)
+      .fill(undefined)
+      .map(() => queue.queue(async () => Date.now()));
+    const acc = await Promise.all(queue_promises);
+    expect(acc.length).toBe(count);
+    acc.sort();
+    expect(acc[count - 1] - acc[0]).toBeLessThan(100);
+  });
+  test('immediately runs all provided rejecting promises within queue size', async () => {
+    const count = 100;
+    const queue = new throttling.TailHeadQueue(count, 1000);
+    const queue_promises = Array(count)
+      .fill(undefined)
+      .map(() => queue.queue(async () => new Promise((_, r) => r(Date.now()))));
+    const acc = await Promise.allSettled(queue_promises);
+    expect(acc.length).toBe(count);
+    const resolved_sorted_acc = acc
+      .map((r) => {
+        expect(r.status).toBe('rejected');
+        if (r.status === 'rejected') {
+          return r.reason;
+        }
+      })
+      .sort();
+    expect(resolved_sorted_acc[count - 1] - resolved_sorted_acc[0]).toBeLessThan(100);
+  });
+  test('runs all provided resolving promises with a delay if they exceed queue size', async () => {
+    const count = 100;
+    const queue = new throttling.TailHeadQueue(count / 3 + 1, 2 * 1000);
+    const queue_promises = Array(count)
+      .fill(undefined)
+      .map(() => queue.queue(async () => Date.now()));
+    const acc = await Promise.all(queue_promises);
+    expect(acc.length).toBe(count);
+    acc.sort();
+    const total_time = acc[count - 1] - acc[0];
+    expect(total_time).toBeGreaterThan(3.8 * 1000);
+    expect(total_time).toBeLessThan(4.2 * 1000);
+  });
+});

--- a/packages/publish/src/lib/throttle-queue.ts
+++ b/packages/publish/src/lib/throttle-queue.ts
@@ -1,0 +1,81 @@
+/**
+ * A queue abstraction for tasks that may require a delayed execution
+ */
+export interface Queue {
+  /**
+   * Run a task once the queue is cleared
+   * @param f A function that will be executed once the queue is useable
+   * @return A promise that wraps the value returned by f
+   */
+  queue<T>(f: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * A sized queue that adds a delay between the end of an item's execution.
+ *
+ * Use only with async code, multi-threading is not supported.
+ */
+export class TailHeadQueue implements Queue {
+  private queue_list: ((v: any) => any)[];
+  private queue_size: number;
+  private queue_period: number;
+  private allowance: number;
+  private last_end: number[];
+
+  /**
+   * @param size The number of items that may run concurrently
+   * @param period The time between the end of the execution of an item and the start of the execution of the next one (ms)
+   */
+  constructor(size, period) {
+    this.queue_list = [];
+    this.queue_size = Math.floor(size);
+    this.queue_period = period;
+    this.allowance = this.queue_size;
+    this.last_end = [];
+  }
+
+  /**
+   * Validate the execution of a queue item and schedule the execution of the next one
+   */
+  _on_settled() {
+    const next = this.queue_list.shift();
+    if (next !== undefined) {
+      setTimeout(next, this.queue_period);
+    } else {
+      // If we ever reach this point and THEN a new item is queued, we need to
+      // explicitly keep track of execution times to be able to add a delay.
+      //
+      // We can't simply wrap this in a setTimeout as it would add a flat
+      // this.queue_period delay to lerna's execution end after the last item
+      // in the queue is processed.
+      this.last_end.push(Date.now());
+      this.allowance += 1;
+    }
+  }
+
+  async queue<T>(f: () => Promise<T>): Promise<T> {
+    let p: Promise<T> | undefined = undefined;
+    if (this.allowance > 0) {
+      this.allowance -= 1;
+      // Check if the queue should delay the promise's execution
+      if (this.allowance + 1 <= this.last_end.length) {
+        const time_offset = Date.now() - (this.last_end.shift() || 0);
+        if (time_offset < this.queue_period) {
+          p = new Promise((r) => setTimeout(r, this.queue_period - time_offset)).then(f);
+        }
+      }
+      if (p === undefined) {
+        p = f();
+      }
+    } else {
+      p = new Promise((r) => {
+        this.queue_list.push(r);
+      }).then(f);
+    }
+    return p.finally(() => {
+      // Don't wait on _on_settled as it is for the queue's continuation
+      // and should not delay processing of the queued item's result.
+      this._on_settled();
+    });
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follows original Lerna [PR 4013](https://github.com/lerna/lerna/pull/4013)

> This is opened to validate the implementation design and get feedback on the specific values that should be used as defaults.
> 
> Currently known limits when uploading to NPM:
> 
> * Burst limit of 25/500 modules per 24h (depending on account/already-published modules)

> Add three publishing options:
> 
> * `--throttle` to enable/disable throttling
> * `--throttle-size`: the 'bucket size' to use when throttling
> * `--throttle-delay`: Once the bucket is full, the minimum time between the end of a module upload and the start of an other module's upload
> 
> Throttling is enabled by default when publishing to NPM. The throttling implementation is designed to allow changes in the implementation/maintaining different implementations without too much trouble

## Motivation and Context

Per Lerna's PR

> See Lerna [issue 3962](https://github.com/lerna/lerna/issues/3962): NPM throttles module publishing, which results in partial publish which are a pain to deal with

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
