### PR TITLE
chore: enforce consistent usage of type-only imports/exports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,13 @@ export default tseslint.config(
     extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
     plugins: { n },
     files: ['**/*.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: ['./tsconfig.base.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
       'arrow-body-style': 'off',
       'class-methods-use-this': 'off',
@@ -45,6 +52,8 @@ export default tseslint.config(
       'prefer-object-spread': 'off',
       strict: 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
+      '@typescript-eslint/consistent-type-exports': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
@@ -70,6 +79,8 @@ export default tseslint.config(
       'vitest/prefer-expect-assertions': 0, // when testing `vitest.configs.all.rules`
       'vitest/prefer-todo': 1,
       'vitest/require-to-throw-message': 1,
+      '@typescript-eslint/consistent-type-exports': 'off',
+      '@typescript-eslint/consistent-type-imports': 'off',
     },
     languageOptions: {
       globals: {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ci:lint": "eslint packages",
     "lint": "eslint packages --cache --cache-location ./node_modules/.cache/eslint",
     "lint:no-cache": "eslint packages",
+    "lint:fix": "eslint packages --fix",
     "outdated:ws": "pnpm -r --stream outdated",
     "test": "cross-env-shell NO_COLOR=true vitest --coverage --config ./vitest/vitest.config.ts",
     "test:watch": "cross-env-shell NO_COLOR=true vitest --watch --config ./vitest/vitest.config.ts",

--- a/packages/changed/src/changed-command.ts
+++ b/packages/changed/src/changed-command.ts
@@ -1,12 +1,5 @@
-import {
-  collectUpdates,
-  Command,
-  CommandType,
-  ChangedCommandOption,
-  ListCommandOption,
-  logOutput,
-  UpdateCollectorOptions,
-} from '@lerna-lite/core';
+import type { CommandType, ChangedCommandOption, ListCommandOption, UpdateCollectorOptions } from '@lerna-lite/core';
+import { collectUpdates, Command, logOutput } from '@lerna-lite/core';
 import { listable } from '@lerna-lite/listable';
 
 export function factory(argv: ChangedCommandOption & ListCommandOption) {

--- a/packages/cli/src/cli-commands/cli-changed-commands.ts
+++ b/packages/cli/src/cli-commands/cli-changed-commands.ts
@@ -1,4 +1,4 @@
-import { ChangedCommandOption, ListCommandOption } from '@lerna-lite/core';
+import type { ChangedCommandOption, ListCommandOption } from '@lerna-lite/core';
 
 import { listableOptions } from './listable/listable-options.js';
 import { filterOptions } from '../filter-options.js';

--- a/packages/cli/src/cli-commands/cli-diff-commands.ts
+++ b/packages/cli/src/cli-commands/cli-diff-commands.ts
@@ -1,4 +1,4 @@
-import { DiffCommandOption } from '@lerna-lite/core';
+import type { DiffCommandOption } from '@lerna-lite/core';
 
 /**
  * @see https://github.com/yargs/yargs/blob/master/docs/advanced.md#providing-a-command-module

--- a/packages/cli/src/cli-commands/cli-exec-commands.ts
+++ b/packages/cli/src/cli-commands/cli-exec-commands.ts
@@ -1,4 +1,4 @@
-import { ExecCommandOption } from '@lerna-lite/core';
+import type { ExecCommandOption } from '@lerna-lite/core';
 
 import { filterOptions } from '../filter-options.js';
 

--- a/packages/cli/src/cli-commands/cli-init-commands.ts
+++ b/packages/cli/src/cli-commands/cli-init-commands.ts
@@ -1,4 +1,4 @@
-import { InitCommandOption } from '@lerna-lite/core';
+import type { InitCommandOption } from '@lerna-lite/core';
 import { InitCommand } from '@lerna-lite/init';
 
 /**

--- a/packages/cli/src/cli-commands/cli-list-commands.ts
+++ b/packages/cli/src/cli-commands/cli-list-commands.ts
@@ -1,4 +1,4 @@
-import { ListCommandOption } from '@lerna-lite/core';
+import type { ListCommandOption } from '@lerna-lite/core';
 
 import { filterOptions } from '../filter-options.js';
 import { listableOptions } from './listable/listable-options.js';

--- a/packages/cli/src/cli-commands/cli-publish-commands.ts
+++ b/packages/cli/src/cli-commands/cli-publish-commands.ts
@@ -1,4 +1,4 @@
-import { PublishCommandOption } from '@lerna-lite/core';
+import type { PublishCommandOption } from '@lerna-lite/core';
 
 import cliVersionCmd, { addBumpPositional } from './cli-version-commands.js';
 import { filterOptions } from '../filter-options.js';

--- a/packages/cli/src/cli-commands/cli-run-commands.ts
+++ b/packages/cli/src/cli-commands/cli-run-commands.ts
@@ -1,4 +1,4 @@
-import { RunCommandOption } from '@lerna-lite/core';
+import type { RunCommandOption } from '@lerna-lite/core';
 
 import { filterOptions } from '../filter-options.js';
 

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -1,4 +1,4 @@
-import { VersionCommandOption } from '@lerna-lite/core';
+import type { VersionCommandOption } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import { filterOptions } from '../filter-options.js';
 

--- a/packages/cli/src/cli-commands/cli-watch-commands.ts
+++ b/packages/cli/src/cli-commands/cli-watch-commands.ts
@@ -1,4 +1,4 @@
-import { WatchCommandOption } from '@lerna-lite/core';
+import type { WatchCommandOption } from '@lerna-lite/core';
 
 import { filterOptions } from '../filter-options.js';
 

--- a/packages/cli/src/cli-commands/listable/listable-options.ts
+++ b/packages/cli/src/cli-commands/listable/listable-options.ts
@@ -1,4 +1,4 @@
-import { ListableOption } from '@lerna-lite/core';
+import type { ListableOption } from '@lerna-lite/core';
 
 export type YargListableOption = {
   [option in keyof ListableOption]: {

--- a/packages/cli/src/filter-options.ts
+++ b/packages/cli/src/filter-options.ts
@@ -1,5 +1,5 @@
 import dedent from 'dedent';
-import { Argv } from 'yargs';
+import type { Argv } from 'yargs';
 
 export function filterOptions(yargs: Argv<any>) {
   // Only for `exec` and 'run' commands

--- a/packages/cli/src/global-options.ts
+++ b/packages/cli/src/global-options.ts
@@ -1,5 +1,5 @@
 import { cpus } from 'node:os';
-import { Argv } from 'yargs';
+import type { Argv } from 'yargs';
 
 export function globalOptions(yargs: Argv<any>) {
   // the global options applicable to _every_ command

--- a/packages/cli/src/lerna-entry.ts
+++ b/packages/cli/src/lerna-entry.ts
@@ -1,6 +1,6 @@
 import { loadJsonFileSync } from 'load-json-file';
 import { dirname, join } from 'node:path';
-import { JsonValue } from '@lerna-lite/core';
+import type { JsonValue } from '@lerna-lite/core';
 import { fileURLToPath } from 'node:url';
 
 import changedCmd from './cli-commands/cli-changed-commands.js';

--- a/packages/core/src/child-process.ts
+++ b/packages/core/src/child-process.ts
@@ -5,7 +5,7 @@ import { constants } from 'node:os';
 import logTransformer from 'strong-log-transformer';
 import c from 'tinyrainbow';
 
-import { Package } from './package.js';
+import type { Package } from './package.js';
 
 // bookkeeping for spawned processes
 const children = new Set();

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -1,10 +1,13 @@
 import cloneDeep from 'clone-deep';
 import dedent from 'dedent';
-import { execaSync, SyncOptions } from 'execa';
+import type { SyncOptions } from 'execa';
+import { execaSync } from 'execa';
 import isCI from 'is-ci';
 import { cpus } from 'node:os';
-import { log, Logger } from '@lerna-lite/npmlog';
-import { FilterOptions, getFilteredPackages } from './filter-packages/index.js';
+import type { Logger } from '@lerna-lite/npmlog';
+import { log } from '@lerna-lite/npmlog';
+import type { FilterOptions } from './filter-packages/index.js';
+import { getFilteredPackages } from './filter-packages/index.js';
 
 import { cleanStack } from './utils/clean-stack.js';
 import { logExecCommand } from './child-process.js';
@@ -13,8 +16,8 @@ import { warnIfHanging } from './utils/warn-if-hanging.js';
 import { writeLogFile } from './utils/write-log-file.js';
 import { Project } from './project/project.js';
 import { ValidationError } from './validation-error.js';
-import { CommandType, ExecOpts, ProjectConfig } from './models/interfaces.js';
-import {
+import type { CommandType, ExecOpts, ProjectConfig } from './models/interfaces.js';
+import type {
   ChangedCommandOption,
   DiffCommandOption,
   ExecCommandOption,
@@ -25,7 +28,7 @@ import {
   WatchCommandOption,
 } from './models/command-options.js';
 import { PackageGraph } from './package-graph/package-graph.js';
-import { Package } from './package.js';
+import type { Package } from './package.js';
 
 // maxBuffer value for running exec
 const DEFAULT_CONCURRENCY = cpus().length;

--- a/packages/core/src/filter-packages/index.ts
+++ b/packages/core/src/filter-packages/index.ts
@@ -1,3 +1,3 @@
 export * from './lib/filter-packages.js';
 export * from './lib/get-filtered-packages.js';
-export * from './lib/interfaces.js';
+export type * from './lib/interfaces.js';

--- a/packages/core/src/filter-packages/lib/filter-packages.ts
+++ b/packages/core/src/filter-packages/lib/filter-packages.ts
@@ -1,4 +1,5 @@
-import { Package, ValidationError } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
+import { ValidationError } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import multimatch from 'multimatch';
 import util from 'node:util';

--- a/packages/core/src/filter-packages/lib/get-filtered-packages.ts
+++ b/packages/core/src/filter-packages/lib/get-filtered-packages.ts
@@ -1,12 +1,12 @@
 import { log } from '@lerna-lite/npmlog';
 
-import { ExecOpts } from '../../models/interfaces.js';
-import { PackageGraph } from '../../package-graph/package-graph.js';
-import { Package } from '../../package.js';
+import type { ExecOpts } from '../../models/interfaces.js';
+import type { PackageGraph } from '../../package-graph/package-graph.js';
+import type { Package } from '../../package.js';
 import { collectUpdates } from '../../utils/collect-updates/collect-updates.js';
 
 import { filterPackages } from './filter-packages.js';
-import { FilterOptions } from './interfaces.js';
+import type { FilterOptions } from './interfaces.js';
 
 /**
  * Retrieve a list of Package instances filtered by various options.

--- a/packages/core/src/filter-packages/lib/interfaces.ts
+++ b/packages/core/src/filter-packages/lib/interfaces.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@lerna-lite/npmlog';
+import type { Logger } from '@lerna-lite/npmlog';
 
 export interface FilterOptions {
   log: Logger;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,8 @@
 export * from './corepack/exec-package-manager.js';
 export * from './corepack/is-corepack-enabled.js';
 export * from './filter-packages/index.js';
-export * from './models/command-options.js';
-export * from './models/interfaces.js';
+export type * from './models/command-options.js';
+export type * from './models/interfaces.js';
 export * from './package-graph/package-graph.js';
 export * from './package-graph/lib/cyclic-package-graph-node.js';
 export * from './package-graph/lib/package-graph-node.js';

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -1,4 +1,4 @@
-import { ArboristLoadOption, ChangelogPresetOptions, RemoteClientType } from './interfaces.js';
+import type { ArboristLoadOption, ChangelogPresetOptions, RemoteClientType } from './interfaces.js';
 
 export interface ChangedCommandOption {
   /** use conventional-changelog to determine version bump and generate CHANGELOG. */

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -1,8 +1,8 @@
-import { Logger } from '@lerna-lite/npmlog';
-import npa from 'npm-package-arg';
+import type { Logger } from '@lerna-lite/npmlog';
+import type npa from 'npm-package-arg';
 
-import { Package } from '../package.js';
-import { InitCommandOption, PublishCommandOption, RunCommandOption, VersionCommandOption } from './command-options.js';
+import type { Package } from '../package.js';
+import type { InitCommandOption, PublishCommandOption, RunCommandOption, VersionCommandOption } from './command-options.js';
 
 /* eslint-disable no-use-before-define */
 export type JsonObject = { [Key in string]: JsonValue } & { [Key in string]?: JsonValue | undefined };

--- a/packages/core/src/package-graph/lib/cyclic-package-graph-node.ts
+++ b/packages/core/src/package-graph/lib/cyclic-package-graph-node.ts
@@ -1,4 +1,4 @@
-import { PackageGraphNode } from '../../package-graph/lib/package-graph-node.js';
+import type { PackageGraphNode } from '../../package-graph/lib/package-graph-node.js';
 
 let lastCollapsedNodeId = 0;
 

--- a/packages/core/src/package-graph/lib/package-graph-node.ts
+++ b/packages/core/src/package-graph/lib/package-graph-node.ts
@@ -1,7 +1,7 @@
-import { Result } from 'npm-package-arg';
+import type { Result } from 'npm-package-arg';
 import semver from 'semver';
 
-import { Package } from '../../package.js';
+import type { Package } from '../../package.js';
 import { prereleaseIdFromVersion } from '../../utils/prerelease-id-from-version.js';
 
 const PKG = Symbol('pkg');

--- a/packages/core/src/package-graph/package-graph.ts
+++ b/packages/core/src/package-graph/package-graph.ts
@@ -7,9 +7,9 @@ import { parse } from 'yaml';
 import { CyclicPackageGraphNode } from './lib/cyclic-package-graph-node.js';
 import { PackageGraphNode } from './lib/package-graph-node.js';
 import { reportCycles } from './lib/report-cycles.js';
-import { Package } from '../package.js';
+import type { Package } from '../package.js';
 import { ValidationError } from '../validation-error.js';
-import { NpaResolveResult } from '../models/interfaces.js';
+import type { NpaResolveResult } from '../models/interfaces.js';
 
 /**
  * A regular expression used to capture and substitute package versions (referred to as "spec" in the lerna-lite code).

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join, resolve as pathResolve, relative } from 'node:
 import { writePackage } from 'write-package';
 import { log } from '@lerna-lite/npmlog';
 
-import { CommandType, DependenciesType, NpaResolveResult, RawManifest } from './models/interfaces.js';
+import type { CommandType, DependenciesType, NpaResolveResult, RawManifest } from './models/interfaces.js';
 
 // symbol used to 'hide' internal state
 const PKG = Symbol('pkg');

--- a/packages/core/src/project/lib/make-file-finder.ts
+++ b/packages/core/src/project/lib/make-file-finder.ts
@@ -1,4 +1,5 @@
-import { glob, globSync, GlobOptions as TinyGlobbyOptions } from 'tinyglobby';
+import type { GlobOptions as TinyGlobbyOptions } from 'tinyglobby';
+import { glob, globSync } from 'tinyglobby';
 import { normalize as pathNormalize, posix } from 'node:path';
 import pMap from 'p-map';
 

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -14,7 +14,7 @@ import { Package } from '../package.js';
 import { applyExtends } from './lib/apply-extends.js';
 import { ValidationError } from '../validation-error.js';
 import { makeFileFinder, makeSyncFileFinder } from './lib/make-file-finder.js';
-import { ProjectConfig, RawManifest } from '../models/interfaces.js';
+import type { ProjectConfig, RawManifest } from '../models/interfaces.js';
 
 /**
  * A representation of the entire project managed by Lerna.

--- a/packages/core/src/utils/check-working-tree.ts
+++ b/packages/core/src/utils/check-working-tree.ts
@@ -1,4 +1,5 @@
-import { collectUncommitted, UncommittedConfig } from './collect-uncommitted.js';
+import type { UncommittedConfig } from './collect-uncommitted.js';
+import { collectUncommitted } from './collect-uncommitted.js';
 import { describeRef } from './describe-ref.js';
 import { ValidationError } from '../validation-error.js';
 

--- a/packages/core/src/utils/collect-uncommitted.ts
+++ b/packages/core/src/utils/collect-uncommitted.ts
@@ -1,4 +1,5 @@
-import { log as npmlog, Logger } from '@lerna-lite/npmlog';
+import type { Logger } from '@lerna-lite/npmlog';
+import { log as npmlog } from '@lerna-lite/npmlog';
 import c from 'tinyrainbow';
 
 import { exec, execSync } from '../child-process.js';

--- a/packages/core/src/utils/collect-updates/collect-updates.ts
+++ b/packages/core/src/utils/collect-updates/collect-updates.ts
@@ -1,8 +1,8 @@
 import { log } from '@lerna-lite/npmlog';
 
 import type { DescribeRefOptions, ExecOpts, UpdateCollectorOptions } from '../../models/interfaces.js';
-import { Package } from '../../package.js';
-import { PackageGraph } from '../../package-graph/package-graph.js';
+import type { Package } from '../../package.js';
+import type { PackageGraph } from '../../package-graph/package-graph.js';
 import { describeRefSync } from '../describe-ref.js';
 import { collectPackages } from './lib/collect-packages.js';
 import { getPackagesForOption } from './lib/get-packages-for-option.js';

--- a/packages/core/src/utils/collect-updates/lib/collect-packages.ts
+++ b/packages/core/src/utils/collect-updates/lib/collect-packages.ts
@@ -1,4 +1,4 @@
-import { PackageGraphNode } from '../../../package-graph/lib/package-graph-node.js';
+import type { PackageGraphNode } from '../../../package-graph/lib/package-graph-node.js';
 import { collectDependents } from './collect-dependents.js';
 
 interface PackageCollectorOptions {

--- a/packages/core/src/utils/collect-updates/lib/has-tags.ts
+++ b/packages/core/src/utils/collect-updates/lib/has-tags.ts
@@ -1,7 +1,7 @@
 import { log } from '@lerna-lite/npmlog';
 
 import { execSync } from '../../../child-process.js';
-import { ExecOpts } from '../../../models/interfaces.js';
+import type { ExecOpts } from '../../../models/interfaces.js';
 
 /**
  * Determine if any git tags are reachable.

--- a/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
+++ b/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
@@ -5,7 +5,7 @@ import { dirname, relative } from 'node:path';
 import slash from 'slash';
 
 import { execSync } from '../../../child-process.js';
-import { ExecOpts } from '../../../models/interfaces.js';
+import type { ExecOpts } from '../../../models/interfaces.js';
 
 /**
  * @param {string} committish

--- a/packages/core/src/utils/describe-ref.ts
+++ b/packages/core/src/utils/describe-ref.ts
@@ -1,6 +1,6 @@
 import { log } from '@lerna-lite/npmlog';
 
-import { DescribeRefDetailedResult, DescribeRefFallbackResult, DescribeRefOptions } from '../models/interfaces.js';
+import type { DescribeRefDetailedResult, DescribeRefFallbackResult, DescribeRefOptions } from '../models/interfaces.js';
 import { exec, execSync } from '../child-process.js';
 
 /**

--- a/packages/core/src/utils/query-graph.ts
+++ b/packages/core/src/utils/query-graph.ts
@@ -1,7 +1,7 @@
 import { PackageGraph } from '../package-graph/package-graph.js';
-import { QueryGraphConfig } from '../models/interfaces.js';
-import { Package } from '../package.js';
-import { PackageGraphNode } from '../package-graph/lib/package-graph-node.js';
+import type { QueryGraphConfig } from '../models/interfaces.js';
+import type { Package } from '../package.js';
+import type { PackageGraphNode } from '../package-graph/lib/package-graph-node.js';
 
 /**
  * A mutable PackageGraph used to query for next available packages.

--- a/packages/core/src/utils/run-lifecycle.ts
+++ b/packages/core/src/utils/run-lifecycle.ts
@@ -3,8 +3,8 @@ import PQueue from 'p-queue';
 import { log } from '@lerna-lite/npmlog';
 
 import { npmConf } from '../utils/npm-conf.js';
-import { LifecycleConfig } from '../models/interfaces.js';
-import { Package } from '../package.js';
+import type { LifecycleConfig } from '../models/interfaces.js';
+import type { Package } from '../package.js';
 
 const queue = new PQueue({ concurrency: 1 });
 

--- a/packages/core/src/utils/run-topologically.ts
+++ b/packages/core/src/utils/run-topologically.ts
@@ -1,9 +1,9 @@
 import PQueue from 'p-queue';
 
 import { QueryGraph } from './query-graph.js';
-import { TopologicalConfig } from '../models/interfaces.js';
-import { Package } from '../package.js';
-import { PackageGraphNode } from '../package-graph/lib/package-graph-node.js';
+import type { TopologicalConfig } from '../models/interfaces.js';
+import type { Package } from '../package.js';
+import type { PackageGraphNode } from '../package-graph/lib/package-graph-node.js';
 
 /**
  * Run callback in maximally-saturated topological order.

--- a/packages/diff/src/diff-command.ts
+++ b/packages/diff/src/diff-command.ts
@@ -1,12 +1,5 @@
-import {
-  Command,
-  CommandType,
-  DiffCommandOption,
-  PackageGraphNode,
-  ProjectConfig,
-  spawn,
-  ValidationError,
-} from '@lerna-lite/core';
+import type { CommandType, DiffCommandOption, PackageGraphNode, ProjectConfig } from '@lerna-lite/core';
+import { Command, spawn, ValidationError } from '@lerna-lite/core';
 
 import { getLastCommit } from './lib/get-last-commit.js';
 import { hasCommit } from './lib/has-commit.js';

--- a/packages/diff/src/lib/get-last-commit.ts
+++ b/packages/diff/src/lib/get-last-commit.ts
@@ -1,4 +1,5 @@
-import { ExecOpts, execSync } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { execSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 /**

--- a/packages/diff/src/lib/has-commit.ts
+++ b/packages/diff/src/lib/has-commit.ts
@@ -1,4 +1,5 @@
-import { ExecOpts, execSync } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { execSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 /**

--- a/packages/exec/src/exec-command.ts
+++ b/packages/exec/src/exec-command.ts
@@ -1,13 +1,9 @@
 import 'dotenv/config';
+import type { CommandType, ExecCommandOption, FilterOptions, Package, ProjectConfig } from '@lerna-lite/core';
 import {
   Command,
-  CommandType,
-  ExecCommandOption,
-  FilterOptions,
   getFilteredPackages,
   logOutput,
-  Package,
-  ProjectConfig,
   runTopologically,
   spawn,
   spawnStreaming,
@@ -17,7 +13,7 @@ import { Profiler } from '@lerna-lite/profiler';
 import pMap from 'p-map';
 import c from 'tinyrainbow';
 
-import { ExecStreamingOption } from './interfaces.js';
+import type { ExecStreamingOption } from './interfaces.js';
 
 export function factory(argv: ExecCommandOption) {
   return new ExecCommand(argv);

--- a/packages/exec/src/index.ts
+++ b/packages/exec/src/index.ts
@@ -1,2 +1,2 @@
-export * from './interfaces.js';
+export type * from './interfaces.js';
 export * from './exec-command.js';

--- a/packages/exec/src/interfaces.ts
+++ b/packages/exec/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 
 export interface ExecScriptOption {
   args?: string[];

--- a/packages/init/src/init-command.ts
+++ b/packages/init/src/init-command.ts
@@ -1,4 +1,5 @@
-import { Command, CommandType, exec, InitCommandOption, ProjectConfig } from '@lerna-lite/core';
+import type { CommandType, InitCommandOption, ProjectConfig } from '@lerna-lite/core';
+import { Command, exec } from '@lerna-lite/core';
 import { mkdirp } from 'fs-extra/esm';
 import { join } from 'node:path';
 import pMap from 'p-map';

--- a/packages/list/src/list-command.ts
+++ b/packages/list/src/list-command.ts
@@ -1,12 +1,5 @@
-import {
-  Command,
-  CommandType,
-  FilterOptions,
-  ListCommandOption,
-  getFilteredPackages,
-  logOutput,
-  ProjectConfig,
-} from '@lerna-lite/core';
+import type { CommandType, FilterOptions, ListCommandOption, ProjectConfig } from '@lerna-lite/core';
+import { Command, getFilteredPackages, logOutput } from '@lerna-lite/core';
 import { listable } from '@lerna-lite/listable';
 
 export function factory(argv: ListCommandOption) {

--- a/packages/listable/src/lib/listable-format.ts
+++ b/packages/listable/src/lib/listable-format.ts
@@ -1,4 +1,5 @@
-import { ListableOption, Package, QueryGraph } from '@lerna-lite/core';
+import type { ListableOption, Package } from '@lerna-lite/core';
+import { QueryGraph } from '@lerna-lite/core';
 import columnify from 'columnify';
 import { relative } from 'node:path';
 import c from 'tinyrainbow';

--- a/packages/npmlog/src/npmlog.ts
+++ b/packages/npmlog/src/npmlog.ts
@@ -4,7 +4,7 @@
 
 import consoleControl from 'console-control-strings';
 import { EventEmitter } from 'node:events';
-import { WriteStream } from 'node:tty';
+import type { WriteStream } from 'node:tty';
 import { format } from 'node:util';
 import setBlocking from 'set-blocking';
 

--- a/packages/profiler/src/index.ts
+++ b/packages/profiler/src/index.ts
@@ -1,2 +1,2 @@
-export * from './models.js';
+export type * from './models.js';
 export * from './profiler.js';

--- a/packages/profiler/src/models.ts
+++ b/packages/profiler/src/models.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@lerna-lite/npmlog';
+import type { Logger } from '@lerna-lite/npmlog';
 
 export interface ProfilerConfig {
   concurrency: number;

--- a/packages/profiler/src/profiler.ts
+++ b/packages/profiler/src/profiler.ts
@@ -1,10 +1,11 @@
 import { outputJson } from 'fs-extra/esm';
-import { log as npmlog, Logger } from '@lerna-lite/npmlog';
+import type { Logger } from '@lerna-lite/npmlog';
+import { log as npmlog } from '@lerna-lite/npmlog';
 
 // @ts-ignore
 import upath from 'upath';
 
-import { ProfilerConfig, TraceEvent } from './models.js';
+import type { ProfilerConfig, TraceEvent } from './models.js';
 
 const getTimeBasedFilename = () => {
   const now = new Date(); // 2011-10-05T14:48:00.000Z

--- a/packages/publish/src/index.ts
+++ b/packages/publish/src/index.ts
@@ -18,5 +18,5 @@ export * from './lib/pack-directory.js';
 export * from './lib/remove-temp-licenses.js';
 export * from './lib/throttle-queue.js';
 export * from './lib/verify-npm-package-access.js';
-export * from './interfaces.js';
+export type * from './interfaces.js';
 export * from './publish-command.js';

--- a/packages/publish/src/interfaces.ts
+++ b/packages/publish/src/interfaces.ts
@@ -1,4 +1,4 @@
-import fetch from 'npm-registry-fetch';
+import type fetch from 'npm-registry-fetch';
 
 export interface DistTagOptions extends fetch.FetchOptions {
   defaultTag?: string;

--- a/packages/publish/src/lib/create-temp-licenses.ts
+++ b/packages/publish/src/lib/create-temp-licenses.ts
@@ -2,7 +2,7 @@ import { copy } from 'fs-extra/esm';
 import { basename, join } from 'node:path';
 import pMap from 'p-map';
 
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 
 /**
  * Create temporary license files.

--- a/packages/publish/src/lib/fetch-config.ts
+++ b/packages/publish/src/lib/fetch-config.ts
@@ -1,4 +1,4 @@
-import { FetchConfig } from '@lerna-lite/core';
+import type { FetchConfig } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 /**

--- a/packages/publish/src/lib/get-current-sha.ts
+++ b/packages/publish/src/lib/get-current-sha.ts
@@ -1,4 +1,5 @@
-import { ExecOpts, execSync } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { execSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 /**

--- a/packages/publish/src/lib/get-current-tags.ts
+++ b/packages/publish/src/lib/get-current-tags.ts
@@ -1,4 +1,5 @@
-import { exec, ExecOpts } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { exec } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import npa from 'npm-package-arg';
 

--- a/packages/publish/src/lib/get-npm-username.ts
+++ b/packages/publish/src/lib/get-npm-username.ts
@@ -1,4 +1,5 @@
-import { FetchConfig, ValidationError } from '@lerna-lite/core';
+import type { FetchConfig } from '@lerna-lite/core';
+import { ValidationError } from '@lerna-lite/core';
 
 import { getFetchConfig } from './fetch-config.js';
 import { getProfileData } from './get-profile-data.js';

--- a/packages/publish/src/lib/get-packages-without-license.ts
+++ b/packages/publish/src/lib/get-packages-without-license.ts
@@ -1,5 +1,5 @@
 import { dirname } from 'node:path';
-import { Package, Project } from '@lerna-lite/core';
+import type { Package, Project } from '@lerna-lite/core';
 
 /**
  * Retrieve a list of packages that lack a license file.

--- a/packages/publish/src/lib/get-packed.ts
+++ b/packages/publish/src/lib/get-packed.ts
@@ -3,9 +3,9 @@ import { stat } from 'fs/promises';
 import { basename } from 'node:path';
 import ssri from 'ssri';
 import tar from 'tar';
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 
-import { Tarball } from '../interfaces.js';
+import type { Tarball } from '../interfaces.js';
 
 export function getPacked(pkg: Package, tarFilePath: string): Promise<Tarball> {
   const bundledWanted = new Set<string>(/* pkg.bundleDependencies || pkg.bundledDependencies || */ []);

--- a/packages/publish/src/lib/get-profile-data.ts
+++ b/packages/publish/src/lib/get-profile-data.ts
@@ -1,6 +1,7 @@
 import fetch from 'npm-registry-fetch';
 
-import { FetchConfig, ProfileData, pulseTillDone } from '@lerna-lite/core';
+import type { FetchConfig, ProfileData } from '@lerna-lite/core';
+import { pulseTillDone } from '@lerna-lite/core';
 
 /**
  * Retrieve profile data of logged-in user.

--- a/packages/publish/src/lib/get-tagged-packages.ts
+++ b/packages/publish/src/lib/get-tagged-packages.ts
@@ -1,4 +1,5 @@
-import { exec, ExecOpts, PackageGraph } from '@lerna-lite/core';
+import type { ExecOpts, PackageGraph } from '@lerna-lite/core';
+import { exec } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import { basename, dirname, join } from 'node:path';
 

--- a/packages/publish/src/lib/get-two-factor-auth-required.ts
+++ b/packages/publish/src/lib/get-two-factor-auth-required.ts
@@ -1,4 +1,5 @@
-import { FetchConfig, ValidationError } from '@lerna-lite/core';
+import type { FetchConfig } from '@lerna-lite/core';
+import { ValidationError } from '@lerna-lite/core';
 
 import { getFetchConfig } from './fetch-config.js';
 import { getProfileData } from './get-profile-data.js';

--- a/packages/publish/src/lib/get-unpublished-packages.ts
+++ b/packages/publish/src/lib/get-unpublished-packages.ts
@@ -1,4 +1,4 @@
-import { FetchConfig, PackageGraph, PackageGraphNode } from '@lerna-lite/core';
+import type { FetchConfig, PackageGraph, PackageGraphNode } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import pMap from 'p-map';
 import pacote from 'pacote';

--- a/packages/publish/src/lib/get-whoami.ts
+++ b/packages/publish/src/lib/get-whoami.ts
@@ -1,6 +1,7 @@
 import fetch from 'npm-registry-fetch';
 
-import { FetchConfig, pulseTillDone } from '@lerna-lite/core';
+import type { FetchConfig } from '@lerna-lite/core';
+import { pulseTillDone } from '@lerna-lite/core';
 
 interface WhoIAm {
   username: string;

--- a/packages/publish/src/lib/git-checkout.ts
+++ b/packages/publish/src/lib/git-checkout.ts
@@ -1,4 +1,5 @@
-import { exec, ExecOpts } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { exec } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 /**

--- a/packages/publish/src/lib/log-packed.ts
+++ b/packages/publish/src/lib/log-packed.ts
@@ -1,11 +1,11 @@
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import byteSize from 'byte-size';
 import columnify from 'columnify';
 import hasUnicode from 'has-unicode';
 import c from 'tinyrainbow';
 
-import { Tarball } from '../interfaces.js';
+import type { Tarball } from '../interfaces.js';
 
 export function logPacked(pkg: Package & { packed: Tarball }, dryRun = false) {
   const tarball = pkg.packed;

--- a/packages/publish/src/lib/npm-dist-tag.ts
+++ b/packages/publish/src/lib/npm-dist-tag.ts
@@ -1,9 +1,10 @@
 import { log } from '@lerna-lite/npmlog';
-import { OneTimePasswordCache, otplease } from '@lerna-lite/version';
+import type { OneTimePasswordCache } from '@lerna-lite/version';
+import { otplease } from '@lerna-lite/version';
 import npa from 'npm-package-arg';
 import fetch from 'npm-registry-fetch';
 
-import { DistTagOptions } from '../interfaces.js';
+import type { DistTagOptions } from '../interfaces.js';
 
 /**
  * Add a dist-tag to a package.

--- a/packages/publish/src/lib/override-publish-config.ts
+++ b/packages/publish/src/lib/override-publish-config.ts
@@ -1,4 +1,5 @@
-import { isEmpty, JsonValue, RawManifest } from '@lerna-lite/core';
+import type { JsonValue, RawManifest } from '@lerna-lite/core';
+import { isEmpty } from '@lerna-lite/core';
 
 // manifest fields that may make sense to overwrite
 const PUBLISH_CONFIG_WHITELIST = new Set([

--- a/packages/publish/src/lib/pack-directory.ts
+++ b/packages/publish/src/lib/pack-directory.ts
@@ -1,9 +1,10 @@
-import { ArboristLoadOption, LifecycleConfig, Package, PackConfig, runLifecycle } from '@lerna-lite/core';
+import type { ArboristLoadOption, LifecycleConfig, PackConfig } from '@lerna-lite/core';
+import { Package, runLifecycle } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import { tempWrite } from '@lerna-lite/version';
 import Arborist from '@npmcli/arborist';
 import { relative } from 'node:path';
-import { Readable } from 'node:stream';
+import type { Readable } from 'node:stream';
 import packlist from 'npm-packlist';
 import tar from 'tar';
 

--- a/packages/publish/src/lib/remove-temp-licenses.ts
+++ b/packages/publish/src/lib/remove-temp-licenses.ts
@@ -1,7 +1,7 @@
 import { remove } from 'fs-extra/esm';
 import pMap from 'p-map';
 
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 
 /**
  * Remove temporary license files.

--- a/packages/publish/src/lib/verify-npm-package-access.ts
+++ b/packages/publish/src/lib/verify-npm-package-access.ts
@@ -1,6 +1,7 @@
 import access from 'libnpmaccess';
 
-import { FetchConfig, Package, pulseTillDone, ValidationError } from '@lerna-lite/core';
+import type { FetchConfig, Package } from '@lerna-lite/core';
+import { pulseTillDone, ValidationError } from '@lerna-lite/core';
 import { getFetchConfig } from './fetch-config.js';
 
 /**

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -10,29 +10,32 @@ import tempDir from 'temp-dir';
 import { glob } from 'tinyglobby';
 import c from 'tinyrainbow';
 
-import { getOneTimePassword, OneTimePasswordCache, VersionCommand } from '@lerna-lite/version';
+import type { OneTimePasswordCache } from '@lerna-lite/version';
+import { getOneTimePassword, VersionCommand } from '@lerna-lite/version';
+import type {
+  CommandType,
+  Conf,
+  NpaResolveResult,
+  Package,
+  PackageGraphNode,
+  ProjectConfig,
+  PublishCommandOption,
+  UpdateCollectorOptions,
+} from '@lerna-lite/core';
 import {
   collectUpdates,
   Command,
-  CommandType,
-  Conf,
   createRunner,
   deleteComplexObjectProp,
   describeRef,
   excludeValuesFromArray,
   logOutput,
-  NpaResolveResult,
   npmConf,
-  Package,
-  PackageGraphNode,
   prereleaseIdFromVersion,
-  ProjectConfig,
   promptConfirmation,
-  PublishCommandOption,
   pulseTillDone,
   runTopologically,
   throwIfUncommitted,
-  UpdateCollectorOptions,
   ValidationError,
 } from '@lerna-lite/core';
 
@@ -52,7 +55,8 @@ import { overridePublishConfig } from './lib/override-publish-config.js';
 import { removeTempLicenses } from './lib/remove-temp-licenses.js';
 import { createTempLicenses } from './lib/create-temp-licenses.js';
 import { getPackagesWithoutLicense } from './lib/get-packages-without-license.js';
-import { Queue, TailHeadQueue } from './lib/throttle-queue.js';
+import type { Queue } from './lib/throttle-queue.js';
+import { TailHeadQueue } from './lib/throttle-queue.js';
 import type { Tarball } from './interfaces.js';
 import { isNpmJsPublishVersionConflict } from './lib/is-npm-js-publish-version-conflict.js';
 import { isNpmPkgGitHubPublishVersionConflict } from './lib/is-npm-pkg-github-publish-version-conflict.js';

--- a/packages/run/src/interfaces.ts
+++ b/packages/run/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 
 export interface RunScriptOption {
   args: any;

--- a/packages/run/src/lib/get-npm-exec-opts.ts
+++ b/packages/run/src/lib/get-npm-exec-opts.ts
@@ -1,4 +1,4 @@
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 export function getNpmExecOpts(pkg: Package) {

--- a/packages/run/src/lib/npm-run-script.ts
+++ b/packages/run/src/lib/npm-run-script.ts
@@ -1,8 +1,9 @@
 import { log } from '@lerna-lite/npmlog';
-import { execPackageManager, Package, spawnStreaming } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
+import { execPackageManager, spawnStreaming } from '@lerna-lite/core';
 
 import { getNpmExecOpts } from './get-npm-exec-opts.js';
-import { RunScriptOption, ScriptStreamingOption } from '../interfaces.js';
+import type { RunScriptOption, ScriptStreamingOption } from '../interfaces.js';
 
 export function npmRunScript(script: string, { args, npmClient, pkg, reject = true }: RunScriptOption, dryRun = false) {
   log.silly('npmRunScript', script, args, pkg.name);

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -1,22 +1,12 @@
-import {
-  Command,
-  CommandType,
-  FilterOptions,
-  getFilteredPackages,
-  logOutput,
-  Package,
-  ProjectConfig,
-  RunCommandOption,
-  runTopologically,
-  ValidationError,
-} from '@lerna-lite/core';
+import type { CommandType, FilterOptions, Package, ProjectConfig, RunCommandOption } from '@lerna-lite/core';
+import { Command, getFilteredPackages, logOutput, runTopologically, ValidationError } from '@lerna-lite/core';
 import { Profiler } from '@lerna-lite/profiler';
 import pMap from 'p-map';
 import c from 'tinyrainbow';
 
 import { npmRunScript, npmRunScriptStreaming } from './lib/npm-run-script.js';
 import { timer } from './lib/timer.js';
-import { ScriptStreamingOption } from './interfaces.js';
+import type { ScriptStreamingOption } from './interfaces.js';
 
 export function factory(argv: RunCommandOption) {
   return new RunCommand(argv);

--- a/packages/version/src/conventional-commits/get-changelog-config.ts
+++ b/packages/version/src/conventional-commits/get-changelog-config.ts
@@ -3,7 +3,7 @@ import { log } from '@lerna-lite/npmlog';
 import npa from 'npm-package-arg';
 import pify from 'pify';
 
-import { ChangelogConfig, ChangelogPresetConfig } from '../interfaces.js';
+import type { ChangelogConfig, ChangelogPresetConfig } from '../interfaces.js';
 
 export class GetChangelogConfig {
   static cfgCache = new Map<string, any>();

--- a/packages/version/src/conventional-commits/get-commits-since-last-release.ts
+++ b/packages/version/src/conventional-commits/get-commits-since-last-release.ts
@@ -1,7 +1,8 @@
-import { DescribeRefOptions, describeRefSync, ExecOpts, execSync, RemoteClientType, ValidationError } from '@lerna-lite/core';
+import type { DescribeRefOptions, ExecOpts, RemoteClientType } from '@lerna-lite/core';
+import { describeRefSync, execSync, ValidationError } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
-import { RemoteCommit } from '../interfaces.js';
+import type { RemoteCommit } from '../interfaces.js';
 import { getGithubCommits } from './get-github-commits.js';
 
 /**

--- a/packages/version/src/conventional-commits/get-github-commits.ts
+++ b/packages/version/src/conventional-commits/get-github-commits.ts
@@ -1,9 +1,10 @@
-import { ExecOpts, getComplexObjectValue } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { getComplexObjectValue } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import dedent from 'dedent';
 
 import { createGitHubClient, parseGitRepo } from '../git-clients/github-client.js';
-import { RemoteCommit } from '../interfaces.js';
+import type { RemoteCommit } from '../interfaces.js';
 
 const QUERY_PAGE_SIZE = 100; // GitHub API is restricting max of 100 per query
 

--- a/packages/version/src/conventional-commits/make-bump-only-filter.ts
+++ b/packages/version/src/conventional-commits/make-bump-only-filter.ts
@@ -1,4 +1,4 @@
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 
 import { BLANK_LINE } from './constants.js';
 

--- a/packages/version/src/conventional-commits/read-existing-changelog.ts
+++ b/packages/version/src/conventional-commits/read-existing-changelog.ts
@@ -1,4 +1,4 @@
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 import { readFile } from 'fs/promises';
 import { join } from 'node:path';
 

--- a/packages/version/src/conventional-commits/recommend-version.ts
+++ b/packages/version/src/conventional-commits/recommend-version.ts
@@ -1,10 +1,11 @@
-import { Package, PackageGraphNode } from '@lerna-lite/core';
+import type { Package, PackageGraphNode } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import conventionalRecommendedBump from 'conventional-recommended-bump';
-import conventionalChangelogCore from 'conventional-changelog-core';
-import semver, { ReleaseType } from 'semver';
+import type conventionalChangelogCore from 'conventional-changelog-core';
+import type { ReleaseType } from 'semver';
+import semver from 'semver';
 
-import { BaseChangelogOptions, VersioningStrategy } from '../interfaces.js';
+import type { BaseChangelogOptions, VersioningStrategy } from '../interfaces.js';
 import { GetChangelogConfig } from './get-changelog-config.js';
 import { applyBuildMetadata } from './apply-build-metadata.js';
 

--- a/packages/version/src/conventional-commits/update-changelog.ts
+++ b/packages/version/src/conventional-commits/update-changelog.ts
@@ -1,14 +1,16 @@
-import { ChangelogPresetOptions, EOL, Package } from '@lerna-lite/core';
+import type { ChangelogPresetOptions, Package } from '@lerna-lite/core';
+import { EOL } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
-import conventionalChangelogCore, { Context } from 'conventional-changelog-core';
-import { Options as WriterOptions } from 'conventional-changelog-writer';
+import type { Context } from 'conventional-changelog-core';
+import conventionalChangelogCore from 'conventional-changelog-core';
+import type { Options as WriterOptions } from 'conventional-changelog-writer';
 import { writeFile } from 'fs/promises';
 import getStream from 'get-stream';
 
 import { BLANK_LINE, CHANGELOG_HEADER } from './constants.js';
 import { GetChangelogConfig } from './get-changelog-config.js';
 import { makeBumpOnlyFilter } from './make-bump-only-filter.js';
-import { ChangelogConfig, ChangelogType, UpdateChangelogOption } from '../interfaces.js';
+import type { ChangelogConfig, ChangelogType, UpdateChangelogOption } from '../interfaces.js';
 import { readExistingChangelog } from './read-existing-changelog.js';
 import { setConfigChangelogCommitClientLogin, setConfigChangelogCommitGitAuthor } from './writer-opts-transform.js';
 

--- a/packages/version/src/conventional-commits/writer-opts-transform.ts
+++ b/packages/version/src/conventional-commits/writer-opts-transform.ts
@@ -1,8 +1,8 @@
-import { Context, GitRawCommitsOptions } from 'conventional-changelog-core';
-import { Options as WriterOptions } from 'conventional-changelog-writer';
-import { Commit } from 'conventional-commits-parser';
+import type { Context, GitRawCommitsOptions } from 'conventional-changelog-core';
+import type { Options as WriterOptions } from 'conventional-changelog-writer';
+import type { Commit } from 'conventional-commits-parser';
 
-import { ChangelogConfig, RemoteCommit } from '../interfaces.js';
+import type { ChangelogConfig, RemoteCommit } from '../interfaces.js';
 
 // available formats can be found at Git's url: https://git-scm.com/docs/git-log#_pretty_formats
 const GIT_COMMIT_WITH_AUTHOR_FORMAT =

--- a/packages/version/src/git-clients/GitLabClient.ts
+++ b/packages/version/src/git-clients/GitLabClient.ts
@@ -2,7 +2,7 @@ import { log } from '@lerna-lite/npmlog';
 import fetch from 'node-fetch';
 import { join } from 'node:path';
 
-import { GitClient, GitClientReleaseOption } from '../interfaces.js';
+import type { GitClient, GitClientReleaseOption } from '../interfaces.js';
 
 export class GitLabClient implements GitClient {
   baseUrl: string;

--- a/packages/version/src/git-clients/github-client.ts
+++ b/packages/version/src/git-clients/github-client.ts
@@ -1,7 +1,7 @@
 import { execSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import { Octokit } from '@octokit/rest';
-import { SyncOptions } from 'execa';
+import { type SyncOptions } from 'execa';
 import parseGitUrl from 'git-url-parse';
 
 export async function createGitHubClient() {

--- a/packages/version/src/git-clients/gitlab-client.ts
+++ b/packages/version/src/git-clients/gitlab-client.ts
@@ -1,7 +1,7 @@
 import { log } from '@lerna-lite/npmlog';
 
 import { GitLabClient } from './GitLabClient.js';
-import { GitCreateReleaseClientOutput } from '../interfaces.js';
+import type { GitCreateReleaseClientOutput } from '../interfaces.js';
 
 function OcktokitAdapter(client): GitCreateReleaseClientOutput {
   return { repos: { createRelease: client.createRelease.bind(client) } };

--- a/packages/version/src/index.ts
+++ b/packages/version/src/index.ts
@@ -22,7 +22,7 @@ export * from './lib/is-breaking-change.js';
 export * from './lib/prompt-version.js';
 export * from './lib/remote-branch-exists.js';
 export * from './lib/update-lockfile-version.js';
-export * from './interfaces.js';
+export type * from './interfaces.js';
 export * from './version-command.js';
 export * from './utils/otplease.js';
 export * from './utils/temp-write.js';

--- a/packages/version/src/interfaces.ts
+++ b/packages/version/src/interfaces.ts
@@ -1,7 +1,7 @@
-import { ChangelogPresetOptions, ExecOpts, Package } from '@lerna-lite/core';
-import { GitRawCommitsOptions, ParserOptions } from 'conventional-changelog-core';
-import { Options as WriterOptions } from 'conventional-changelog-writer';
-import { Options as RecommendedBumpOptions } from 'conventional-recommended-bump';
+import type { ChangelogPresetOptions, ExecOpts, Package } from '@lerna-lite/core';
+import type { GitRawCommitsOptions, ParserOptions } from 'conventional-changelog-core';
+import type { Options as WriterOptions } from 'conventional-changelog-writer';
+import type { Options as RecommendedBumpOptions } from 'conventional-recommended-bump';
 
 export interface GitCommitOption {
   amend: boolean;

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -1,4 +1,5 @@
-import { RemoteClientType, ValidationError } from '@lerna-lite/core';
+import type { RemoteClientType } from '@lerna-lite/core';
+import { ValidationError } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import newGithubReleaseUrl from 'new-github-release-url';
 import semver from 'semver';
@@ -6,7 +7,7 @@ import c from 'tinyrainbow';
 
 import { createGitHubClient, parseGitRepo } from '../git-clients/github-client.js';
 import { createGitLabClient } from '../git-clients/gitlab-client.js';
-import { GitClientReleaseOption, GitCreateReleaseClientOutput, ReleaseCommandProps, ReleaseOptions } from '../interfaces.js';
+import type { GitClientReleaseOption, GitCreateReleaseClientOutput, ReleaseCommandProps, ReleaseOptions } from '../interfaces.js';
 
 export async function createReleaseClient(type: 'github' | 'gitlab'): Promise<GitCreateReleaseClientOutput> {
   switch (type) {

--- a/packages/version/src/lib/get-current-branch.ts
+++ b/packages/version/src/lib/get-current-branch.ts
@@ -1,4 +1,5 @@
-import { ExecOpts, execSync } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { execSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 export function getCurrentBranch(opts: ExecOpts, dryRun = false) {

--- a/packages/version/src/lib/git-add.ts
+++ b/packages/version/src/lib/git-add.ts
@@ -1,4 +1,5 @@
-import { exec, ExecOpts } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { exec } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import { relative, resolve as pathResolve } from 'node:path';
 import slash from 'slash';

--- a/packages/version/src/lib/git-commit.ts
+++ b/packages/version/src/lib/git-commit.ts
@@ -1,8 +1,9 @@
-import { exec, ExecOpts } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { exec } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import { EOL } from 'node:os';
 
-import { GitCommitOption } from '../interfaces.js';
+import type { GitCommitOption } from '../interfaces.js';
 import { tempWrite } from '../utils/temp-write.js';
 
 /**

--- a/packages/version/src/lib/git-push.ts
+++ b/packages/version/src/lib/git-push.ts
@@ -1,4 +1,5 @@
-import { exec, ExecOpts } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { exec } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 /**

--- a/packages/version/src/lib/git-tag.ts
+++ b/packages/version/src/lib/git-tag.ts
@@ -1,7 +1,8 @@
-import { exec, ExecOpts } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { exec } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
-import { GitTagOption } from '../interfaces.js';
+import type { GitTagOption } from '../interfaces.js';
 
 /**
  * @param {string} tag

--- a/packages/version/src/lib/is-anything-committed.ts
+++ b/packages/version/src/lib/is-anything-committed.ts
@@ -1,4 +1,5 @@
-import { ExecOpts, execSync } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { execSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 export function isAnythingCommitted(opts: ExecOpts, dryRun = false) {

--- a/packages/version/src/lib/is-behind-upstream.ts
+++ b/packages/version/src/lib/is-behind-upstream.ts
@@ -1,4 +1,5 @@
-import { ExecOpts, execSync } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { execSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 export function isBehindUpstream(gitRemote: string, branch: string, opts: ExecOpts, dryRun = false) {

--- a/packages/version/src/lib/prompt-version.ts
+++ b/packages/version/src/lib/prompt-version.ts
@@ -1,5 +1,6 @@
 import semver from 'semver';
-import { PackageGraphNode, promptSelectOne, promptTextInput } from '@lerna-lite/core';
+import type { PackageGraphNode } from '@lerna-lite/core';
+import { promptSelectOne, promptTextInput } from '@lerna-lite/core';
 
 import { applyBuildMetadata } from '../conventional-commits/apply-build-metadata.js';
 

--- a/packages/version/src/lib/remote-branch-exists.ts
+++ b/packages/version/src/lib/remote-branch-exists.ts
@@ -1,4 +1,5 @@
-import { ExecOpts, execSync } from '@lerna-lite/core';
+import type { ExecOpts } from '@lerna-lite/core';
+import { execSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 
 /**

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -1,4 +1,5 @@
-import { execPackageManager, execPackageManagerSync, Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
+import { execPackageManager, execPackageManagerSync } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import { loadJsonFile } from 'load-json-file';
 import { promises } from 'node:fs';

--- a/packages/version/src/utils/otplease.ts
+++ b/packages/version/src/utils/otplease.ts
@@ -1,6 +1,6 @@
 import { promptTextInput } from '@lerna-lite/core';
 
-import { OneTimePasswordCache } from '../interfaces.js';
+import type { OneTimePasswordCache } from '../interfaces.js';
 
 // basic single-entry semaphore
 const semaphore: any = {

--- a/packages/version/src/utils/temp-write.ts
+++ b/packages/version/src/utils/temp-write.ts
@@ -9,7 +9,7 @@ import { isStream } from 'is-stream';
 import { makeDirectory, makeDirectorySync } from 'make-dir';
 import tempDir from 'temp-dir';
 import { dirname, join } from 'node:path';
-import { Readable } from 'node:stream';
+import type { Readable } from 'node:stream';
 import { promisify } from 'node:util';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -47,7 +47,7 @@ import {
   runInstallLockFileOnly,
   saveUpdatedLockJsonFile,
 } from './lib/update-lockfile-version.js';
-import { GitCreateReleaseClientOutput, ReleaseNote, RemoteCommit } from './interfaces.js';
+import type { GitCreateReleaseClientOutput, ReleaseNote, RemoteCommit } from './interfaces.js';
 import { applyBuildMetadata } from './conventional-commits/apply-build-metadata.js';
 import { getCommitsSinceLastRelease } from './conventional-commits/get-commits-since-last-release.js';
 import { recommendVersion } from './conventional-commits/recommend-version.js';

--- a/packages/watch/src/index.ts
+++ b/packages/watch/src/index.ts
@@ -1,2 +1,2 @@
 export type * from './models.js';
-export type * from './watch-command.js';
+export * from './watch-command.js';

--- a/packages/watch/src/index.ts
+++ b/packages/watch/src/index.ts
@@ -1,2 +1,2 @@
-export * from './models.js';
-export * from './watch-command.js';
+export type * from './models.js';
+export type * from './watch-command.js';

--- a/packages/watch/src/models.ts
+++ b/packages/watch/src/models.ts
@@ -1,4 +1,4 @@
-import { Package } from '@lerna-lite/core';
+import type { Package } from '@lerna-lite/core';
 
 export type ChokidarEventType = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
 

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -1,20 +1,20 @@
 import {
   Command,
-  FilterOptions,
-  Package,
-  ProjectConfig,
+  type FilterOptions,
+  type Package,
+  type ProjectConfig,
   getFilteredPackages,
   pluralize,
   spawn,
   spawnStreaming,
   ValidationError,
-  WatchCommandOption,
+  type WatchCommandOption,
 } from '@lerna-lite/core';
 import chokidar from 'chokidar';
 import { join } from 'node:path';
 
 import { CHOKIDAR_AVAILABLE_OPTIONS, DEBOUNCE_DELAY, FILE_DELIMITER } from './constants.js';
-import { ChangesStructure } from './models.js';
+import type { ChangesStructure } from './models.js';
 
 export function factory(argv: WatchCommandOption) {
   return new WatchCommand(argv);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -38,5 +38,5 @@
     "strict": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules/**/*.*", "**/__helpers__/**", "**/__mocks__/**", "**/__tests__/**"]
+  "exclude": ["node_modules/**/*.*", "**/__helpers__/**", "**/__mocks__/**"]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

typescript-eslint provides two ESLint rules that can standardize using (or not using) type-only exports and imports

https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/#enforcing-with-typescript-eslint

## Motivation and Context

tagging type only imports/exports can in some cases improve TypeScript loading of the projects and also in some cases reduce build size slightly

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
