### PR TITLE
fix: dry-run, don't throw no changelog w/o release, fixes #988

### DIFF
--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -49,7 +49,6 @@ import { createGitHubClient } from '../git-clients/github-client.js';
 import { createGitLabClient } from '../git-clients/gitlab-client.js';
 
 // helpers
-import { loggingOutput } from '@lerna-test/helpers/logging-output.js';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 const initFixture = initFixtureFactory(__dirname);
 
@@ -137,11 +136,14 @@ describe.each([
   });
 
   it('shows a console warning if --no-changelog also passed with --dry-run mode', async () => {
+    // const logSpy = vi.spyOn(log, 'warn');
     const cwd = await initFixture('independent');
+
+    (recommendVersion as Mock).mockResolvedValueOnce('1.1.0');
+
     await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--no-changelog', '--dry-run'));
 
-    const logMessages = loggingOutput('warn');
-    expect(logMessages).toContain('To create a release, you cannot pass --no-changelog');
+    // expect(logSpy).toHaveBeenCalledWith('ERELEASE', 'To create a release, you cannot pass --no-changelog');
   });
 
   it('throws an error if environment variables are not present', async () => {

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -136,14 +136,14 @@ describe.each([
   });
 
   it('shows a console warning if --no-changelog also passed with --dry-run mode', async () => {
-    // const logSpy = vi.spyOn(log, 'warn');
+    const logSpy = vi.spyOn(log, 'warn');
     const cwd = await initFixture('independent');
 
     (recommendVersion as Mock).mockResolvedValueOnce('1.1.0');
 
     await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--no-changelog', '--dry-run'));
 
-    // expect(logSpy).toHaveBeenCalledWith('ERELEASE', 'To create a release, you cannot pass --no-changelog');
+    expect(logSpy).toHaveBeenCalledWith('ERELEASE', 'To create a release, you cannot pass --no-changelog');
   });
 
   it('throws an error if environment variables are not present', async () => {

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -137,9 +137,9 @@ describe.each([
 
   it('shows a console warning if --no-changelog also passed with --dry-run mode', async () => {
     const cwd = await initFixture('independent');
-    const logMessages = loggingOutput('warn');
     lernaVersion(cwd)('--create-release', type, '--conventional-commits', '--no-changelog', '--dry-run');
 
+    const logMessages = loggingOutput('warn');
     expect(logMessages).toContain('To create a release, you cannot pass --no-changelog');
   });
 

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -138,7 +138,7 @@ describe.each([
 
   it('shows a console warning if --no-changelog also passed with --dry-run mode', async () => {
     const cwd = await initFixture('independent');
-    lernaVersion(cwd)('--create-release', type, '--conventional-commits', '--no-changelog', '--dry-run');
+    await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--no-changelog', '--dry-run'));
 
     const logMessages = loggingOutput('warn');
     expect(logMessages).toContain('To create a release, you cannot pass --no-changelog');

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -138,7 +138,7 @@ describe.each([
   it('shows a console warning if --no-changelog also passed with --dry-run mode', async () => {
     const cwd = await initFixture('independent');
     const logMessages = loggingOutput('warn');
-    const command = lernaVersion(cwd)('--create-release', type, '--conventional-commits', '--no-changelog', '--dry-run');
+    lernaVersion(cwd)('--create-release', type, '--conventional-commits', '--no-changelog', '--dry-run');
 
     expect(logMessages).toContain('To create a release, you cannot pass --no-changelog');
   });

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -49,6 +49,7 @@ import { createGitHubClient } from '../git-clients/github-client.js';
 import { createGitLabClient } from '../git-clients/gitlab-client.js';
 
 // helpers
+import { loggingOutput } from '@lerna-test/helpers/logging-output.js';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
 const initFixture = initFixtureFactory(__dirname);
 

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -135,6 +135,14 @@ describe.each([
     expect(client.releases.size).toBe(0);
   });
 
+  it('shows a console warning if --no-changelog also passed with --dry-run mode', async () => {
+    const cwd = await initFixture('independent');
+    const logMessages = loggingOutput('warn');
+    const command = lernaVersion(cwd)('--create-release', type, '--conventional-commits', '--no-changelog', '--dry-run');
+
+    expect(logMessages).toContain('To create a release, you cannot pass --no-changelog');
+  });
+
   it('throws an error if environment variables are not present', async () => {
     const cwd = await initFixture('normal');
     const command = lernaVersion(cwd)('--create-release', type, '--conventional-commits');

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -160,7 +160,12 @@ export class VersionCommand extends Command<VersionCommandOption> {
       );
     }
 
-    if (this.releaseClient && this.options.changelog === false && this.options.generateReleaseNotes !== true) {
+    if (
+      !this.options.dryRun &&
+      this.releaseClient &&
+      this.options.changelog === false &&
+      this.options.generateReleaseNotes !== true
+    ) {
       throw new ValidationError('ERELEASE', 'To create a release, you cannot pass --no-changelog');
     }
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -160,15 +160,6 @@ export class VersionCommand extends Command<VersionCommandOption> {
       );
     }
 
-    if (this.releaseClient && this.options.changelog === false && this.options.generateReleaseNotes !== true) {
-      const msg = 'To create a release, you cannot pass --no-changelog';
-      if (this.options.dryRun) {
-        this.logger.warn('ERELEASE', msg);
-      } else {
-        throw new ValidationError('ERELEASE', msg);
-      }
-    }
-
     if (
       this.options.conventionalCommits &&
       typeof this.options.changelogPreset === 'object' &&
@@ -196,6 +187,14 @@ export class VersionCommand extends Command<VersionCommandOption> {
   }
 
   async initialize() {
+    if (this.releaseClient && this.options.changelog === false && this.options.generateReleaseNotes !== true) {
+      const msg = 'To create a release, you cannot pass --no-changelog';
+      if (!this.options.dryRun) {
+        throw new ValidationError('ERELEASE', msg);
+      }
+      this.logger.warn('ERELEASE', msg);
+    }
+
     const isIndependent = this.project.isIndependent();
     const describeTag = this.options.describeTag;
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -160,13 +160,13 @@ export class VersionCommand extends Command<VersionCommandOption> {
       );
     }
 
-    if (
-      !this.options.dryRun &&
-      this.releaseClient &&
-      this.options.changelog === false &&
-      this.options.generateReleaseNotes !== true
-    ) {
-      throw new ValidationError('ERELEASE', 'To create a release, you cannot pass --no-changelog');
+    if (this.releaseClient && this.options.changelog === false && this.options.generateReleaseNotes !== true) {
+      const msg = 'To create a release, you cannot pass --no-changelog';
+      if (this.options.dryRun) {
+        this.logger.warn('ERELEASE', msg);
+      } else {
+        throw new ValidationError('ERELEASE', msg);
+      }
     }
 
     if (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Skip certain conditions in dry-run mode

## Motivation and Context

fixes #988 
No need to throw in dry-run mode when user has a release without changelog enabled

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
