### PR TITLE
fix: replace node-glob with globby to decrease deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "file-url": "^4.0.0",
     "find-up": "^7.0.0",
     "fs-extra": "^11.2.0",
-    "glob": "^10.4.5",
     "globby": "^14.0.2",
     "load-json-file": "^7.0.1",
     "normalize-newline": "^4.1.0",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -45,7 +45,7 @@
     "chalk": "^5.3.0",
     "columnify": "^1.6.0",
     "fs-extra": "^11.2.0",
-    "glob": "^10.4.5",
+    "globby": "^14.0.2",
     "has-unicode": "^2.0.1",
     "libnpmaccess": "^8.0.6",
     "libnpmpublish": "^9.0.9",

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
-import { glob } from 'glob';
+import crypto from 'crypto';
 import { outputFileSync, removeSync } from 'fs-extra/esm';
+import { globby } from 'globby';
 import { EOL } from 'node:os';
 import { join as pathJoin, normalize, relative } from 'node:path';
-import crypto from 'crypto';
 import normalizePath from 'normalize-path';
 import pMap from 'p-map';
 import pPipe, { type UnaryFunction } from 'p-pipe';
@@ -325,8 +325,8 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     // optionally cleanup temp packed files after publish, opt-in option
     if (this.options.cleanupTempFiles) {
-      glob(normalizePath(pathJoin(tempDir, '/lerna-*'))).then((deleteFolders) => {
-        // delete silently all files/folders that startsWith "lerna-"
+      globby(normalizePath(pathJoin(tempDir, '/lerna-*')), { onlyDirectories: true }).then((deleteFolders) => {
+        // silently delete all files/folders that startsWith "lerna-"
         deleteFolders.forEach((folder) => removeSync(folder));
         this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
-      glob:
-        specifier: ^10.4.5
-        version: 10.4.5
       globby:
         specifier: ^14.0.2
         version: 14.0.2
@@ -553,9 +550,9 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
-      glob:
-        specifier: ^10.4.5
-        version: 10.4.5
+      globby:
+        specifier: ^14.0.2
+        version: 14.0.2
       has-unicode:
         specifier: ^2.0.1
         version: 2.0.1

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -1,11 +1,15 @@
-import { glob } from 'glob';
-import { join } from 'node:path';
+import { globby } from 'globby';
+import { join as pathJoin } from 'node:path';
 import { removeSync } from 'fs-extra/esm';
 import tempDir from 'temp-dir';
 import normalizePath from 'normalize-path';
 
-glob(normalizePath(join(tempDir, '/lerna-*'))).then((deleteFolders) => {
-  // delete silently all files/folders that startsWith "lerna-"
-  console.log(`Found ${deleteFolders.length} temp folders to cleanup.`);
-  (deleteFolders || []).forEach((folder) => removeSync(folder));
-});
+globby(normalizePath(pathJoin(tempDir, '/lerna-*')), { onlyDirectories: true })
+  .then((deleteFolders) => {
+    // silently delete all files/folders that startsWith "lerna-"
+    console.log(`Found ${deleteFolders.length} temp folders to cleanup.`);
+    (deleteFolders || []).forEach((folder) => removeSync(folder));
+  })
+  .catch((error) => {
+    console.error('Error occurred while cleaning up temp folders:', error);
+  });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace 2 places that use `node-glob` with `globby` since we use it across the project

## Motivation and Context

simply want to decrease number of dependencies :)

I eventually want to migrate to `tinyglobby` but not until they support the missing option `followSymbolicLinks`

## How Has This Been Tested?

tested locally by running `cleanup-temp-files.mjs` npm script which runs after unit tests closes. While investigating, I found that `{ onlyDirectories: true }` is required for the migration to work

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
