### PR TITLE
fix(publish): replace +{SHA} with .{SHA} in lerna publish --canary

### DIFF
--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -461,22 +461,22 @@ describe('Package', () => {
       it('bumps peerDependencies canary with SHA versions when allowPeerDependenciesUpdate flag is enabled except for dependencies with semver range operator', () => {
         const pkg = factory({
           peerDependencies: {
-            a: '^1.0.0-alpha.0+SHA',
-            b: '>=1.0.0-alpha.0+SHA', // range will not be bumped
+            a: '^1.0.0-alpha.0.SHA',
+            b: '>=1.0.0-alpha.0.SHA', // range will not be bumped
           },
         });
 
-        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0-alpha.0+SHA', '.');
-        const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0-alpha.0+SHA', '.');
+        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0-alpha.0.SHA', '.');
+        const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0-alpha.0.SHA', '.');
 
-        pkg.updateLocalDependency(resolvedA, '1.0.0-alpha.1+SHA', '^', true);
-        pkg.updateLocalDependency(resolvedB, '1.0.0-alpha.1+SHA', '^', true);
+        pkg.updateLocalDependency(resolvedA, '1.0.0-alpha.1.SHA', '^', true);
+        pkg.updateLocalDependency(resolvedB, '1.0.0-alpha.1.SHA', '^', true);
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
             "peerDependencies": {
-              "a": "^1.0.0-alpha.1+SHA",
-              "b": ">=1.0.0-alpha.0+SHA",
+              "a": "^1.0.0-alpha.1.SHA",
+              "b": ">=1.0.0-alpha.0.SHA",
             },
           }
         `);

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -125,16 +125,16 @@ Only configurable via `lerna.json` because an object must be provided:
 
 ```sh
 lerna publish --canary
-# 1.0.0 => 1.0.1-alpha.0+${SHA} of packages changed since the previous commit
-# a subsequent canary publish will yield 1.0.1-alpha.1+${SHA}, etc
+# 1.0.0 => 1.0.1-alpha.0.${SHA} of packages changed since the previous commit
+# a subsequent canary publish will yield 1.0.1-alpha.1.${SHA}, etc
 
 lerna publish --canary --preid beta
-# 1.0.0 => 1.0.1-beta.0+${SHA}
+# 1.0.0 => 1.0.1-beta.0.${SHA}
 
 # The following are equivalent:
 lerna publish --canary minor
 lerna publish --canary preminor
-# 1.0.0 => 1.1.0-alpha.0+${SHA}
+# 1.0.0 => 1.1.0-alpha.0.${SHA}
 ```
 
 When run with this flag, `lerna publish` publishes packages in a more granular way (per commit).

--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -120,10 +120,10 @@ test('publish --canary', async () => {
   );
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 1.0.1-alpha.0+SHA,
-      "package-3": 1.0.1-alpha.0+SHA,
-      "package-4": 1.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.SHA,
+      "package-2": 1.0.1-alpha.0.SHA,
+      "package-3": 1.0.1-alpha.0.SHA,
+      "package-4": 1.0.1-alpha.0.SHA,
     }
   `);
 });
@@ -145,10 +145,10 @@ test('publish --canary with auto-confirm --yes', async () => {
   );
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 1.0.1-alpha.0+SHA,
-      "package-3": 1.0.1-alpha.0+SHA,
-      "package-4": 1.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.SHA,
+      "package-2": 1.0.1-alpha.0.SHA,
+      "package-3": 1.0.1-alpha.0.SHA,
+      "package-4": 1.0.1-alpha.0.SHA,
     }
   `);
 });
@@ -162,9 +162,9 @@ test('publish --canary --preid beta', async () => {
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-beta.0+SHA,
-      "package-2": 1.0.1-beta.0+SHA,
-      "package-3": 1.0.1-beta.0+SHA,
+      "package-1": 1.0.1-beta.0.SHA,
+      "package-2": 1.0.1-beta.0.SHA,
+      "package-3": 1.0.1-beta.0.SHA,
     }
   `);
 });
