### PR TITLE
fix(publish): re-prompt OTP if it expired when publishing too many pkgs

### DIFF
--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -942,65 +942,68 @@ export class PublishCommand extends Command<PublishCommandOption> {
       );
     }
 
-    const mapper = pPipe(
-      ...(
-        [
-          (pkg: Package & { packed: Tarball }) => {
-            const preDistTag = this.getPreDistTag(pkg);
-            const tag = !this.options.tempTag && preDistTag ? preDistTag : opts.tag;
-            const pkgOpts = Object.assign({}, opts, { tag });
+    const mapper = async (pkg: Package & { packed: Tarball }) => {
+      const preDistTag = this.getPreDistTag(pkg);
+      const tag = !this.options.tempTag && preDistTag ? preDistTag : opts.tag;
+      const pkgOpts = Object.assign({}, opts, { tag });
 
-            return pulseTillDone(
-              queue
-                ? queue.queue(() => npmPublish(pkg, pkg.packed.tarFilePath, pkgOpts, this.otpCache))
-                : npmPublish(pkg, pkg.packed.tarFilePath, pkgOpts, this.otpCache)
-            )
-              .then(() => {
-                this.publishedPackages.push(pkg);
+      try {
+        await pulseTillDone(
+          queue
+            ? queue.queue(() => npmPublish(pkg, pkg.packed.tarFilePath, pkgOpts, this.otpCache))
+            : npmPublish(pkg, pkg.packed.tarFilePath, pkgOpts, this.otpCache)
+        );
+        this.publishedPackages.push(pkg);
 
-                tracker.success('published', pkg.name, pkg.version);
-                tracker.completeWork(1);
+        tracker.success('published', pkg.name, pkg.version);
+        tracker.completeWork(1);
 
-                logPacked(pkg, this.options.dryRun);
+        logPacked(pkg, this.options.dryRun);
 
-                return pkg;
-              })
-              .catch((err) => {
-                const isNpmJsComConflict = isNpmJsPublishVersionConflict(err);
-                const isNpmPkgGitHubComConflict = isNpmPkgGitHubPublishVersionConflict(err);
+        return pkg;
+      } catch (err: any) {
+        if (err.code === 'EOTP') {
+          this.logger.warn('OTP expired, requesting a new OTP...');
+          await this.requestOneTimePassword(); // Re-request OTP
+          return pulseTillDone(
+            queue
+              ? queue.queue(() => npmPublish(pkg, pkg.packed.tarFilePath, pkgOpts, this.otpCache))
+              : npmPublish(pkg, pkg.packed.tarFilePath, pkgOpts, this.otpCache)
+          ); // Retry publish
+        }
 
-                if (isNpmJsComConflict || isNpmPkgGitHubComConflict) {
-                  tracker.warn('publish', `Package is already published: ${pkg.name}@${pkg.version}`);
-                  tracker.completeWork(1);
-                  return pkg;
-                }
+        const isNpmJsComConflict = isNpmJsPublishVersionConflict(err);
+        const isNpmPkgGitHubComConflict = isNpmPkgGitHubPublishVersionConflict(err);
 
-                this.logger.silly('', err);
-                this.logger.warn('notice', `Package failed to publish: ${pkg.name}`);
-                this.logger.error(err.code, (err.body && err.body.error) || err.message);
+        if (isNpmJsComConflict || isNpmPkgGitHubComConflict) {
+          tracker.warn('publish', `Package is already published: ${pkg.name}@${pkg.version}`);
+          tracker.completeWork(1);
+          return pkg;
+        }
 
-                // avoid dumping logs, this isn't a lerna problem
-                err.name = 'ValidationError';
-                // ensure process exits non-zero
-                if ('errno' in err && typeof err.errno === 'number' && Number.isFinite(err.errno)) {
-                  process.exitCode = err.errno;
-                } else {
-                  this.logger.error('', `errno "${err.errno}" is not a valid exit code - exiting with code 1`);
-                  process.exitCode = 1;
-                }
+        this.logger.silly('', err);
+        this.logger.warn('notice', `Package failed to publish: ${pkg.name}`);
+        this.logger.error(err.code, (err.body && err.body.error) || err.message);
 
-                throw err;
-              });
-          },
-        ] as UnaryFunction<any, unknown>[]
-      ).filter(Boolean)
-    );
+        // avoid dumping logs, this isn't a lerna problem
+        err.name = 'ValidationError';
+        // ensure process exits non-zero
+        if ('errno' in err && typeof err.errno === 'number' && Number.isFinite(err.errno)) {
+          process.exitCode = err.errno;
+        } else {
+          this.logger.error('', `errno "${err.errno}" is not a valid exit code - exiting with code 1`);
+          process.exitCode = 1;
+        }
+
+        throw err;
+      }
+    };
 
     chain = chain.then(() => {
       if (this.toposort) {
-        return this.topoMapPackages(mapper);
+        return this.topoMapPackages((pkg) => mapper(pkg as Package & { packed: Tarball }));
       }
-      return pMap(this.packagesToPublish, mapper, { concurrency: this.concurrency });
+      return pMap(this.packagesToPublish as (Package & { packed: Tarball })[], mapper, { concurrency: this.concurrency });
     });
 
     if (!this.hasRootedLeaf) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For large monorepo, we should re-prompt OTP (one-time password) when it expires. 

## Motivation and Context

When publishing very large monorepo, it could happen that the user's OTP expires before all packages are published and that is unfortunate but predictable since OTP are generally 30sec only. So this PR will catch any OTP error and re-prompt the user for an updated OTP, it will then resume publishing with the newer OTP until every packages are published

## How Has This Been Tested?

Unit tests were added, but we would have to test in real life to see if it really work. It will hopefully work and I should be able to test that soon since I'm having this problem personally in 1 of my monorepo.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
