### PR TITLE
fix: drop `strip-ansi` in favor of native stripVTControlCharacters

### DIFF
--- a/packages/npmlog/package.json
+++ b/packages/npmlog/package.json
@@ -42,7 +42,6 @@
     "set-blocking": "^2.0.0",
     "signal-exit": "^4.1.0",
     "string-width": "^7.2.0",
-    "strip-ansi": "^7.1.0",
     "wide-align": "^1.1.5"
   },
   "devDependencies": {

--- a/packages/npmlog/src/gauge/wide-truncate.ts
+++ b/packages/npmlog/src/gauge/wide-truncate.ts
@@ -2,7 +2,7 @@
  * Inlined from deprecated package https://github.com/npm/gauge/blob/f8092518a47ac6a96027ae3ad97d0251ffe7643b
  */
 
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'node:util';
 import stringWidth from 'string-width';
 
 export function wideTruncate(str: string, target: number) {
@@ -19,7 +19,7 @@ export function wideTruncate(str: string, target: number) {
   // We compute the number of bytes of ansi sequences here and add
   // that to our initial truncation to ensure that we don't slice one
   // that we want to keep in half.
-  const noAnsi = stripAnsi(str);
+  const noAnsi = stripVTControlCharacters(str);
   const ansiSize = str.length + noAnsi.length;
   let truncated = str.slice(0, target + ansiSize);
 

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -16,6 +16,7 @@ import { pathExistsSync, readJsonSync } from 'fs-extra/esm';
 import { promises as fsPromises } from 'node:fs';
 import { dirname as pathDirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { stripVTControlCharacters } from 'node:util';
 
 // mocked or stubbed modules
 import { loadJsonFile } from 'load-json-file';
@@ -39,9 +40,7 @@ import {
 // Serialize the JSONError output to be more human readable
 expect.addSnapshotSerializer({
   serialize(str: string) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const stripAnsi = require('strip-ansi');
-    return stripAnsi(str).replace(/Error in: .*lerna\.json/, 'Error in: normalized/path/to/lerna.json');
+    return stripVTControlCharacters(str).replace(/Error in: .*lerna\.json/, 'Error in: normalized/path/to/lerna.json');
   },
   test(val: string) {
     return val != null && typeof val === 'string' && val.includes('Error in: ');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,9 +460,6 @@ importers:
       string-width:
         specifier: ^7.2.0
         version: 7.2.0
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       wide-align:
         specifier: ^1.1.5
         version: 1.1.5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

replace `strip-ansi` import with `stripVTControlCharacters` from `node:util` native

## Motivation and Context

References https://github.com/es-tooling/ecosystem-cleanup/issues/122

## How Has This Been Tested?

existing tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
