### PR TITLE
feat(publish): support full file path for --summary-file

### DIFF
--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -418,7 +418,7 @@ export interface PublishCommandOption extends VersionCommandOption {
   noVerifyAccess?: boolean;
 
   /** Generate a json summary report after all packages have been successfully published, you can pass an optional path for where to save the file. */
-  summaryFile?: boolean | string;
+  summaryFile?: string;
 
   /** proxy for `--no-verify-access` */
   verifyAccess?: boolean;

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -392,6 +392,8 @@ order (all dependencies before dependents) by default.
 lerna publish --canary --yes --summary-file
 # Will create a summary file in the provided directory, i.e. `./some/other/dir/lerna-publish-summary.json`
 lerna publish --canary --yes --summary-file ./some/other/dir
+# Will create a summary file with the provided name, i.e. `./some/other/dir/my-summary.json`
+lerna publish --canary --yes --summary-file ./some/other/dir/my-summary.json
 ```
 
 When run with this flag, a json summary report will be generated after all packages have been successfully published (see below for an example).

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -1045,6 +1045,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
   }
 
   private getSummaryFilePath(): string {
+    /* v8 ignore next 3 */
     if (this.options.summaryFile === undefined) {
       throw new Error('summaryFile options is not defined. Unable to get path.');
     }
@@ -1055,6 +1056,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     const normalizedPath = normalize(this.options.summaryFile);
 
+    /* v8 ignore next 3 */
     if (normalizedPath === '') {
       throw new Error('summaryFile is not a valid path.');
     }

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { glob } from 'glob';
 import { outputFileSync, removeSync } from 'fs-extra/esm';
 import { EOL } from 'node:os';
-import { join, relative } from 'node:path';
+import { join as pathJoin, normalize, relative } from 'node:path';
 import crypto from 'crypto';
 import normalizePath from 'normalize-path';
 import pMap from 'p-map';
@@ -304,11 +304,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
     logOutput(`Successfully published: ${logPrefix}`);
 
     if (this.options.summaryFile !== undefined) {
-      // create a json object and output it to a file location.
-      //prettier-ignore
-      const filePath = this.options.summaryFile
-        ? `${this.options.summaryFile}/lerna-publish-summary.json`
-        : './lerna-publish-summary.json';
+      const filePath = this.getSummaryFilePath();
       const jsonObject = publishedPackagesSorted.map((pkg) => {
         return {
           packageName: pkg.name,
@@ -329,7 +325,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     // optionally cleanup temp packed files after publish, opt-in option
     if (this.options.cleanupTempFiles) {
-      glob(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
+      glob(normalizePath(pathJoin(tempDir, '/lerna-*'))).then((deleteFolders) => {
         // delete silently all files/folders that startsWith "lerna-"
         deleteFolders.forEach((folder) => removeSync(folder));
         this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);
@@ -1046,5 +1042,27 @@ export class PublishCommand extends Command<PublishCommandOption> {
     if (isPrerelease) {
       return this.options.preDistTag;
     }
+  }
+
+  private getSummaryFilePath(): string {
+    if (this.options.summaryFile === undefined) {
+      throw new Error('summaryFile options is not defined. Unable to get path.');
+    }
+
+    if (this.options.summaryFile === '') {
+      return pathJoin(process.cwd(), './lerna-publish-summary.json');
+    }
+
+    const normalizedPath = normalize(this.options.summaryFile);
+
+    if (normalizedPath === '') {
+      throw new Error('summaryFile is not a valid path.');
+    }
+
+    if (normalizedPath.endsWith('.json')) {
+      return pathJoin(process.cwd(), normalizedPath);
+    }
+
+    return pathJoin(process.cwd(), normalizedPath, 'lerna-publish-summary.json');
   }
 }


### PR DESCRIPTION
> Add possibility to provide a filepath to the `--summary-file` option in the publish command

## Description

As per Lerna's PR 4039 

<!-- [PR 4039](https://github.com/lerna/lerna/pull/4039) -->

> This PR introduces a new capability to the Lerna library, allowing users to specify a filepath instead of a directory path for the `--summary-file` option.
> 
> Previously, users could only provide a directory path and the created filename is statically defined in the code as `lerna-publish-summary.json` , which limited the flexibility in defining the location and name of the summary file.

## Motivation and Context

As per Lerna's PR

> With this change, users can now directly specify the full path, including the filename, where the summary should be saved.

## How Has This Been Tested?

> In the `publish-command.spec.ts` file, adding a new test case where a filepath is passed as input parameter.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
