### PR TITLE
refactor: remove unnecessary NPM version check lower than 8.5

### DIFF
--- a/__fixtures__/pack-directory/packages/a/prepare.ts
+++ b/__fixtures__/pack-directory/packages/a/prepare.ts
@@ -9,5 +9,4 @@ mkdirSync(dirname(targetIndex));
 const reader = createReadStream(sourceIndex);
 const writer = createWriteStream(targetIndex);
 
-// fs.copyFileSync is node >=8.5.0
 reader.pipe(writer);

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -914,7 +914,7 @@ lerna version --sync-workspace-lock
 Depending on the `npmClient` defined, it will perform the following:
 
 ```sh
-# npm is assuming a `package-lock.json` lock file and npm client >= 8.5.0 is required
+# npm is assuming a `package-lock.json` lock file
 npm install --package-lock-only
 
 # pnpm is assuming a "pnpm-lock.yaml" lock file and "npmClient": "pnpm"

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -218,8 +218,7 @@ describe('pnpm client', () => {
 
 describe('run install lockfile-only', () => {
   describe('npm client', () => {
-    it(`should update project root lockfile by calling npm script "npm install --package-lock-only --ignore-scripts" when npm version is >= 8.5.0`, async () => {
-      (execPackageManagerSync as any).mockReturnValueOnce('8.5.0');
+    it(`should update project root lockfile by calling npm script "npm install --package-lock-only --ignore-scripts"`, async () => {
       vi.spyOn(fsPromises, 'access').mockResolvedValue(true as any);
       (execPackageManager as Mock).mockImplementationOnce(() => true);
       const cwd = await initFixture('lockfile-version2');
@@ -231,24 +230,7 @@ describe('run install lockfile-only', () => {
       expect(lockFileOutput).toBe('package-lock.json');
     });
 
-    it(`should display a log error when npm version is below 8.5.0 and not actually sync anything`, async () => {
-      (execPackageManagerSync as any).mockReturnValueOnce('8.4.0');
-      vi.spyOn(fsPromises, 'access').mockResolvedValue(true as any);
-      (execPackageManager as Mock).mockImplementationOnce(() => true);
-      const cwd = await initFixture('lockfile-version2');
-      const logSpy = vi.spyOn(log, 'error');
-
-      await runInstallLockFileOnly('npm', cwd, { npmClientArgs: [] });
-
-      expect(execPackageManagerSync).toHaveBeenCalledWith('npm', ['--version']);
-      expect(logSpy).toHaveBeenCalledWith(
-        'lock',
-        expect.stringContaining('your npm version is lower than 8.5.0 which is the minimum requirement to use `--sync-workspace-lock`')
-      );
-    });
-
     it(`should update project root lockfile by calling npm script "npm install --package-lock-only" without running npm scripts when --run-scripts-on-lockfile-update is enabled`, async () => {
-      (execPackageManagerSync as any).mockReturnValueOnce('8.5.0');
       vi.spyOn(fsPromises, 'access').mockResolvedValue(true as any);
       (execPackageManager as Mock).mockImplementationOnce(() => true);
       const cwd = await initFixture('lockfile-version2');
@@ -261,7 +243,6 @@ describe('run install lockfile-only', () => {
     });
 
     it(`should update project root lockfile by calling npm script "npm install --package-lock-only" with extra npm client arguments when provided`, async () => {
-      (execPackageManagerSync as any).mockReturnValueOnce('8.5.0');
       vi.spyOn(fsPromises, 'access').mockResolvedValue(true as any);
       (execPackageManager as Mock).mockImplementationOnce(() => true);
       const cwd = await initFixture('lockfile-version2');
@@ -274,7 +255,6 @@ describe('run install lockfile-only', () => {
     });
 
     it(`should update project root lockfile by calling npm script "npm install --legacy-peer-deps,--force" with multiple npm client arguments provided as CSV`, async () => {
-      (execPackageManagerSync as any).mockReturnValueOnce('8.5.0');
       const cwd = await initFixture('lockfile-version2');
 
       const lockFileOutput = await runInstallLockFileOnly('npm', cwd, { npmClientArgs: ['--legacy-peer-deps,--force'] });

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -168,25 +168,18 @@ export async function runInstallLockFileOnly(
         const localNpmVersion = execPackageManagerSync('npm', ['--version']);
         log.silly(`npm`, `current local npm version is "${localNpmVersion}"`);
 
-        // with npm version >=8.5.0, we can simply call "npm install --package-lock-only"
-        if (semver.gte(localNpmVersion, '8.5.0')) {
-          log.verbose('lock', `updating lock file via "npm install --package-lock-only"`);
-          await execPackageManager(
-            'npm',
-            [
-              'install',
-              '--package-lock-only',
-              !options.runScriptsOnLockfileUpdate ? '--ignore-scripts' : '',
-              ...npmClientArgs,
-            ].filter(Boolean),
-            { cwd }
-          );
-        } else {
-          log.error(
-            'lock',
-            'your npm version is lower than 8.5.0 which is the minimum requirement to use `--sync-workspace-lock`'
-          );
-        }
+        // we can simply call "npm install --package-lock-only" to update the lock file
+        log.verbose('lock', `updating lock file via "npm install --package-lock-only"`);
+        await execPackageManager(
+          'npm',
+          [
+            'install',
+            '--package-lock-only',
+            !options.runScriptsOnLockfileUpdate ? '--ignore-scripts' : '',
+            ...npmClientArgs,
+          ].filter(Boolean),
+          { cwd }
+        );
 
         outputLockfileName = inputLockfileName;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove unused code

## Motivation and Context

Forgot to remove this check when releasing the latest major, we no longer need to check the NPM version to be >=8.5.0 since NodeJS 20.17 (our new requirement) has NPM 10.8.2 by default so the version becomes irrelevant 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
