### PR TITLE
refactor: simplify `makeBumpOnlyFilter` to make only 1 call instead of 2

### DIFF
--- a/packages/version/src/conventional-commits/make-bump-only-filter.ts
+++ b/packages/version/src/conventional-commits/make-bump-only-filter.ts
@@ -6,21 +6,19 @@ import { BLANK_LINE } from './constants.js';
  * @param {import("@lerna/package").Package} pkg
  * @return {(entry: string) => string}
  */
-export function makeBumpOnlyFilter(pkg: Package) {
-  return (newEntry: string) => {
-    // When force publishing, it is possible that there will be no actual changes, only a version bump.
-    if (!newEntry.split('\n').some((line) => line.startsWith('*'))) {
-      // keep ref of a "bump only" in the package itself
-      pkg.isBumpOnlyVersion = true;
+export function makeBumpOnlyFilter(pkg: Package, newEntry: string) {
+  // When force publishing, it is possible that there will be no actual changes, only a version bump.
+  if (!newEntry.split('\n').some((line) => line.startsWith('*'))) {
+    // keep ref of a "bump only" in the package itself
+    pkg.isBumpOnlyVersion = true;
 
-      // Add a note to indicate that only a version bump has occurred.
-      // TODO: actually list the dependencies that were bumped
-      const message = `**Note:** Version bump only for package ${pkg.name}`;
+    // Add a note to indicate that only a version bump has occurred.
+    // TODO: actually list the dependencies that were bumped
+    const message = `**Note:** Version bump only for package ${pkg.name}`;
 
-      // the extra blank lines preserve the whitespace delimiting releases
-      return [newEntry.trim(), message, BLANK_LINE].join(BLANK_LINE);
-    }
+    // the extra blank lines preserve the whitespace delimiting releases
+    return [newEntry.trim(), message, BLANK_LINE].join(BLANK_LINE);
+  }
 
-    return newEntry;
-  };
+  return newEntry;
 }

--- a/packages/version/src/conventional-commits/update-changelog.ts
+++ b/packages/version/src/conventional-commits/update-changelog.ts
@@ -94,7 +94,7 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
     for await (const chunk of changelogStream) {
       entry += chunk;
     }
-    return makeBumpOnlyFilter(pkg)(entry);
+    return makeBumpOnlyFilter(pkg, entry);
   })();
 
   return Promise.all([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Simplifying code

## Motivation and Context

Another small refactor to make the `makeBumpOnlyFilter` do only 1 call instead of 2

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
