### PR TITLE
fix(core): don't include other deps when `graphType` is provided

### DIFF
--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -320,7 +320,8 @@ export class Command<T extends AvailableCommandOption> {
     if (this.commandName !== 'info') {
       chain = chain.then(() => this.project.getPackages());
       chain = chain.then((packages) => {
-        this.packageGraph = new PackageGraph(packages || [], 'allDependencies');
+        const { graphType } = this.options.command?.[this.commandName] ?? {};
+        this.packageGraph = new PackageGraph(packages || [], graphType ?? 'allDependencies');
       });
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description



## Motivation and Context

Replicate a fix that was provided as a patch in [yeoman-api](https://github.com/yeoman/yeoman-api) in this patch [commit](https://github.com/yeoman/yeoman-api/commit/29061293f6681b094f9205c897595ab4255fc76e). This fix was described as the following: 

> `@yeoman/api` packages is a base definition for every other workspace, it provides:
> 
> * immutable types that should never have breaking changes.
> * stable base dependencies using peerDependencies.
> 
> A new release `@yeoman/api` should be individual without touching other packages. `@lerna-lite` commands are (eg: `lerna publish --ignore-changes '**' --force-publish @yeoman/types`):
> 
> * touching projects with widened peerDependencies, as far as I remember it adds devDependencies:
>   https://github.com/yeoman/yeoman-api/blob/615eede5c5dfd96a827d04cd72351d6706bfcc6c/workspaces/conflicter/package.json#L61
> 
> This change makes `@lerna-lite` to ignore others packages making it individual in this case. Why add a devDependency?



## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
