### PR TITLE
fix(version): Update default "describe [Git] tag" pattern in non-independent mode to 'v*'

### DIFF
--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -507,7 +507,7 @@ describe('collectUpdates()', () => {
     expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*custom-tag*' }, true);
   });
 
-  it('no use "describeTag" in non-independent mode', async () => {
+  it('use "describeTag" with default value in non-independent mode', async () => {
     const graph = buildGraph();
     const pkgs = graph.rawPackageList;
     const execOpts = { cwd: '/test' };
@@ -516,10 +516,10 @@ describe('collectUpdates()', () => {
       isIndependent: false,
       includeMergedTags: true,
     });
-    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '' }, true);
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: 'v*' }, true);
   });
 
-  it('use "describeTag" with empty value in independent mode', async () => {
+  it('use "describeTag" with default value in independent mode', async () => {
     const graph = buildGraph();
     const pkgs = graph.rawPackageList;
     const execOpts = { cwd: '/test' };

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -44,7 +44,7 @@ export function collectUpdates(
       : new Map(filteredPackages.map(({ name }) => [name, packageGraph.get(name)]));
 
   let committish = commandOptions.since;
-  const tagPattern = describeTag ? describeTag : isIndependent ? '*@*' : '';
+  const tagPattern = describeTag ? describeTag : isIndependent ? '*@*' : 'v*';
 
   if (hasTags(execOpts, tagPattern)) {
     const describeOptions: DescribeRefOptions = {

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -464,7 +464,7 @@ lerna version --create-release gitlab --skip-bump-only-releases
 ### `--describe-tag <pattern>`
 When `lerna version` is executed, it will identifies packages that have been updated since the previous tagged release. The rules it identifies are based on describe tag pattern (excuted `git describe --match` behind the scenes).
 
-The tag pattern defaults to `*@*` (independent mode) or `""` (non-independent mode). You can configure `describeTag` in `lerna.json` to specify the tag pattern.
+The tag pattern defaults to `*@*` (independent mode) or `"v*"` (non-independent mode). You can configure `describeTag` in `lerna.json` to specify the tag pattern.
 
 The `describeTag` will also take effect under `lerna publish`, for example `lerna publish --canary`, but it will not take effect under `lerna publish from-git`.
 


### PR DESCRIPTION
## Description

Changed the default --describe-tag pattern from an empty string to 'v*' for non-independent mode in the `lerna version` command. Updated related documentation and tests to reflect this change. 
This change is being done to have --describe-tag and --tag-version-prefix in sync for non-independent mode.

## Motivation and Context

When using `fixed` mode, I ran into similar problems as described in #220. Setting `describeTag` to `v*` helped.

In my opinion, it should be the default to have `describeTag` and `tagVersionPrefix` synced.

## How Has This Been Tested?

I wasn't able to test locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
