### PR TITLE
refactor: drop unnecessary `get-stream` from update changelog

### DIFF
--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -49,7 +49,6 @@
     "conventional-recommended-bump": "^11.1.0",
     "dedent": "catalog:",
     "fs-extra": "catalog:",
-    "get-stream": "^9.0.1",
     "git-url-parse": "^16.1.0",
     "graceful-fs": "^4.2.11",
     "is-stream": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,9 +761,6 @@ importers:
       fs-extra:
         specifier: 'catalog:'
         version: 11.3.0
-      get-stream:
-        specifier: ^9.0.1
-        version: 9.0.1
       git-url-parse:
         specifier: ^16.1.0
         version: 16.1.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Small refactoring to drop a dependency

## Motivation and Context

small refactor after updating to latest `conventional-changelog` dependency which now return an `AsyncGenerator`, with that in mind we can easily get rid of the previous `get-stream` and just use Promises. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
