### PR TITLE
fix(version): enable changing commit message when using amend

### DIFF
--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -295,6 +295,9 @@ export interface VersionCommandOption {
   /** Pass the `--force` flag to `git tag`. */
   forceGitTag?: boolean;
 
+  /** Are we overriding the commit message? */
+  overrideMessage?: boolean;
+
   /** Defaults to 'v', customize the tag prefix. To remove entirely, pass an empty string. */
   tagVersionPrefix?: string;
 

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -796,12 +796,12 @@ describe('VersionCommand', () => {
       expect(checkWorkingTree).not.toHaveBeenCalled();
     });
 
-    it('ignores custom messages', async () => {
-      const testDir = await initFixture('normal', 'preserved');
-      await new VersionCommand(createArgv(testDir, '-m', 'ignored', '--amend'));
+    it('considers custom messages', async () => {
+      const cwd = await initFixture('normal', 'preserved');
+      await lernaVersion(cwd)('-m', 'custom', '--amend');
 
-      const message = await getCommitMessage(testDir);
-      expect(message).toBe('preserved');
+      const message = await getCommitMessage(cwd);
+      expect(message).toBe('custom');
     });
   });
 

--- a/packages/version/src/lib/git-commit.ts
+++ b/packages/version/src/lib/git-commit.ts
@@ -12,7 +12,7 @@ import { tempWrite } from '../utils/index.js';
  */
 export function gitCommit(
   message: string,
-  { amend, commitHooks, signGitCommit, signoffGitCommit }: GitCommitOption,
+  { amend, commitHooks, overrideMessage, signGitCommit, signoffGitCommit }: GitCommitOption,
   opts: ExecOpts,
   dryRun = false
 ) {
@@ -31,13 +31,20 @@ export function gitCommit(
     args.push('--signoff');
   }
 
+  const shouldChangeMessage = amend ? amend && overrideMessage : true;
   if (amend) {
-    args.push('--amend', '--no-edit');
-  } else if (message.indexOf(EOL) > -1) {
-    // Use tempfile to allow multi\nline strings.
-    args.push('-F', tempWrite.sync(message, 'lerna-commit.txt'));
+    args.push('--amend');
+  }
+
+  if (shouldChangeMessage) {
+    if (message.indexOf(EOL) > -1) {
+      // Use tempfile to allow multi\nline strings.
+      args.push('-F', tempWrite.sync(message, 'lerna-commit.txt'));
+    } else {
+      args.push('-m', message);
+    }
   } else {
-    args.push('-m', message);
+    args.push('--no-edit');
   }
 
   log.verbose('git', args.join(' '));

--- a/packages/version/src/models/index.ts
+++ b/packages/version/src/models/index.ts
@@ -6,11 +6,18 @@ import { Options as RecommendedBumpOptions } from 'conventional-recommended-bump
 export interface GitCommitOption {
   amend: boolean;
   commitHooks: boolean;
+  overrideMessage?: boolean;
   signGitCommit: boolean;
   signoffGitCommit: boolean;
 }
 
 export interface GitTagOption {
+  amend?: boolean;
+  commitHooks?: boolean;
+  granularPathspec?: boolean;
+  signGitCommit?: boolean;
+  signoffGitCommit?: boolean;
+  overrideMessage?: boolean;
   forceGitTag?: boolean;
   signGitTag?: boolean;
 }

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -124,12 +124,14 @@ export class VersionCommand extends Command<VersionCommandOption> {
       forceGitTag,
       tagVersionPrefix = 'v',
       premajorVersionBump = 'default',
+      message,
     } = this.options;
 
     this.gitRemote = gitRemote;
     this.tagPrefix = tagVersionPrefix;
     this.commitAndTag = gitTagVersion;
     this.pushToRemote = gitTagVersion && amend !== true && push;
+    const overrideMessage = amend && !!message;
     this.changelogIncludeCommitsClientLogin =
       changelogIncludeCommitsClientLogin === '' ? true : changelogIncludeCommitsClientLogin;
     this.changelogIncludeCommitsGitAuthor = changelogIncludeCommitsGitAuthor === '' ? true : changelogIncludeCommitsGitAuthor;
@@ -179,6 +181,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       amend,
       commitHooks,
       granularPathspec,
+      overrideMessage,
       signGitCommit,
       signoffGitCommit,
       signGitTag,


### PR DESCRIPTION
## Description

As per Lerna's PR 3954
<!-- [PR](https://github.com/lerna/lerna/pull/3954) -->

> allows overriding of the commit message

## Motivation and Context

> fixes Lerna's issue 3936
> Using "--amend" and "--message" options will not overwrite the original commit message

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
