### PR TITLE
chore: remove unnecessary deprecated @types/git-url-parse

### DIFF
--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -73,7 +73,6 @@
     "@npm/types": "^2.0.0",
     "@types/dedent": "catalog:",
     "@types/fs-extra": "catalog:",
-    "@types/git-url-parse": "^16.0.2",
     "@types/js-yaml": "^4.0.9",
     "@types/minimatch": "catalog:",
     "@types/npm-package-arg": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,9 +822,6 @@ importers:
       '@types/fs-extra':
         specifier: 'catalog:'
         version: 11.0.4
-      '@types/git-url-parse':
-        specifier: ^16.0.2
-        version: 16.0.2
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -1532,10 +1529,6 @@ packages:
 
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
-
-  '@types/git-url-parse@16.0.2':
-    resolution: {integrity: sha512-STa+QaJtPbqwtioDIncRyft1xXrsTIYW0KkS6RS6l++NiDaQxqgsIkNp2Jf9nJ1KnCGPOvWaR1iO+B7LkM8+ew==}
-    deprecated: This is a stub types definition. git-url-parse provides its own type definitions, so you do not need this installed.
 
   '@types/glob-parent@5.1.3':
     resolution: {integrity: sha512-p+NciRH8TRvrgISOCQ55CP+lktMmDpOXsp4spULIIz0L4aJ6G9zFX+N0UZ2xulmJRgaQLRxXIp4xHdL6YOQjDg==}
@@ -4218,10 +4211,6 @@ snapshots:
     dependencies:
       '@types/jsonfile': 6.1.4
       '@types/node': 22.13.14
-
-  '@types/git-url-parse@16.0.2':
-    dependencies:
-      git-url-parse: 16.1.0
 
   '@types/glob-parent@5.1.3': {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

Remove deprecated and unnecessary dev dependency `@types/git-url-parse`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