@@ -177,9 +177,9 @@ test("publish --canary --tag-version-prefix='abc'", async () => {
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 1.0.1-alpha.0+SHA,
-      "package-3": 1.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.SHA,
+      "package-2": 1.0.1-alpha.0.SHA,
+      "package-3": 1.0.1-alpha.0.SHA,
     }
   `);
 });
@@ -193,9 +193,9 @@ test('publish --canary <semver>', async () => {
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 1.0.1-alpha.0+SHA,
-      "package-3": 1.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.SHA,
+      "package-2": 1.0.1-alpha.0.SHA,
+      "package-3": 1.0.1-alpha.0.SHA,
     }
   `);
 });
@@ -208,9 +208,9 @@ test('publish --canary --independent', async () => {
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.1.0-alpha.0+SHA,
-      "package-2": 2.1.0-alpha.0+SHA,
-      "package-3": 3.1.0-alpha.0+SHA,
+      "package-1": 1.1.0-alpha.0.SHA,
+      "package-2": 2.1.0-alpha.0.SHA,
+      "package-3": 3.1.0-alpha.0.SHA,
     }
   `);
 });
@@ -236,7 +236,7 @@ test('publish --canary addresses unpublished package', async () => {
   // there have been two commits since the beginning of the repo
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-6": 1.0.0-alpha.1+SHA,
+      "package-6": 1.0.0-alpha.1.SHA,
     }
   `);
 });
@@ -250,11 +250,11 @@ describe('publish --canary differential', () => {
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
       {
-        "package-1": 1.0.1-alpha.0+SHA,
-        "package-2": 1.0.1-alpha.0+SHA,
-        "package-3": 1.0.1-alpha.0+SHA,
-        "package-4": 1.0.1-alpha.0+SHA,
-        "package-5": 1.0.1-alpha.0+SHA,
+        "package-1": 1.0.1-alpha.0.SHA,
+        "package-2": 1.0.1-alpha.0.SHA,
+        "package-3": 1.0.1-alpha.0.SHA,
+        "package-4": 1.0.1-alpha.0.SHA,
+        "package-5": 1.0.1-alpha.0.SHA,
       }
     `);
   });
@@ -267,9 +267,9 @@ describe('publish --canary differential', () => {
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
       {
-        "package-3": 1.1.0-alpha.0+SHA,
-        "package-4": 1.1.0-alpha.0+SHA,
-        "package-5": 1.1.0-alpha.0+SHA,
+        "package-3": 1.1.0-alpha.0.SHA,
+        "package-4": 1.1.0-alpha.0.SHA,
+        "package-5": 1.1.0-alpha.0.SHA,
       }
     `);
   });
@@ -282,7 +282,7 @@ describe('publish --canary differential', () => {
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
       {
-        "package-5": 2.0.0-alpha.0+SHA,
+        "package-5": 2.0.0-alpha.0.SHA,
       }
     `);
   });
@@ -301,7 +301,7 @@ describe('publish --canary sequential', () => {
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
       {
-        "package-5": 5.0.1-alpha.0+SHA,
+        "package-5": 5.0.1-alpha.0.SHA,
       }
     `);
   });
@@ -312,9 +312,9 @@ describe('publish --canary sequential', () => {
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
       {
-        "package-3": 3.0.1-alpha.1+SHA,
-        "package-4": 4.0.1-alpha.1+SHA,
-        "package-5": 5.0.1-alpha.1+SHA,
+        "package-3": 3.0.1-alpha.1.SHA,
+        "package-4": 4.0.1-alpha.1.SHA,
+        "package-5": 5.0.1-alpha.1.SHA,
       }
     `);
   });
@@ -325,11 +325,11 @@ describe('publish --canary sequential', () => {
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
       {
-        "package-1": 1.0.1-alpha.2+SHA,
-        "package-2": 2.0.1-alpha.2+SHA,
-        "package-3": 3.0.1-alpha.2+SHA,
-        "package-4": 4.0.1-alpha.2+SHA,
-        "package-5": 5.0.1-alpha.2+SHA,
+        "package-1": 1.0.1-alpha.2.SHA,
+        "package-2": 2.0.1-alpha.2.SHA,
+        "package-3": 3.0.1-alpha.2.SHA,
+        "package-4": 4.0.1-alpha.2.SHA,
+        "package-5": 5.0.1-alpha.2.SHA,
       }
     `);
   });
