### PR TITLE
chore: fix test failures found in vitest-ecosystem-ci

### DIFF
--- a/packages/core/src/__tests__/command.spec.ts
+++ b/packages/core/src/__tests__/command.spec.ts
@@ -340,7 +340,7 @@ describe('core-command', () => {
     ['initialize', 'execute'].forEach((method) => {
       it(`throws if ${method}() is not overridden`, () => {
         const command = new Command({ cwd: testDir, onRejected } as any);
-        expect(() => command[method]()).toThrow('');
+        expect(() => command[method]()).toThrow(`${method}() needs to be implemented.`);
       });
     });
   });

--- a/packages/core/src/utils/__tests__/env-replace.spec.ts
+++ b/packages/core/src/utils/__tests__/env-replace.spec.ts
@@ -6,7 +6,7 @@ describe('env-replace()', () => {
   it('should throw an error when there are no env variable defined or found', () => {
     const input = 'http://registry.npmjs.org/:_authToken=${UNKNOWN_TOKEN}';
 
-    expect(() => envReplace(input)).toThrow('');
+    expect(() => envReplace(input)).toThrow('Failed to replace env in config');
   });
 
   it('should return the same input when not a string', () => {

--- a/packages/core/src/utils/__tests__/pulse-till-done.spec.ts
+++ b/packages/core/src/utils/__tests__/pulse-till-done.spec.ts
@@ -17,6 +17,6 @@ describe('pulse-till-done()', () => {
   });
 
   it('throws when an invalid file is provided to pulse', async () => {
-    await expect(pulseTillDone(json('../../../invalid-file.json', { name: '@lerna-lite/core' }))).rejects.toThrow('');
+    await expect(pulseTillDone(json('../../../invalid-file.json', { name: '@lerna-lite/core' }))).rejects.toThrow('404 Not Found');
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Vitest `toThrowError` shouldn't be set to an empty string

## Motivation and Context

fixes an issue identified in latest vitest-ecosystem-ci
https://github.com/vitest-dev/vitest-ecosystem-ci/actions/runs/11397873060/job/31714024446

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
