### PR TITLE
fix: use cosmiconfig global searchStrategy to fix breaking behaviour

### DIFF
--- a/packages/core/src/filter-packages/__tests__/get-filtered-packages.spec.ts
+++ b/packages/core/src/filter-packages/__tests__/get-filtered-packages.spec.ts
@@ -32,7 +32,7 @@ async function buildGraph(cwd) {
 }
 
 function parseOptions(...args) {
-  return filterOptions(yargs().exitProcess(false).showHelpOnFail(false)).parse(args);
+  return filterOptions(yargs().locale('en').exitProcess(false).showHelpOnFail(false)).parse(args);
 }
 
 // working dir is never mutated

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -44,6 +44,7 @@ export class Project {
           '.json5': this.json5Loader,
         },
         searchPlaces: ['lerna.json', 'lerna.jsonc', 'lerna.json5', 'package.json'],
+        searchStrategy: 'global',
         transform(obj) {
           // cosmiconfig returns null when nothing is found
           if (!obj) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna's PR 4159

> cosmiconfig have been upgrade to 9.0.0 in #4062 But there is a breaking change in cosmiconfig 9.0.0 See https://github.com/cosmiconfig/cosmiconfig/blob/main/CHANGELOG.md#900
> 
> > Breaking change: This is the default value if you don't pass a stopDir option, which means that cosmiconfig no longer traverses directories by default, and instead just looks in the current working directory.
> > If you want to achieve maximum backwards compatibility without adding an explicit stopDir, add the searchStrategy: 'global' option.
> 
> Any lerna commands run in subdirectories are broken now.


## Motivation and Context

Fixes issue opened in Lerna, [issue 4118](https://github.com/lerna/lerna/issues/4118)

> Lerna seems to be losing --scope directory context

> This is due to the cosmiconfig upgrade (https://github.com/lerna/lerna/pull/4062), which has breaking changes which have seemingly been ignored (https://github.com/cosmiconfig/cosmiconfig/blob/main/CHANGELOG.md#900).
Any lerna commands run in subdirectories are broken now. We use lerna in subdirectories to build a package and its dependencies like lerna run build --scope @org/this-package --include-dependencies.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
