### PR TITLE
feat: upgrade `conventional-changelog` to v7

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,14 +20,7 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "node",
-      "args": [
-        "packages/cli/dist/cli.js",
-        "version",
-        "--dry-run",
-        "--yes",
-        "--changelog-include-commits-client-login",
-        "--conventional-commits"
-      ],
+      "args": ["packages/cli/dist/cli.js", "version", "--dry-run", "--yes", "--conventional-commits"],
       "cwd": "${workspaceRoot}",
       "console": "integratedTerminal",
       "internalConsoleOptions": "openOnSessionStart",

--- a/helpers/fixtures.ts
+++ b/helpers/fixtures.ts
@@ -1,9 +1,10 @@
+import { join } from 'node:path';
+
 import { execa } from 'execa';
 import fileUrl from 'file-url';
-import { temporaryDirectory } from 'tempy';
-import { copy, ensureDir } from 'fs-extra/esm';
 import { findUp } from 'find-up';
-import { join } from 'node:path';
+import { copy, ensureDir } from 'fs-extra/esm';
+import { temporaryDirectory } from 'tempy';
 
 import { gitAdd, gitCommit, gitInit } from './git/index.js';
 

--- a/helpers/git/index.ts
+++ b/helpers/git/index.ts
@@ -1,9 +1,10 @@
-import { execa } from 'execa';
-import { loadJsonFile } from 'load-json-file';
 import cp from 'node:child_process';
 import { EOL } from 'node:os';
 import { dirname, join, resolve as pathResolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { execa } from 'execa';
+import { loadJsonFile } from 'load-json-file';
 import { writeJsonFile } from 'write-json-file';
 
 import { tempWrite } from '../../packages/version/dist/utils/temp-write.js';

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/yargs": "^17.0.33",
     "@vitest/coverage-v8": "^3.1.4",
     "@vitest/eslint-plugin": "^1.2.0",
-    "conventional-changelog-conventionalcommits": "^8.0.0",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
     "cross-env": "^7.0.3",
     "eslint": "^9.27.0",
     "eslint-config-prettier": "^10.1.5",

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -338,10 +338,7 @@ Below is a full demo of how you can use a preset with full configuration
       "issuePrefixes": ["#"],
       "commitUrlFormat": "{{host}}/{{owner}}/{{repository}}/commit/{{hash}}",
       "compareUrlFormat": "{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}",
-      "userUrlFormat": "{{host}}/{{user}}",
-      "writerOpts": {
-        "commitPartial": "- {{message}}\n"
-      }
+      "userUrlFormat": "{{host}}/{{user}}"
   },
   "packages": ["packages/*"]
 }

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -36,12 +36,13 @@
     "node": "^20.17.0 || >=22.9.0"
   },
   "dependencies": {
+    "@conventional-changelog/git-client": "^2.2.0",
     "@lerna-lite/cli": "workspace:*",
     "@lerna-lite/core": "workspace:*",
     "@lerna-lite/npmlog": "workspace:*",
     "@octokit/plugin-enterprise-rest": "^6.0.1",
     "@octokit/rest": "^21.1.1",
-    "conventional-changelog": "^6.0.0",
+    "conventional-changelog": "^7.0.2",
     "conventional-changelog-angular": "^8.0.0",
     "conventional-changelog-writer": "^8.1.0",
     "conventional-commits-parser": "^6.1.0",

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/config-builder-preset.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/config-builder-preset.ts
@@ -1,26 +1,25 @@
 // https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
 // (conventional-changelog-angular/conventional-recommended-bump.js, etc)
-import parserOpts from './parser-opts.js';
+import parser from './parser-opts.js';
 import whatBump from './what-bump.js';
-import writerOpts from './writer-opts.js';
+import writer from './writer-opts.js';
 
 // https://github.com/conventional-changelog/conventional-changelog/blob/943542f3b2342bb5933d84847fb19b727c607df0/packages/conventional-changelog-ember/index.js#L10
-module.exports = presetOpts;
 
-export function presetOpts(param) {
+export default function presetOpts(param) {
   if (typeof param !== 'function') {
     return Promise.resolve(
       Object.assign(param, {
-        parserOpts,
-        writerOpts,
+        parser,
+        writer,
         whatBump,
       })
     );
   }
 
   process.nextTick(param, null, {
-    parserOpts,
-    writerOpts,
+    parser,
+    writer,
     whatBump,
   });
 }

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/erroring-preset.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/erroring-preset.ts
@@ -1,7 +1,5 @@
 const erroringPresets = {
-  recommendedBumpOpts: {
-    whatBump: 'I should be a function',
-  },
+  whatBump: 'I should be a function',
 };
 
 export default erroringPresets;

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/legacy-callback-preset.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/legacy-callback-preset.ts
@@ -5,9 +5,8 @@ import whatBump from './what-bump.js';
 import writerOpts from './writer-opts.js';
 
 // https://github.com/conventional-changelog/conventional-changelog/blob/943542f3b2342bb5933d84847fb19b727c607df0/packages/conventional-changelog-ember/index.js#L10
-module.exports = presetOpts;
 
-export function presetOpts(cb) {
+export default function presetOpts(cb) {
   process.nextTick(cb, null, {
     parserOpts,
     writerOpts,

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset-async.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset-async.ts
@@ -1,19 +1,12 @@
 // https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
-import parserOpts from './parser-opts.js';
+import parser from './parser-opts.js';
 import whatBump from './what-bump.js';
-import writerOpts from './writer-opts.js';
+import writer from './writer-opts.js';
 
-module.exports = createPreset;
-
-export async function createPreset(_config) {
+export default async function createPreset(_config) {
   return {
-    conventionalChangelog: {
-      parserOpts,
-      writerOpts,
-    },
-    recommendedBumpOpts: {
-      parserOpts,
-      whatBump,
-    },
+    parser: parser,
+    writer: writer,
+    whatBump,
   };
 }

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset.ts
@@ -4,13 +4,10 @@ import parserOpts from './parser-opts.js';
 import whatBump from './what-bump.js';
 import writerOpts from './writer-opts.js';
 
-module.exports = {
+export default {
   conventionalChangelog: {
-    parserOpts,
-    writerOpts,
-  },
-  recommendedBumpOpts: {
-    parserOpts,
+    parser: parserOpts,
+    writer: writerOpts,
     whatBump,
   },
 };

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/null-preset.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/null-preset.ts
@@ -4,13 +4,8 @@ import whatBump from './null-what-bump.js';
 import parserOpts from './parser-opts.js';
 import writerOpts from './writer-opts.js';
 
-export const output = {
-  conventionalChangelog: {
-    parserOpts,
-    writerOpts,
-  },
-  recommendedBumpOpts: {
-    parserOpts,
-    whatBump,
-  },
+export default {
+  parser: parserOpts,
+  writer: writerOpts,
+  whatBump,
 };

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/writer-opts.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/writer-opts.ts
@@ -1,63 +1,64 @@
 export default {
   transform: (commit, context) => {
+    const clonedCommit = { ...commit };
     let discard = true;
     const issues: string[] = [];
 
-    commit.notes.forEach((note) => {
-      note.title = `BREAKING CHANGES`;
+    clonedCommit.notes.forEach((note) => {
+      note.title = 'BREAKING CHANGES';
       discard = false;
     });
 
-    if (commit.type === `feat`) {
-      commit.type = `Features`;
-    } else if (commit.type === `fix`) {
-      commit.type = `Bug Fixes`;
-    } else if (commit.type === `perf`) {
-      commit.type = `Performance Improvements`;
-    } else if (commit.type === `revert`) {
-      commit.type = `Reverts`;
+    if (clonedCommit.type === 'feat') {
+      clonedCommit.type = 'Features';
+    } else if (clonedCommit.type === 'fix') {
+      clonedCommit.type = 'Bug Fixes';
+    } else if (clonedCommit.type === 'perf') {
+      clonedCommit.type = 'Performance Improvements';
+    } else if (clonedCommit.type === 'revert') {
+      clonedCommit.type = 'Reverts';
     } else if (discard) {
       return;
-    } else if (commit.type === `docs`) {
-      commit.type = `Documentation`;
-    } else if (commit.type === `style`) {
-      commit.type = `Styles`;
-    } else if (commit.type === `refactor`) {
-      commit.type = `Code Refactoring`;
-    } else if (commit.type === `test`) {
-      commit.type = `Tests`;
-    } else if (commit.type === `build`) {
-      commit.type = `Build System`;
-    } else if (commit.type === `ci`) {
-      commit.type = `Continuous Integration`;
+    } else if (clonedCommit.type === 'docs') {
+      clonedCommit.type = 'Documentation';
+    } else if (clonedCommit.type === 'style') {
+      clonedCommit.type = 'Styles';
+    } else if (clonedCommit.type === 'refactor') {
+      clonedCommit.type = 'Code Refactoring';
+    } else if (clonedCommit.type === 'test') {
+      clonedCommit.type = 'Tests';
+    } else if (clonedCommit.type === 'build') {
+      clonedCommit.type = 'Build System';
+    } else if (clonedCommit.type === 'ci') {
+      clonedCommit.type = 'Continuous Integration';
     }
 
-    if (commit.scope === `*`) {
-      commit.scope = ``;
+    if (clonedCommit.scope === '*') {
+      clonedCommit.scope = '';
     }
 
-    if (typeof commit.hash === `string`) {
-      commit.hash = commit.hash.substring(0, 7);
+    if (typeof clonedCommit.hash === 'string') {
+      clonedCommit.shortHash = clonedCommit.hash.substring(0, 7);
     }
 
-    if (typeof commit.subject === `string`) {
+    if (typeof clonedCommit.subject === 'string') {
       let url = context.repository ? `${context.host}/${context.owner}/${context.repository}` : context.repoUrl;
       if (url) {
         url = `${url}/issues/`;
         // Issue URLs.
-        commit.subject = commit.subject.replace(/#([0-9]+)/g, (_, issue: string) => {
+        clonedCommit.subject = clonedCommit.subject.replace(/#([0-9]+)/g, (_, issue: string) => {
           issues.push(issue);
           return `[#${issue}](${url}${issue})`;
         });
       }
       if (context.host) {
         // User URLs.
-        commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9]){0,38})/g, `[@$1](${context.host}/$1)`);
+        clonedCommit.subject = clonedCommit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9]){0,38})/g, '[@$1](${context.host}/$1)');
       }
     }
 
     // remove references that already appear in the subject
-    commit.references = commit.references.filter((reference) => {
+    clonedCommit.references = clonedCommit.references.filter((reference) => {
       if (issues.indexOf(reference.issue) === -1) {
         return true;
       }
@@ -65,12 +66,12 @@ export default {
       return false;
     });
 
-    return commit;
+    return clonedCommit;
   },
-  groupBy: `type`,
-  commitGroupsSort: `title`,
-  commitsSort: [`scope`, `subject`],
-  noteGroupsSort: `title`,
+  groupBy: 'type',
+  commitGroupsSort: 'title',
+  commitsSort: ['scope', 'subject'],
+  noteGroupsSort: 'title',
   // notesSort: compareFunc,
   mainTemplate: [
     '{{> header}}',
@@ -94,8 +95,28 @@ export default {
     '{{~#if isPatch~}} </small>',
     '{{~/if}}',
     '',
+    '',
   ].join('\n'),
-  commitPartial: '* {{header}}',
+  commitPartial: [
+    '* {{header}} {{#if @root.linkReferences~}}',
+    '([{{shortHash}}](',
+    '{{~#if @root.repository}}',
+    '{{~#if @root.host}}',
+    '{{~@root.host}}/',
+    '{{~/if}}',
+    '{{~#if @root.owner}}',
+    '{{~@root.owner}}/',
+    '{{~/if}}',
+    '{{~@root.repository}}',
+    '{{~else}}',
+    '{{~@root.repoUrl}}',
+    '{{~/if}}/',
+    '{{~@root.commit}}/{{hash}}))',
+    '{{~else}}',
+    '{{~shortHash}}',
+    '{{~/if}}',
+    '',
+  ].join('\n'),
   footerPartial: [
     '{{#if noteGroups}}',
     '{{#each noteGroups}}',

--- a/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
+++ b/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-*  ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
+* I should be placed in the CHANGELOG ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
 
 `;
 
@@ -49,7 +49,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-*  ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
+* I should be placed in the CHANGELOG ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
 
 `;
 

--- a/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
+++ b/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`conventional-commits > updateChangelog() > creates changelog with chang
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 1.1.0 (YYYY-MM-DD)
+## 1.1.0 (YYYY-MM-DD)
 
 ### Features
 

--- a/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
+++ b/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`conventional-commits > updateChangelog() > creates changelog with chang
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 1.1.0 (YYYY-MM-DD)
+# 1.1.0 (YYYY-MM-DD)
 
 ### Features
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* I should be placed in the CHANGELOG ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
+*  ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
 
 `;
 
@@ -49,7 +49,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* I should be placed in the CHANGELOG ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
+*  ([SHA](https://github.com/lerna/changelog-missing/commit/GIT_HEAD))
 
 `;
 

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -808,11 +808,7 @@ describe('conventional-commits', () => {
       await pkg1.set('version', '1.0.1').serialize();
       await pkg2.set('version', '1.1.0').serialize();
 
-      const opts = {
-        conventionalChangelog: {
-          changelogPreset: 'conventional-changelog-angular',
-        },
-      };
+      const opts = { changelogPreset: 'conventional-changelog-angular' };
       const [changelogOne, changelogTwo] = await Promise.all([updateChangelog(pkg1, 'independent', opts), updateChangelog(pkg2, 'independent', opts)]);
 
       expect(changelogOne.newEntry.trimEnd()).toMatchInlineSnapshot(`

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -808,7 +808,11 @@ describe('conventional-commits', () => {
       await pkg1.set('version', '1.0.1').serialize();
       await pkg2.set('version', '1.1.0').serialize();
 
-      const opts = { changelogPreset: 'conventional-changelog-angular' };
+      const opts = {
+        conventionalChangelog: {
+          changelogPreset: 'conventional-changelog-angular'
+        }
+      };
       const [changelogOne, changelogTwo] = await Promise.all([updateChangelog(pkg1, 'independent', opts), updateChangelog(pkg2, 'independent', opts)]);
 
       expect(changelogOne.newEntry.trimEnd()).toMatchInlineSnapshot(`

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -810,8 +810,8 @@ describe('conventional-commits', () => {
 
       const opts = {
         conventionalChangelog: {
-          changelogPreset: 'conventional-changelog-angular'
-        }
+          changelogPreset: 'conventional-changelog-angular',
+        },
       };
       const [changelogOne, changelogTwo] = await Promise.all([updateChangelog(pkg1, 'independent', opts), updateChangelog(pkg2, 'independent', opts)]);
 

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -141,8 +141,7 @@ describe('conventional-commits', () => {
       expect(bump2).toBe('1.1.0-beta.0');
     });
 
-    // TODO: need to be re-enabled once problem with Vitest Snapshot is fixed
-    it.skip('returns package-specific version bumps from prereleases with prereleaseId', async () => {
+    it('returns package-specific version bumps from prereleases with prereleaseId', async () => {
       const cwd = await initFixture('prerelease-independent');
       const [pkg1, pkg2, pkg3] = await Project.getPackages(cwd);
       const opts = { changelogPreset: 'angular' };
@@ -554,7 +553,7 @@ describe('conventional-commits', () => {
         }),
       ]);
 
-      expect(leafChangelog.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(leafChangelog.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/dragons-are-awesome1.0.0...dragons-are-awesome1.0.1) (YYYY-MM-DD)
 
 
@@ -562,7 +561,7 @@ describe('conventional-commits', () => {
 
         * A second commit for our CHANGELOG ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/GIT_HEAD))
       `);
-      expect(rootChangelog.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(rootChangelog.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/dragons-are-awesome1.0.0...dragons-are-awesome1.0.1) (YYYY-MM-DD)
 
 
@@ -586,7 +585,7 @@ describe('conventional-commits', () => {
       });
 
       // second commit should not show up again
-      expect(lastRootChangelog.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(lastRootChangelog.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.2](/compare/dragons-are-awesome1.0.1...dragons-are-awesome1.0.2) (YYYY-MM-DD)
 
 
@@ -623,7 +622,7 @@ describe('conventional-commits', () => {
         }),
       ]);
 
-      expect(leafChangelog.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(leafChangelog.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/dragons-are-awesome1.0.0...dragons-are-awesome1.0.1) (YYYY-MM-DD)
 
 
@@ -631,7 +630,7 @@ describe('conventional-commits', () => {
 
         * A second commit for our CHANGELOG ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/GIT_HEAD)) (Tester McPerson)
       `);
-      expect(rootChangelog.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(rootChangelog.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/dragons-are-awesome1.0.0...dragons-are-awesome1.0.1) (YYYY-MM-DD)
 
 
@@ -656,7 +655,7 @@ describe('conventional-commits', () => {
       });
 
       // second commit should not show up again
-      expect(lastRootChangelog.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(lastRootChangelog.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.2](/compare/dragons-are-awesome1.0.1...dragons-are-awesome1.0.2) (YYYY-MM-DD)
 
 
@@ -686,7 +685,8 @@ describe('conventional-commits', () => {
       });
 
       expect(pkg2.isBumpOnlyVersion).toBeTruthy();
-      expect(leafChangelog.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(leafChangelog.newEntry.trimEnd()).toMatchInlineSnapshot(`
+        <a name="1.0.1"></a>
         ## <small>1.0.1 (YYYY-MM-DD)</small>
 
         **Note:** Version bump only for package package-2
@@ -713,9 +713,10 @@ describe('conventional-commits', () => {
       });
 
       expect(leafChangelog.newEntry).toMatchInlineSnapshot(`
+        <a name="1.0.1"></a>
         ## <small>1.0.1 (YYYY-MM-DD)</small>
 
-        * fix(pkg1): A commit using the old preset API ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/SHA))
+        * fix(pkg1): A commit using the old preset API ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/GIT_HEAD))
 
       `);
     });
@@ -740,9 +741,10 @@ describe('conventional-commits', () => {
       });
 
       expect(leafChangelog.newEntry).toMatchInlineSnapshot(`
+        <a name="1.0.1"></a>
         ## <small>1.0.1 (YYYY-MM-DD)</small>
 
-        * fix(pkg2): A commit using a legacy callback preset ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/SHA))
+        * fix(pkg2): A commit using a legacy callback preset ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/GIT_HEAD))
 
       `);
     });
@@ -776,9 +778,10 @@ describe('conventional-commits', () => {
       });
 
       expect(leafChangelog.newEntry).toMatchInlineSnapshot(`
+        <a name="1.0.1"></a>
         ## <small>1.0.1 (YYYY-MM-DD)</small>
 
-        * fix(pkg2): A commit using a legacy callback preset ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/SHA))
+        * fix(pkg2): A commit using a legacy callback preset ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/GIT_HEAD))
 
       `);
     });
@@ -805,12 +808,10 @@ describe('conventional-commits', () => {
       await pkg1.set('version', '1.0.1').serialize();
       await pkg2.set('version', '1.1.0').serialize();
 
-      const opts = {
-        changelogPreset: 'conventional-changelog-angular',
-      };
+      const opts = { changelogPreset: 'conventional-changelog-angular' };
       const [changelogOne, changelogTwo] = await Promise.all([updateChangelog(pkg1, 'independent', opts), updateChangelog(pkg2, 'independent', opts)]);
 
-      expect(changelogOne.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelogOne.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/package-1@1.0.0...package-1@1.0.1) (YYYY-MM-DD)
 
 
@@ -818,7 +819,7 @@ describe('conventional-commits', () => {
 
         * **stuff:** changed ([SHA](https://github.com/lerna/conventional-commits-independent/commit/GIT_HEAD))
       `);
-      expect(changelogTwo.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelogTwo.newEntry.trimEnd()).toMatchInlineSnapshot(`
         # [1.1.0](/compare/package-2@1.0.0...package-2@1.1.0) (YYYY-MM-DD)
 
 
@@ -857,7 +858,7 @@ describe('conventional-commits', () => {
       };
       const [changelogOne, changelogTwo] = await Promise.all([updateChangelog(pkg1, 'independent', opts), updateChangelog(pkg2, 'independent', opts)]);
 
-      expect(changelogOne.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelogOne.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/package-1@1.0.0...package-1@1.0.1) (YYYY-MM-DD)
 
 
@@ -865,7 +866,7 @@ describe('conventional-commits', () => {
 
         * **stuff:** changed ([SHA](https://github.com/lerna/conventional-commits-independent/commit/GIT_HEAD)) (Tester McPerson)
       `);
-      expect(changelogOne.content.trimRight()).toMatchInlineSnapshot(`
+      expect(changelogOne.content.trimEnd()).toMatchInlineSnapshot(`
         # Change Log
         # Custom Header Message
 
@@ -878,7 +879,7 @@ describe('conventional-commits', () => {
 
         * **stuff:** changed ([SHA](https://github.com/lerna/conventional-commits-independent/commit/GIT_HEAD)) (Tester McPerson)
       `);
-      expect(changelogTwo.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelogTwo.newEntry.trimEnd()).toMatchInlineSnapshot(`
         # [1.1.0](/compare/package-2@1.0.0...package-2@1.1.0) (YYYY-MM-DD)
 
 
@@ -916,7 +917,7 @@ describe('conventional-commits', () => {
       };
       const [changelogOne, changelogTwo] = await Promise.all([updateChangelog(pkg1, 'independent', opts), updateChangelog(pkg2, 'independent', opts)]);
 
-      expect(changelogOne.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelogOne.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/package-1@1.0.0...package-1@1.0.1) (YYYY-MM-DD)
 
 
@@ -924,7 +925,7 @@ describe('conventional-commits', () => {
 
         * **stuff:** changed ([SHA](https://github.com/lerna/conventional-commits-independent/commit/GIT_HEAD)) by **Tester McPerson** (test@example.com)
       `);
-      expect(changelogTwo.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelogTwo.newEntry.trimEnd()).toMatchInlineSnapshot(`
         # [1.1.0](/compare/package-2@1.0.0...package-2@1.1.0) (YYYY-MM-DD)
 
 
@@ -1000,7 +1001,7 @@ describe('conventional-commits', () => {
       const changelog2 = await updateChangelog(pkg2, 'independent', opt2s);
       const changelog3 = await updateChangelog(pkg2, 'independent', opt3s);
 
-      expect(changelog1.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelog1.newEntry.trimEnd()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/package-1@1.0.0...package-1@1.0.1) (YYYY-MM-DD)
 
 
@@ -1008,7 +1009,7 @@ describe('conventional-commits', () => {
 
         * **stuff:** changed ([SHA](https://github.com/lerna/conventional-commits-independent/commit/GIT_HEAD)) (@tester-mcperson)
       `);
-      expect(changelog2.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelog2.newEntry.trimEnd()).toMatchInlineSnapshot(`
         # [1.1.0](/compare/package-2@1.0.0...package-2@1.1.0) (YYYY-MM-DD)
 
 
@@ -1018,7 +1019,7 @@ describe('conventional-commits', () => {
       `);
 
       // when SHA isn't found, it will still try to format the message but without a user @
-      expect(changelog3.newEntry.trimRight()).toMatchInlineSnapshot(`
+      expect(changelog3.newEntry.trimEnd()).toMatchInlineSnapshot(`
         # [1.1.0](/compare/package-2@1.0.0...package-2@1.1.0) (YYYY-MM-DD)
 
 

--- a/packages/version/src/conventional-commits/recommend-version.ts
+++ b/packages/version/src/conventional-commits/recommend-version.ts
@@ -6,7 +6,7 @@ import { Bumper, packagePrefix } from 'conventional-recommended-bump';
 import type { ReleaseType } from 'semver';
 import semver from 'semver';
 
-import type { BaseChangelogOptions, ChangelogConfig, VersioningStrategy } from '../interfaces.js';
+import type { BaseChangelogOptions, VersioningStrategy } from '../interfaces.js';
 import { applyBuildMetadata } from './apply-build-metadata.js';
 import { GetChangelogConfig } from './get-changelog-config.js';
 
@@ -32,12 +32,8 @@ export async function recommendVersion(
   const bumper = new Bumper();
 
   // 'new' preset API
-  const changelogConfig: ChangelogConfig = await GetChangelogConfig.getChangelogConfig(changelogPreset, rootPath);
-  const parserOptions =
-    changelogConfig.output?.recommendedBumpOpts.parserOpts ||
-    changelogConfig.conventionalChangelog?.parserOpts ||
-    changelogConfig.parser ||
-    {};
+  const changelogConfig = await GetChangelogConfig.getChangelogConfig(changelogPreset, rootPath);
+  const parserOptions = changelogConfig.parser || {};
 
   bumper.commits({ path: pkg.location }, parserOptions);
 
@@ -71,14 +67,12 @@ export async function recommendVersion(
       return changelogConfig.whatBump;
     }
 
-    const bumperPreset = changelogConfig?.output || changelogConfig;
-
     /* v8 ignore next 3 */
-    if (!bumperPreset) {
+    if (!changelogConfig) {
       return () => ({ releaseType: null });
     }
 
-    return (bumperPreset as ChangelogConfig).whatBump || bumperPreset.recommendedBumpOpts?.whatBump;
+    return changelogConfig.whatBump;
   }
 
   // Ensure potential ValidationError in getChangelogConfig() is propagated correctly

--- a/packages/version/src/conventional-commits/update-changelog.ts
+++ b/packages/version/src/conventional-commits/update-changelog.ts
@@ -1,9 +1,9 @@
+import { type GetCommitsParams, type GetSemverTagsParams, packagePrefix } from '@conventional-changelog/git-client';
 import type { ChangelogPresetOptions, Package } from '@lerna-lite/core';
 import { EOL } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
-import type { Context, Options as ChangelogCoreOptions } from 'conventional-changelog';
-import conventionalChangelogCore from 'conventional-changelog';
-import type { Options as WriterOptions } from 'conventional-changelog-writer';
+import { ConventionalChangelog, type Options as ChangelogCoreOptions } from 'conventional-changelog';
+import type { Context, Options as WriterOptions } from 'conventional-changelog-writer';
 import { writeFile } from 'fs/promises';
 import getStream from 'get-stream';
 
@@ -35,21 +35,23 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
   } = updateOptions;
 
   const config = await GetChangelogConfig.getChangelogConfig(changelogPreset, rootPath);
-  const options = {} as { config: ChangelogConfig; lernaPackage: string; tagPrefix: string; pkg: { path: string } };
+  const genOptions = {} as ChangelogCoreOptions;
+  const tagOptions = {} as GetSemverTagsParams;
   const context = {} as Context; // pass as positional because cc-core's merge-config is wack
   const writerOpts = {} as WriterOptions;
+  let changelogConfig = {} as ChangelogConfig;
 
   // cc-core mutates input :P
   if (config.conventionalChangelog) {
     // "new" preset API
-    options.config = Object.assign({}, config.conventionalChangelog) as unknown as ChangelogConfig;
+    changelogConfig = Object.assign({}, config.conventionalChangelog) as unknown as ChangelogConfig;
   } else {
     // "old" preset API
-    options.config = Object.assign({}, config) as ChangelogConfig;
+    changelogConfig = Object.assign({}, config) as ChangelogConfig;
   }
 
   // NOTE: must pass as positional argument due to weird bug in merge-config
-  const gitRawCommitsOpts = Object.assign({}, options.config.gitRawCommitsOpts);
+  const gitRawCommitsOpts: GetCommitsParams = {};
 
   // are we including commit author name/email or remote client login name
   if (changelogIncludeCommitsGitAuthor || changelogIncludeCommitsGitAuthor === '') {
@@ -59,39 +61,39 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
     setConfigChangelogCommitClientLogin(config, gitRawCommitsOpts, writerOpts, commitsSinceLastRelease, changelogIncludeCommitsClientLogin);
   }
 
+  let pkgPath = '';
   if (type === 'root') {
     context.version = version;
 
     // preserve tagPrefix because cc-core can't find the currentTag otherwise
-    context.currentTag = `${tagPrefix}${version}`;
-
     // root changelogs are only enabled in fixed mode, and need the proper tag prefix
-    options.tagPrefix = tagPrefix;
+    tagOptions.prefix = tagPrefix;
   } else {
     // "fixed" or "independent"
     gitRawCommitsOpts.path = pkg.location;
-    options.pkg = { path: pkg.manifestLocation };
+    pkgPath = pkg.manifestLocation;
 
     if (type === 'independent') {
-      options.lernaPackage = pkg.name;
+      tagOptions.prefix = packagePrefix(pkg.name);
     } else {
       // only fixed mode can have a custom tag prefix
-      options.tagPrefix = tagPrefix;
+      tagOptions.prefix = tagPrefix;
 
       // preserve tagPrefix because cc-core can't find the currentTag otherwise
-      context.currentTag = `${tagPrefix}${pkg.version}`;
       context.version = pkg.version;
     }
   }
 
   // generate the markdown for the upcoming release.
-  const changelogStream = conventionalChangelogCore(
-    options as ChangelogCoreOptions,
-    context,
-    gitRawCommitsOpts,
-    undefined,
-    writerOpts
-  );
+  const changelogStream = new ConventionalChangelog()
+    .readPackage(pkgPath)
+    .config(changelogConfig)
+    .commits(gitRawCommitsOpts)
+    .context(context)
+    .options(genOptions)
+    .tags(tagOptions)
+    .writer(writerOpts)
+    .write();
 
   return Promise.all([
     // prettier-ignore

--- a/packages/version/src/conventional-commits/update-changelog.ts
+++ b/packages/version/src/conventional-commits/update-changelog.ts
@@ -42,13 +42,8 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
   let changelogConfig = {} as ChangelogConfig;
 
   // cc-core mutates input :P
-  if (config.conventionalChangelog) {
-    // "new" preset API
-    changelogConfig = Object.assign({}, config.conventionalChangelog) as unknown as ChangelogConfig;
-  } else {
-    // "old" preset API
-    changelogConfig = Object.assign({}, config) as ChangelogConfig;
-  }
+  // "new" preset API
+  changelogConfig = Object.assign({}, config) as ChangelogConfig;
 
   // NOTE: must pass as positional argument due to weird bug in merge-config
   const gitRawCommitsOpts: GetCommitsParams = {};

--- a/packages/version/src/conventional-commits/writer-opts-transform.ts
+++ b/packages/version/src/conventional-commits/writer-opts-transform.ts
@@ -1,4 +1,4 @@
-import type { GitRawCommitsOptions } from 'conventional-changelog';
+import { type GetCommitsParams } from '@conventional-changelog/git-client';
 import type { Options as WriterOptions } from 'conventional-changelog-writer';
 
 import type { ChangelogConfig, RemoteCommit } from '../interfaces.js';
@@ -20,7 +20,7 @@ const GIT_COMMIT_WITH_AUTHOR_FORMAT =
  */
 export function setConfigChangelogCommitGitAuthor(
   config: ChangelogConfig,
-  gitRawCommitsOpts: GitRawCommitsOptions,
+  gitRawCommitsOpts: GetCommitsParams,
   writerOpts: WriterOptions,
   commitCustomFormat?: string | boolean
 ) {
@@ -40,14 +40,14 @@ export function setConfigChangelogCommitGitAuthor(
  * and finally no matter which changelog preset is loaded, we'll append the client login to the commit template
  * ie:: **deps:** update all non-major dependencies ([ed1db35](https://github.com/.../ed1db35)) (@renovate-bot)
  * @param {ChangelogConfig} config
- * @param {GitRawCommitsOptions} gitRawCommitsOpts
+ * @param {GetCommitsParams} gitRawCommitsOpts
  * @param {WriterOptions} writerOpts
  * @param {RemoteCommit[]} commitsSinceLastRelease
  * @param {string | boolean} [commitCustomFormat]
  */
 export function setConfigChangelogCommitClientLogin(
   config: ChangelogConfig,
-  gitRawCommitsOpts: GitRawCommitsOptions,
+  gitRawCommitsOpts: GetCommitsParams,
   writerOpts: WriterOptions,
   commitsSinceLastRelease: RemoteCommit[],
   commitCustomFormat?: string | boolean

--- a/packages/version/src/interfaces.ts
+++ b/packages/version/src/interfaces.ts
@@ -1,8 +1,8 @@
+import type { GetCommitsParams, GetSemverTagsParams } from '@conventional-changelog/git-client';
 import type { ChangelogPresetOptions, ExecOpts, Package } from '@lerna-lite/core';
-import type { Context, GitRawCommitsOptions, ParserOptions } from 'conventional-changelog';
 import type { Options as WriterOptions } from 'conventional-changelog-writer';
-import type { Commit, ParserStreamOptions } from 'conventional-commits-parser';
-import type { BumperRecommendation, Preset as BumperPresetOptions } from 'conventional-recommended-bump';
+import type { Commit, ParserOptions, ParserStreamOptions } from 'conventional-commits-parser';
+import type { BumperRecommendation } from 'conventional-recommended-bump';
 
 export interface GitCommitOption {
   amend: boolean;
@@ -33,27 +33,29 @@ export interface BaseChangelogOptions {
   tagPrefix?: string;
 }
 
+/** @deprecated @use ChangelogBumperOption interface */
+export interface OldChangelogBumperOption {
+  parserOpts: ParserOptions;
+  writerOpts: WriterOptions;
+  whatBump: (commits: Commit[]) => Promise<BumperRecommendation | null | undefined>;
+}
+
 export interface ChangelogBumperOption {
   parser: ParserOptions;
   writer: WriterOptions;
   whatBump: (commits: Commit[]) => Promise<BumperRecommendation | null | undefined>;
 }
 
-export interface ChangelogConfig extends ChangelogBumperOption {
-  context?: Partial<Context> | undefined;
-  gitRawCommitsOpts?: GitRawCommitsOptions & { path: string };
+export interface ChangelogConfig {
+  /** @deprecated to be removed in next major */
+  conventionalChangelog?: ChangelogBumperOption | OldChangelogBumperOption;
+  name?: string;
   key?: string;
-  parserOpts?: ParserOptions | undefined;
-  conventionalChangelog: { parserOpts: ParserOptions; writerOpts: WriterOptions };
-  output?: {
-    conventionalChangelog: { parserOpts: ParserOptions; writerOpts: WriterOptions };
-    recommendedBumpOpts: {
-      parserOpts: ParserStreamOptions;
-      whatBump: (commits: Commit[]) => Promise<BumperRecommendation | null | undefined>;
-    };
-  };
-  recommendedBumpOpts?: BumperPresetOptions;
-  writerOpts?: WriterOptions;
+  tags?: GetSemverTagsParams;
+  commits?: GetCommitsParams;
+  parser?: ParserStreamOptions;
+  writer?: WriterOptions;
+  whatBump: (commits: Commit[]) => Promise<BumperRecommendation | null | undefined>;
 }
 
 export interface ReleaseNote {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0(eslint@9.27.0)(typescript@5.8.3)(vitest@3.1.4(@types/node@22.15.21)(yaml@2.8.0))
       conventional-changelog-conventionalcommits:
-        specifier: ^8.0.0
-        version: 8.0.0
+        specifier: ^9.0.0
+        version: 9.0.0
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -722,6 +722,9 @@ importers:
 
   packages/version:
     dependencies:
+      '@conventional-changelog/git-client':
+        specifier: ^2.2.0
+        version: 2.2.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
       '@lerna-lite/cli':
         specifier: workspace:*
         version: link:../cli
@@ -738,8 +741,8 @@ importers:
         specifier: ^21.1.1
         version: 21.1.1
       conventional-changelog:
-        specifier: ^6.0.0
-        version: 6.0.0(conventional-commits-filter@5.0.0)
+        specifier: ^7.0.2
+        version: 7.0.2(conventional-commits-filter@5.0.0)
       conventional-changelog-angular:
         specifier: ^8.0.0
         version: 8.0.0
@@ -912,20 +915,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@conventional-changelog/git-client@1.0.1':
-    resolution: {integrity: sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      conventional-commits-filter: ^5.0.0
-      conventional-commits-parser: ^6.0.0
-    peerDependenciesMeta:
-      conventional-commits-filter:
-        optional: true
-      conventional-commits-parser:
-        optional: true
-
-  '@conventional-changelog/git-client@2.1.0':
-    resolution: {integrity: sha512-UbqJIDXuN3Pedgtn8hll8dTTtP/ufleQdk0jgoS2miMpL9fH4oKg5wrDNT1luND+RLf+i9xNqte65aPAsfjXAw==}
+  '@conventional-changelog/git-client@2.2.0':
+    resolution: {integrity: sha512-pi7zipe40jaf0GBmC0COO7jh1m1U2ZZ0LRbt19ydVleZ5pfwy3yGb+Tl40irqJz69+UqmE9+ZjaJc7j46Jhqng==}
     engines: {node: '>=18'}
     peerDependencies:
       conventional-commits-filter: ^5.0.0
@@ -1153,10 +1144,6 @@ packages:
   '@humanwhocodes/retry@0.4.2':
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
-
-  '@hutson/parse-repository-url@5.0.0':
-    resolution: {integrity: sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==}
-    engines: {node: '>=10.13.0'}
 
   '@inquirer/core@10.1.11':
     resolution: {integrity: sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==}
@@ -1716,9 +1703,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  add-stream@1.0.0:
-    resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
-
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -1914,40 +1898,8 @@ packages:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
     engines: {node: '>=18'}
 
-  conventional-changelog-atom@5.0.0:
-    resolution: {integrity: sha512-WfzCaAvSCFPkznnLgLnfacRAzjgqjLUjvf3MftfsJzQdDICqkOOpcMtdJF3wTerxSpv2IAAjX8doM3Vozqle3g==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-codemirror@5.0.0:
-    resolution: {integrity: sha512-8gsBDI5Y3vrKUCxN6Ue8xr6occZ5nsDEc4C7jO/EovFGozx8uttCAyfhRrvoUAWi2WMm3OmYs+0mPJU7kQdYWQ==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-conventionalcommits@8.0.0:
-    resolution: {integrity: sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-core@8.0.0:
-    resolution: {integrity: sha512-EATUx5y9xewpEe10UEGNpbSHRC6cVZgO+hXQjofMqpy+gFIrcGvH3Fl6yk2VFKh7m+ffenup2N7SZJYpyD9evw==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-ember@5.0.0:
-    resolution: {integrity: sha512-RPflVfm5s4cSO33GH/Ey26oxhiC67akcxSKL8CLRT3kQX2W3dbE19sSOM56iFqUJYEwv9mD9r6k79weWe1urfg==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-eslint@6.0.0:
-    resolution: {integrity: sha512-eiUyULWjzq+ybPjXwU6NNRflApDWlPEQEHvI8UAItYW/h22RKkMnOAtfCZxMmrcMO1OKUWtcf2MxKYMWe9zJuw==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-express@5.0.0:
-    resolution: {integrity: sha512-D8Q6WctPkQpvr2HNCCmwU5GkX22BVHM0r4EW8vN0230TSyS/d6VQJDAxGb84lbg0dFjpO22MwmsikKL++Oo/oQ==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-jquery@6.0.0:
-    resolution: {integrity: sha512-2kxmVakyehgyrho2ZHBi90v4AHswkGzHuTaoH40bmeNqUt20yEkDOSpw8HlPBfvEQBwGtbE+5HpRwzj6ac2UfA==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-jshint@5.0.0:
-    resolution: {integrity: sha512-gGNphSb/opc76n2eWaO6ma4/Wqu3tpa2w7i9WYqI6Cs2fncDSI2/ihOfMvXveeTTeld0oFvwMVNV+IYQIk3F3g==}
+  conventional-changelog-conventionalcommits@9.0.0:
+    resolution: {integrity: sha512-5e48V0+DsWvQBEnnbBFhYQwYDzFPXVrakGPP1uSxekDkr5d7YWrmaWsgJpKFR0SkXmxK6qQr9O42uuLb9wpKxA==}
     engines: {node: '>=18'}
 
   conventional-changelog-preset-loader@5.0.0:
@@ -1959,9 +1911,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  conventional-changelog@6.0.0:
-    resolution: {integrity: sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==}
+  conventional-changelog@7.0.2:
+    resolution: {integrity: sha512-dz38xbKg2Nzd2zoPY1PXPq7skbN1tdx402OkcirIE44LetmoWODmt4h/6AwtQb6+ZHjbmMfW6Jxt4dyGt5P8cw==}
     engines: {node: '>=18'}
+    hasBin: true
 
   conventional-commits-filter@5.0.0:
     resolution: {integrity: sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==}
@@ -2221,6 +2174,9 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
+  fd-package-json@1.2.0:
+    resolution: {integrity: sha512-45LSPmWf+gC5tdCQMNH4s9Sr00bIkiD9aN7dc5hqkrEw1geRYyDQS1v1oMHAW3ysfxfndqGsrDREHHjNNbKUfA==}
+
   fdir@6.4.4:
     resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
     peerDependencies:
@@ -2244,10 +2200,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  find-up-simple@1.0.1:
-    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
-    engines: {node: '>=18'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2306,16 +2258,6 @@ packages:
 
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
-
-  git-raw-commits@5.0.0:
-    resolution: {integrity: sha512-I2ZXrXeOc0KrCvC7swqtIFXFN+rbjnC7b2T943tvemIOVNl+XP8YnA9UVwqFhzzLClnSA60KR/qEjLpXzs73Qg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  git-semver-tags@8.0.0:
-    resolution: {integrity: sha512-N7YRIklvPH3wYWAR2vysaqGLPRcpwQ0GKdlqTiVN5w1UmCdaeY3K8s6DMKRCh54DDdzyt/OAB6C8jgVtb7Y2Fg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   git-up@8.1.1:
     resolution: {integrity: sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==}
@@ -3059,10 +3001,6 @@ packages:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  read-package-up@11.0.0:
-    resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
-    engines: {node: '>=18'}
-
   read-pkg@9.0.1:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
     engines: {node: '>=18'}
@@ -3521,6 +3459,9 @@ packages:
       jsdom:
         optional: true
 
+  walk-up-path@3.0.1:
+    resolution: {integrity: sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==}
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
@@ -3671,15 +3612,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@conventional-changelog/git-client@1.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)':
-    dependencies:
-      '@types/semver': 7.7.0
-      semver: 7.7.2
-    optionalDependencies:
-      conventional-commits-filter: 5.0.0
-      conventional-commits-parser: 6.1.0
-
-  '@conventional-changelog/git-client@2.1.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)':
+  '@conventional-changelog/git-client@2.2.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)':
     dependencies:
       semver: 7.7.2
     optionalDependencies:
@@ -3826,8 +3759,6 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.2': {}
-
-  '@hutson/parse-repository-url@5.0.0': {}
 
   '@inquirer/core@10.1.11(@types/node@22.15.21)':
     dependencies:
@@ -4460,8 +4391,6 @@ snapshots:
 
   acorn@8.14.1: {}
 
-  add-stream@1.0.0: {}
-
   agent-base@7.1.3: {}
 
   ajv@6.12.6:
@@ -4640,38 +4569,7 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-atom@5.0.0: {}
-
-  conventional-changelog-codemirror@5.0.0: {}
-
-  conventional-changelog-conventionalcommits@8.0.0:
-    dependencies:
-      compare-func: 2.0.0
-
-  conventional-changelog-core@8.0.0(conventional-commits-filter@5.0.0):
-    dependencies:
-      '@hutson/parse-repository-url': 5.0.0
-      add-stream: 1.0.0
-      conventional-changelog-writer: 8.1.0
-      conventional-commits-parser: 6.1.0
-      git-raw-commits: 5.0.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
-      git-semver-tags: 8.0.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
-      hosted-git-info: 7.0.2
-      normalize-package-data: 6.0.2
-      read-package-up: 11.0.0
-      read-pkg: 9.0.1
-    transitivePeerDependencies:
-      - conventional-commits-filter
-
-  conventional-changelog-ember@5.0.0: {}
-
-  conventional-changelog-eslint@6.0.0: {}
-
-  conventional-changelog-express@5.0.0: {}
-
-  conventional-changelog-jquery@6.0.0: {}
-
-  conventional-changelog-jshint@5.0.0:
+  conventional-changelog-conventionalcommits@9.0.0:
     dependencies:
       compare-func: 2.0.0
 
@@ -4684,19 +4582,16 @@ snapshots:
       meow: 13.2.0
       semver: 7.7.2
 
-  conventional-changelog@6.0.0(conventional-commits-filter@5.0.0):
+  conventional-changelog@7.0.2(conventional-commits-filter@5.0.0):
     dependencies:
-      conventional-changelog-angular: 8.0.0
-      conventional-changelog-atom: 5.0.0
-      conventional-changelog-codemirror: 5.0.0
-      conventional-changelog-conventionalcommits: 8.0.0
-      conventional-changelog-core: 8.0.0(conventional-commits-filter@5.0.0)
-      conventional-changelog-ember: 5.0.0
-      conventional-changelog-eslint: 6.0.0
-      conventional-changelog-express: 5.0.0
-      conventional-changelog-jquery: 6.0.0
-      conventional-changelog-jshint: 5.0.0
+      '@conventional-changelog/git-client': 2.2.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
+      '@types/normalize-package-data': 2.4.4
       conventional-changelog-preset-loader: 5.0.0
+      conventional-changelog-writer: 8.1.0
+      conventional-commits-parser: 6.1.0
+      fd-package-json: 1.2.0
+      meow: 13.2.0
+      normalize-package-data: 7.0.0
     transitivePeerDependencies:
       - conventional-commits-filter
 
@@ -4708,7 +4603,7 @@ snapshots:
 
   conventional-recommended-bump@11.1.0:
     dependencies:
-      '@conventional-changelog/git-client': 2.1.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
+      '@conventional-changelog/git-client': 2.2.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
       conventional-changelog-preset-loader: 5.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.1.0
@@ -4979,6 +4874,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-package-json@1.2.0:
+    dependencies:
+      walk-up-path: 3.0.1
+
   fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
@@ -4996,8 +4895,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  find-up-simple@1.0.1: {}
 
   find-up@4.1.0:
     dependencies:
@@ -5058,22 +4955,6 @@ snapshots:
   get-tsconfig@4.10.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  git-raw-commits@5.0.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0):
-    dependencies:
-      '@conventional-changelog/git-client': 1.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
-      meow: 13.2.0
-    transitivePeerDependencies:
-      - conventional-commits-filter
-      - conventional-commits-parser
-
-  git-semver-tags@8.0.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0):
-    dependencies:
-      '@conventional-changelog/git-client': 1.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
-      meow: 13.2.0
-    transitivePeerDependencies:
-      - conventional-commits-filter
-      - conventional-commits-parser
 
   git-up@8.1.1:
     dependencies:
@@ -5804,12 +5685,6 @@ snapshots:
       json-parse-even-better-errors: 4.0.0
       npm-normalize-package-bin: 4.0.0
 
-  read-package-up@11.0.0:
-    dependencies:
-      find-up-simple: 1.0.1
-      read-pkg: 9.0.1
-      type-fest: 4.38.0
-
   read-pkg@9.0.1:
     dependencies:
       '@types/normalize-package-data': 2.4.4
@@ -6267,6 +6142,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  walk-up-path@3.0.1: {}
 
   walk-up-path@4.0.0: {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Upgrade 2 conventional-changelog packages to their latest major
- `conventional-changelog@7`
- `conventional-changelog-conventionalcommits@9`

## Motivation and Context

These 2 dependencies had again major breaking changes that required some major changes to get them working (also as usual, no migration guide provided, so it's a lot of code reading to figure out how to migrate). It seems ok now but one of the biggest difference now is that the new API for Presets only seems to accept an object like this `{ parser, writer, whatBump }`  (in other words, `parserOpts`, `writerOpts` were renamed and I've put some code to support them until our next major, even though I don't think anyone uses this super old legacy loading of "Preset as a file config")

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
