### PR TITLE
fix(version): truncate release body based on maximum size allowed

### DIFF
--- a/packages/version/src/__tests__/create-release.spec.ts
+++ b/packages/version/src/__tests__/create-release.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { truncateReleaseBody } from '../lib/create-release';
+
+describe('truncateReleaseBody', () => {
+  const generateRandomString = (length: number): string => {
+    const letters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    let result = '';
+    for (let i = 0; i < length; i++) {
+      result += letters.charAt(Math.floor(Math.random() * letters.length));
+    }
+    return result;
+  };
+
+  it('should not truncate when body length is within limit for GitHub', () => {
+    const body = generateRandomString(124999);
+    const truncatedBody = truncateReleaseBody(body, 'github');
+    expect(truncatedBody).toBe(body);
+  });
+
+  it('should not truncate when body length is within limit for GitLab', () => {
+    const body = generateRandomString(999999);
+    const truncatedBody = truncateReleaseBody(body, 'gitlab');
+    expect(truncatedBody).toBe(body);
+  });
+
+  it('should truncate when body length exceeds limit for GitHub', () => {
+    const body = generateRandomString(125001);
+    const truncatedBody = truncateReleaseBody(body, 'github');
+    expect(truncatedBody.length).toBe(125000);
+    expect(truncatedBody.endsWith('...')).toBe(true);
+  });
+
+  it('should truncate when body length exceeds limit for GitLab', () => {
+    const body = generateRandomString(1000001);
+    const truncatedBody = truncateReleaseBody(body, 'gitlab');
+    expect(truncatedBody.length).toBe(1000000);
+    expect(truncatedBody.endsWith('...')).toBe(true);
+  });
+
+  it('should return the body as is when type is undefined', () => {
+    const body = generateRandomString(150000);
+    const truncatedBody = truncateReleaseBody(body);
+    expect(truncatedBody).toBe(body);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per original Lerna [PR 4041](https://github.com/lerna/lerna/pull/4041)
> This pull request introduces the `truncateReleaseBody` function, which ensures that release body content does not exceed the specified maximum length for GitHub and GitLab release descriptions, thereby preventing errors.


## Motivation and Context

As per original Lerna PR

> Fixes Lerna [issue 3833](https://github.com/lerna/lerna/issues/3833)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