@@ -340,9 +340,9 @@ describe('publish --canary sequential', () => {
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
       {
-        "package-3": 3.0.1-alpha.3+SHA,
-        "package-4": 4.0.1-alpha.3+SHA,
-        "package-5": 5.0.1-alpha.3+SHA,
+        "package-3": 3.0.1-alpha.3.SHA,
+        "package-4": 4.0.1-alpha.3.SHA,
+        "package-5": 5.0.1-alpha.3.SHA,
       }
     `);
   });
@@ -353,7 +353,7 @@ describe('publish --canary sequential', () => {
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
       {
-        "package-5": 5.0.1-alpha.4+SHA,
+        "package-5": 5.0.1-alpha.4.SHA,
       }
     `);
   });
@@ -380,10 +380,10 @@ test('publish --canary --force-publish on tagged release avoids early exit', asy
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 1.0.1-alpha.0+SHA,
-      "package-3": 1.0.1-alpha.0+SHA,
-      "package-4": 1.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.SHA,
+      "package-2": 1.0.1-alpha.0.SHA,
+      "package-3": 1.0.1-alpha.0.SHA,
+      "package-4": 1.0.1-alpha.0.SHA,
     }
   `);
 });
@@ -404,8 +404,8 @@ test('publish --canary --force-publish <arg> on tagged release avoids early exit
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-2": 2.0.1-alpha.0+SHA,
-      "package-3": 3.0.1-alpha.0+SHA,
+      "package-2": 2.0.1-alpha.0.SHA,
+      "package-3": 3.0.1-alpha.0.SHA,
     }
   `);
 });
@@ -447,10 +447,10 @@ test('publish --canary without _any_ tags', async () => {
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 1.0.1-alpha.0+SHA,
-      "package-3": 1.0.1-alpha.0+SHA,
-      "package-4": 1.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.SHA,
+      "package-2": 1.0.1-alpha.0.SHA,
+      "package-3": 1.0.1-alpha.0.SHA,
+      "package-4": 1.0.1-alpha.0.SHA,
     }
   `);
 });
@@ -461,11 +461,11 @@ test('publish --canary without _any_ tags (independent)', async () => {
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 2.0.1-alpha.0+SHA,
-      "package-3": 3.0.1-alpha.0+SHA,
-      "package-4": 4.0.1-alpha.0+SHA,
-      "package-6": 0.1.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.SHA,
+      "package-2": 2.0.1-alpha.0.SHA,
+      "package-3": 3.0.1-alpha.0.SHA,
+      "package-4": 4.0.1-alpha.0.SHA,
+      "package-6": 0.1.1-alpha.0.SHA,
     }
   `);
 });
@@ -491,8 +491,8 @@ test('publish --canary --no-private', async () => {
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
     {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 2.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.SHA,
+      "package-2": 2.0.1-alpha.0.SHA,
     }
   `);
 });

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -472,7 +472,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
       // semver.inc() starts a new prerelease at .0, git describe starts at .1
       // and build metadata is always ignored when comparing dependency ranges
-      return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}+${sha}`;
+      return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}.${sha}`;
     };
 
     if (isIndependent) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Instead of using plus (+) sign in package name provided by --canary flag, use dot.

This PR is based on original Lerna's PR 4124

## Motivation and Context

It's not possible to publish --canary version into jfrog artifactory, as jfrog is cutting part of filename, due to + (plus) character. So, instead of using +, I would suggest to use dot.

https://github.com/lerna/lerna/issues/2060

As per Lerna's original author [comment](https://github.com/lerna/lerna/issues/2060#issuecomment-569968758)

> Yeah, in retrospect using the `+` to append `commit_hash` was a mistake, as even the public registry completely ignores it (it's allowed to, per the [spec](https://semver.org/#spec-item-10)).

> Yes, true, the spec is only speaking to precedence there. In my manual testing, I found that attempting to publish version 1.2.3-alpha.0+12345 will always result in a version of 1.2.3-alpha.0 being available from the registry. Of course, this was done after i had shipped it... ;_;

> The version specifiers passed to npm commands are generally cleaned up by [semver](https://www.npmjs.com/package/semver)'s valid() method before further processing, which [yields the same behavior as my ad-hoc registry tests](https://runkit.com/embed/z1hbbnsfy3wf).

another of saying that when Lerna's author decided to use `+SHA` it was working fine at the beginning but it wasn't official in any Specs ... and later on of course they changed their in mind and modified the Specs and it no longer works with the `+` but it works with `.`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
