### PR TITLE
chore: remove deprecate eslint-plugin-node and just use n alternative

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,6 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import n from 'eslint-plugin-n';
-import node from 'eslint-plugin-node';
 import eslintPrettier from 'eslint-config-prettier';
 import vitest from 'eslint-plugin-vitest';
 
@@ -11,7 +10,7 @@ export default tseslint.config(
   },
   {
     extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
-    plugins: { n, node },
+    plugins: { n },
     files: ['**/*.ts'],
     rules: {
       'arrow-body-style': 'off',
@@ -24,15 +23,8 @@ export default tseslint.config(
       'import/no-unresolved': 'off',
       'import/order': 'off',
       'max-len': 'off',
+      'n/file-extension-in-import': ['error', 'always'],
       'n/no-missing-require': 'off',
-      'node/file-extension-in-import': [
-        'error',
-        'always',
-        {
-          tryExtensions: ['.js', '.json'],
-          '.xxx': 'always',
-        },
-      ],
       'no-async-promise-executor': 'off',
       'no-param-reassign': 'off',
       'no-restricted-syntax': 'off',

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "eslint": "^9.8.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-n": "^17.10.2",
-    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-vitest": "^0.5.4",
     "execa": "^8.0.1",
     "file-url": "^4.0.0",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-// eslint-disable-next-line node/file-extension-in-import
 import 'dotenv/config';
 import importLocal from 'import-local';
 import { log } from '@lerna-lite/npmlog';

--- a/packages/core/src/__tests__/cyclic-package-graph-node.spec.ts
+++ b/packages/core/src/__tests__/cyclic-package-graph-node.spec.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 
-import { Project } from '../project';
+import { Project } from '../project/project.js';
 import { initFixtureFactory } from '@lerna-test/helpers';
 import { CyclicPackageGraphNode } from '../package-graph/lib/cyclic-package-graph-node.js';
-import { PackageGraphNode } from '../package-graph';
+import { PackageGraphNode } from '../package-graph/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -13,7 +13,7 @@ vi.mock('write-package');
 
 // file under test
 import { Package } from '../package.js';
-import { NpaResolveResult, RawManifest } from '../models';
+import { NpaResolveResult, RawManifest } from '../models/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/core/src/package-graph/__tests__/package-graph.spec.ts
+++ b/packages/core/src/package-graph/__tests__/package-graph.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { RawManifest } from '../../models';
+import { RawManifest } from '../../models/index.js';
 import { Package } from '../../package.js';
 import { PackageGraphNode } from '../lib/package-graph-node.js';
 

--- a/packages/core/src/utils/__tests__/collect-uncommitted.spec.ts
+++ b/packages/core/src/utils/__tests__/collect-uncommitted.spec.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { fileURLToPath } from 'node:url';
 
 // helpers
-import { Project } from '../../project';
+import { Project } from '../../project/project.js';
 import { gitAdd } from '@lerna-test/helpers';
 import { initFixtureFactory } from '@lerna-test/helpers';
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/core/src/utils/__tests__/describe-ref.spec.ts
+++ b/packages/core/src/utils/__tests__/describe-ref.spec.ts
@@ -4,7 +4,7 @@ vi.mock('../../child-process');
 
 import * as childProcess from '../../child-process.js';
 import { describeRef, describeRefSync } from '../describe-ref.js';
-import { DescribeRefDetailedResult } from '../../models';
+import { DescribeRefDetailedResult } from '../../models/index.js';
 
 const DEFAULT_ARGS = ['describe', '--always', '--long', '--dirty', '--first-parent'];
 

--- a/packages/core/src/utils/__tests__/run-lifecycle.spec.ts
+++ b/packages/core/src/utils/__tests__/run-lifecycle.spec.ts
@@ -11,7 +11,7 @@ import runScript from '@npmcli/run-script';
 import { npmConf } from '../npm-conf.js';
 import { Package } from '../../package.js';
 import { runLifecycle, createRunner } from '../run-lifecycle.js';
-import { LifecycleConfig } from '../../models';
+import { LifecycleConfig } from '../../models/index.js';
 
 describe('runLifecycle()', () => {
   beforeEach(() => {

--- a/packages/exec/src/exec-command.ts
+++ b/packages/exec/src/exec-command.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/file-extension-in-import
 import 'dotenv/config';
 import chalk from 'chalk';
 import pMap from 'p-map';

--- a/packages/publish/src/__tests__/log-packed.spec.ts
+++ b/packages/publish/src/__tests__/log-packed.spec.ts
@@ -4,8 +4,8 @@ import { Package } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import chalk from 'chalk';
 
-import { logPacked } from '../lib';
-import { Tarball } from '../models';
+import { logPacked } from '../lib/index.js';
+import { Tarball } from '../models/index.js';
 
 describe('log-packed', () => {
   const pkg = {

--- a/packages/publish/src/__tests__/npm-dist-tag.spec.ts
+++ b/packages/publish/src/__tests__/npm-dist-tag.spec.ts
@@ -11,7 +11,7 @@ import fetch from 'npm-registry-fetch';
 
 // file under test
 import * as npmDistTag from '../lib/npm-dist-tag.js';
-import { DistTagOptions } from '../models';
+import { DistTagOptions } from '../models/index.js';
 
 const stubLog = {
   verbose: vi.fn(),

--- a/packages/publish/src/__tests__/npm-publish.spec.ts
+++ b/packages/publish/src/__tests__/npm-publish.spec.ts
@@ -21,7 +21,7 @@ import { dirname, join, normalize } from 'node:path';
 
 // file under test
 import { npmPublish } from '../lib/npm-publish.js';
-import { LibNpmPublishOptions } from '../models';
+import { LibNpmPublishOptions } from '../models/index.js';
 
 describe('npm-publish', () => {
   const mockTarData = Buffer.from('MOCK');

--- a/packages/run/src/lib/__tests__/npm-run-script.spec.ts
+++ b/packages/run/src/lib/__tests__/npm-run-script.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, Mock, vi } from 'vitest';
 vi.mock('@lerna-lite/core');
 
 import { execPackageManager, spawnStreaming } from '@lerna-lite/core';
-import { RunScriptOption, ScriptStreamingOption } from '../../models';
+import { RunScriptOption, ScriptStreamingOption } from '../../models/index.js';
 
 // file under test
 import { npmRunScript, npmRunScriptStreaming } from '../npm-run-script.js';

--- a/packages/version/src/__tests__/git-commit.spec.ts
+++ b/packages/version/src/__tests__/git-commit.spec.ts
@@ -6,7 +6,7 @@ import { EOL } from 'node:os';
 import { exec } from '@lerna-lite/core';
 import { gitCommit } from '../lib/git-commit.js';
 import { tempWrite } from '../utils/temp-write.js';
-import { GitCommitOption } from '../models';
+import { GitCommitOption } from '../models/index.js';
 
 describe('git commit', () => {
   (exec as any).mockResolvedValue(null);

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -40,7 +40,7 @@ import yaml from 'js-yaml';
 // mocked or stubbed modules
 import * as writePkg from 'write-package';
 import { checkWorkingTree, collectUpdates, logOutput, promptConfirmation, promptSelectOne, throwIfUncommitted, VersionCommandOption } from '@lerna-lite/core';
-import { getCommitsSinceLastRelease } from '../conventional-commits';
+import { getCommitsSinceLastRelease } from '../conventional-commits/index.js';
 import { gitPush as libPush, gitPushSingleTag as libPushSingleTag } from '../lib/git-push.js';
 import { isAnythingCommitted } from '../lib/is-anything-committed.js';
 import { isBehindUpstream } from '../lib/is-behind-upstream.js';

--- a/packages/version/src/__tests__/version-conventional-commits.spec.ts
+++ b/packages/version/src/__tests__/version-conventional-commits.spec.ts
@@ -42,7 +42,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import * as writePkg from 'write-package';
 import { collectUpdates, VersionCommandOption } from '@lerna-lite/core';
-import { recommendVersion, updateChangelog } from '../conventional-commits';
+import { recommendVersion, updateChangelog } from '../conventional-commits/index.js';
 
 // helpers
 import { initFixtureFactory, showCommit } from '@lerna-test/helpers';

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -41,8 +41,8 @@ import { dirname } from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import { logOutput, VersionCommandOption } from '@lerna-lite/core';
-import { updateChangelog, recommendVersion } from '../conventional-commits';
-import { createGitHubClient, createGitLabClient } from '../git-clients';
+import { updateChangelog, recommendVersion } from '../conventional-commits/index.js';
+import { createGitHubClient, createGitLabClient } from '../git-clients/index.js';
 import { createRelease, createReleaseClient } from '../lib/create-release.js';
 
 // helpers

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -12,7 +12,7 @@ const initFixture = initFixtureFactory(__dirname);
 
 // file under test
 import { Package } from '@lerna-lite/core';
-import { applyBuildMetadata, recommendVersion, updateChangelog } from '../../conventional-commits';
+import { applyBuildMetadata, recommendVersion, updateChangelog } from '../../conventional-commits.js';
 import { GetChangelogConfig } from '../get-changelog-config.js';
 
 // stabilize changelog commit SHA and datestamp

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -12,7 +12,7 @@ const initFixture = initFixtureFactory(__dirname);
 
 // file under test
 import { Package } from '@lerna-lite/core';
-import { applyBuildMetadata, recommendVersion, updateChangelog } from '../../conventional-commits.js';
+import { applyBuildMetadata, recommendVersion, updateChangelog } from '../../conventional-commits/index.js';
 import { GetChangelogConfig } from '../get-changelog-config.js';
 
 // stabilize changelog commit SHA and datestamp

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       eslint-plugin-n:
         specifier: ^17.10.2
         version: 17.10.2(eslint@9.8.0)
-      eslint-plugin-node:
-        specifier: ^11.1.0
-        version: 11.1.0(eslint@9.8.0)
       eslint-plugin-vitest:
         specifier: ^0.5.4
         version: 0.5.4(eslint@9.8.0)(typescript@5.5.4)(vitest@2.0.5)
@@ -3219,17 +3216,6 @@ packages:
       eslint-compat-utils: 0.5.0(eslint@9.8.0)
     dev: true
 
-  /eslint-plugin-es@3.0.1(eslint@9.8.0):
-    resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
-    engines: {node: '>=8.10.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-    dependencies:
-      eslint: 9.8.0
-      eslint-utils: 2.1.0
-      regexpp: 3.2.0
-    dev: true
-
   /eslint-plugin-n@17.10.2(eslint@9.8.0):
     resolution: {integrity: sha512-e+s4eAf5NtJaxPhTNu3qMO0Iz40WANS93w9LQgYcvuljgvDmWi/a3rh+OrNyMHeng6aOWGJO0rCg5lH4zi8yTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3245,21 +3231,6 @@ packages:
       ignore: 5.3.1
       minimatch: 9.0.5
       semver: 7.6.3
-    dev: true
-
-  /eslint-plugin-node@11.1.0(eslint@9.8.0):
-    resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
-    engines: {node: '>=8.10.0'}
-    peerDependencies:
-      eslint: '>=5.16.0'
-    dependencies:
-      eslint: 9.8.0
-      eslint-plugin-es: 3.0.1(eslint@9.8.0)
-      eslint-utils: 2.1.0
-      ignore: 5.3.1
-      minimatch: 3.1.2
-      resolve: 1.22.8
-      semver: 6.3.1
     dev: true
 
   /eslint-plugin-vitest@0.5.4(eslint@9.8.0)(typescript@5.5.4)(vitest@2.0.5):
@@ -3289,18 +3260,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: true
-
-  /eslint-utils@2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
-    engines: {node: '>=6'}
-    dependencies:
-      eslint-visitor-keys: 1.3.0
-    dev: true
-
-  /eslint-visitor-keys@1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
     dev: true
 
   /eslint-visitor-keys@3.4.3:
@@ -4738,10 +4697,6 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
-  /path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
-
   /path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
@@ -4942,11 +4897,6 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /regexpp@3.2.0:
-    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
-    engines: {node: '>=8'}
-    dev: true
-
   /replace-buffer@1.2.1:
     resolution: {integrity: sha512-ly3OKwKu+3T55DjP5PjIMzxgz9lFx6dQnBmAIxryZyRKl8f22juy12ShOyuq8WrQE5UlFOseZgQZDua0iF9DHw==}
     engines: {node: '>=4'}
@@ -4974,15 +4924,6 @@ packages:
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-    dev: true
-
-  /resolve@1.22.8:
-    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
-    hasBin: true
-    dependencies:
-      is-core-module: 2.13.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
   /retry@0.12.0:
@@ -5047,11 +4988,6 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     requiresBuild: true
     optional: true
-
-  /semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-    dev: true
 
   /semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
@@ -5263,11 +5199,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
-
-  /supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
     dev: true
 
   /tacks@1.2.6:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

`eslint-plugin-node` is deprecated and the alternative `eslint-plugin-n` is actually already a plugin that we use

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
