### PR TITLE
fix: pnpm catalog should detect git changes with named catalog

### DIFF
--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -4,12 +4,10 @@ import type npa from 'npm-package-arg';
 import type { Package } from '../package.js';
 import type { InitCommandOption, PublishCommandOption, RunCommandOption, VersionCommandOption } from './command-options.js';
 
-/* eslint-disable no-use-before-define */
 export type JsonObject = { [Key in string]: JsonValue } & { [Key in string]?: JsonValue | undefined };
 export type JsonArray = JsonValue[];
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
-/* eslint-enable no-use-before-define */
 
 export interface ArboristLoadOption {
   global?: any;

--- a/packages/core/src/package-graph/lib/cyclic-package-graph-node.ts
+++ b/packages/core/src/package-graph/lib/cyclic-package-graph-node.ts
@@ -8,9 +8,8 @@ let lastCollapsedNodeId = 0;
  * information are the connections to the other nodes of the graph.
  * It can contain either `PackageGraphNode`s or other `CyclicPackageGraphNode`s.
  *
- * @extends {Map<string, import('..').PackageGraphNode | CyclicPackageGraphNode>}
+ * @extends {Map<string, PackageGraphNode | CyclicPackageGraphNode>}
  */
-// eslint-disable-next-line no-use-before-define
 export class CyclicPackageGraphNode extends Map<string, PackageGraphNode | CyclicPackageGraphNode> {
   name: string;
   localDependencies: Map<string, any>;

--- a/packages/core/src/utils/collect-updates/__tests__/lib-make-diff-predicate.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/lib-make-diff-predicate.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, Mock, test, vi } from 'vitest';
+import { beforeEach, describe, expect, Mock, test, vi } from 'vitest';
 
 vi.mock('../../../child-process');
 
@@ -140,139 +140,161 @@ test('not exclude any subpackages when --independent-subpackages option is enabl
   });
 });
 
-test('diffWorkspaceCatalog with external dependency changes in pnpm workspace catalog', () => {
-  setup([]);
+describe('pnpm catalog', () => {
+  test('diffWorkspaceCatalog with external dependency changes in pnpm workspace catalog', () => {
+    setup([]);
 
-  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, undefined, ['vite'], {});
-  const result = hasDiff({
-    location: '/test/packages/pkg-1',
-    localDependencies: new Map([]),
-    externalDependencies: new Map([['vite', {}]]),
-  } as PackageGraphNode);
+    const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, undefined, ['vite'], {});
+    const result = hasDiff({
+      location: '/test/packages/pkg-1',
+      localDependencies: new Map([]),
+      externalDependencies: new Map([['vite', {}]]),
+    } as PackageGraphNode);
 
-  expect(result).toBe(true);
-  expect(childProcesses.execSync).toHaveBeenLastCalledWith('git', ['diff', '--name-only', 'v1.0.0', '--', 'packages/pkg-1'], { cwd: '/test' });
-});
-
-test('diffWorkspaceCatalog with local dependency changes in pnpm workspace catalog', () => {
-  setup([]);
-
-  const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, undefined, ['@mono/pkg-1'], {});
-  const result = hasDiff({
-    location: '/test/packages/pkg-1',
-    localDependencies: new Map([['@mono/pkg-1', {}]]),
-    externalDependencies: new Map([]),
-  } as PackageGraphNode);
-
-  expect(result).toBe(true);
-  expect(childProcesses.execSync).toHaveBeenLastCalledWith('git', ['diff', '--name-only', 'v1.0.0', '--', 'packages/pkg-1'], { cwd: '/test' });
-});
-
-test('diff workspace catalog returning dependencies that changed in the catalog', () => {
-  // make a diff on the catalog for the "execa" dependency
-  const mockPrevCatalogCommit = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^8.0.0\n  fs-extra: ^11.3.0';
-  const mockNewCatalogCommit = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^9.5.2\n  fs-extra: ^11.3.0';
-  const diff =
-    'diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml\nindex 1994993f..bf229582 100644\n--- a/pnpm-workspace.yaml\n+++ b/pnpm-workspace.yaml\n@@ -5,16 +5,16 @@ catalog:' +
-    '\n-  execa: ^8.0.1\n+  execa: ^9.5.2\n   fs-extra: ^11.3.0' +
-    'diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml\nindex 1994993f..bf229582 100644\n--- a/pnpm-workspace.yaml\n+++ b/pnpm-workspace.yaml' +
-    '\n@@ -11,13 +11,13 @@ catalog:\n-  execa: ^8.0.1\n+  execa: ^9.5.2\n   fs-extra: ^11.3.0\n@@ -30,7 +30,7';
-
-  (readFileMock as Mock).mockName('readFile').mockReturnValueOnce(mockNewCatalogCommit);
-  (childProcesses.execSync as Mock)
-    .mockReturnValueOnce(mockPrevCatalogCommit) // first call is to get previous catalog commit
-    .mockReturnValueOnce(diff); // next call is to get diff between current and previous catalog
-
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes).toEqual(['execa']);
-});
-
-test('diffWorkspaceCatalog returns changed external dependencies when catalog values differ', () => {
-  const prev = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^8.0.0\n  fs-extra: ^11.3.0';
-  const curr = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^9.5.2\n  fs-extra: ^11.3.0';
-  (readFileMock as Mock).mockReturnValueOnce(curr);
-  (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
-
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes).toEqual(['execa']);
-});
-
-test('diffWorkspaceCatalog returns changed local dependencies when catalog values differ', () => {
-  const prev = 'packages:\n  - packages/**\n\ncatalog:\n  "@mono/pkg-1": ^8.0.0\n  fs-extra: ^11.3.0';
-  const curr = 'packages:\n  - packages/**\n\ncatalog:\n  "@mono/pkg-1": ^9.5.2\n  fs-extra: ^11.3.0';
-  (readFileMock as Mock).mockReturnValueOnce(curr);
-  (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
-
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes).toEqual(['@mono/pkg-1']);
-});
-
-test('diffWorkspaceCatalog returns multiple changed dependencies', () => {
-  const prev = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^8.0.0\n  fs-extra: ^10.0.0';
-  const curr = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^9.5.2\n  fs-extra: ^11.3.0';
-  (readFileMock as Mock).mockReturnValueOnce(curr);
-  (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
-
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes.sort()).toEqual(['execa', 'fs-extra']);
-});
-
-test('diffWorkspaceCatalog returns empty array if no changes', () => {
-  const prev = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^9.5.2\n  fs-extra: ^11.3.0';
-  const curr = prev;
-  (readFileMock as Mock).mockReturnValueOnce(curr);
-  (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
-
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes).toEqual([]);
-});
-
-test('diffWorkspaceCatalog returns empty array if catalog key is missing', () => {
-  const prev = 'packages:\n  - packages/**\n\n';
-  const curr = 'packages:\n  - packages/**\n\n';
-  (readFileMock as Mock).mockReturnValueOnce(curr);
-  (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
-
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes).toEqual([]);
-});
-
-test('diffWorkspaceCatalog returns empty array if all methods fail', () => {
-  (readFileMock as Mock).mockImplementationOnce(() => {
-    throw new Error('fail');
+    expect(result).toBe(true);
+    expect(childProcesses.execSync).toHaveBeenLastCalledWith('git', ['diff', '--name-only', 'v1.0.0', '--', 'packages/pkg-1'], { cwd: '/test' });
   });
-  (childProcesses.execSync as Mock)
-    .mockImplementationOnce(() => {
+
+  test('diffWorkspaceCatalog with local dependency changes in pnpm workspace catalog', () => {
+    setup([]);
+
+    const hasDiff = makeDiffPredicate('v1.0.0', { cwd: '/test' }, undefined, ['@mono/pkg-1'], {});
+    const result = hasDiff({
+      location: '/test/packages/pkg-1',
+      localDependencies: new Map([['@mono/pkg-1', {}]]),
+      externalDependencies: new Map([]),
+    } as PackageGraphNode);
+
+    expect(result).toBe(true);
+    expect(childProcesses.execSync).toHaveBeenLastCalledWith('git', ['diff', '--name-only', 'v1.0.0', '--', 'packages/pkg-1'], { cwd: '/test' });
+  });
+
+  test('diff workspace catalog returning dependencies that changed in the catalog', () => {
+    // make a diff on the catalog for the "execa" dependency
+    const mockPrevCatalogCommit = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^8.0.0\n  fs-extra: ^11.3.0';
+    const mockNewCatalogCommit = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^9.5.2\n  fs-extra: ^11.3.0';
+    const diff =
+      'diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml\nindex 1994993f..bf229582 100644\n--- a/pnpm-workspace.yaml\n+++ b/pnpm-workspace.yaml\n@@ -5,16 +5,16 @@ catalog:' +
+      '\n-  execa: ^8.0.1\n+  execa: ^9.5.2\n   fs-extra: ^11.3.0' +
+      'diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml\nindex 1994993f..bf229582 100644\n--- a/pnpm-workspace.yaml\n+++ b/pnpm-workspace.yaml' +
+      '\n@@ -11,13 +11,13 @@ catalog:\n-  execa: ^8.0.1\n+  execa: ^9.5.2\n   fs-extra: ^11.3.0\n@@ -30,7 +30,7';
+
+    (readFileMock as Mock).mockName('readFile').mockReturnValueOnce(mockNewCatalogCommit);
+    (childProcesses.execSync as Mock)
+      .mockReturnValueOnce(mockPrevCatalogCommit) // first call is to get previous catalog commit
+      .mockReturnValueOnce(diff); // next call is to get diff between current and previous catalog
+
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual(['execa']);
+  });
+
+  test('diff workspace catalogs returning dependencies that changed in the catalog', () => {
+    // make a diff on the catalog for the "execa" dependency
+    const mockPrevCatalogCommit = 'packages:\n  - packages/**\n\ncatalogs:\n  build:\n    execa: ^8.0.0\n    fs-extra: ^11.3.0';
+    const mockNewCatalogCommit = 'packages:\n  - packages/**\n\ncatalogs:\n  build:\n    execa: ^9.5.2\n    fs-extra: ^11.3.0';
+    const diff =
+      'diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml\nindex 1994993f..bf229582 100644\n--- a/pnpm-workspace.yaml\n+++ b/pnpm-workspace.yaml\n@@ -5,16 +5,16 @@ catalogs:' +
+      '\n  build:' +
+      '\n-    execa: ^8.0.1\n+    execa: ^9.5.2\n     fs-extra: ^11.3.0' +
+      'diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml\nindex 1994993f..bf229582 100644\n--- a/pnpm-workspace.yaml\n+++ b/pnpm-workspace.yaml' +
+      '\n@@ -11,13 +11,13 @@ catalog:\n  build:\n-    execa: ^8.0.1\n+    execa: ^9.5.2\n     fs-extra: ^11.3.0\n@@ -30,7 +30,7';
+
+    (readFileMock as Mock).mockName('readFile').mockReturnValueOnce(mockNewCatalogCommit);
+    (childProcesses.execSync as Mock)
+      .mockReturnValueOnce(mockPrevCatalogCommit) // first call is to get previous catalog commit
+      .mockReturnValueOnce(diff); // next call is to get diff between current and previous catalog
+
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual(['execa']);
+  });
+
+  test('diffWorkspaceCatalog returns changed external dependencies when catalog values differ', () => {
+    const prev = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^8.0.0\n  fs-extra: ^11.3.0';
+    const curr = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^9.5.2\n  fs-extra: ^11.3.0';
+    (readFileMock as Mock).mockReturnValueOnce(curr);
+    (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
+
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual(['execa']);
+  });
+
+  test('diffWorkspaceCatalog returns changed local dependencies when catalog values differ', () => {
+    const prev = 'packages:\n  - packages/**\n\ncatalog:\n  "@mono/pkg-1": ^8.0.0\n  fs-extra: ^11.3.0';
+    const curr = 'packages:\n  - packages/**\n\ncatalog:\n  "@mono/pkg-1": ^9.5.2\n  fs-extra: ^11.3.0';
+    (readFileMock as Mock).mockReturnValueOnce(curr);
+    (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
+
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual(['@mono/pkg-1']);
+  });
+
+  test('diffWorkspaceCatalog returns multiple changed dependencies', () => {
+    const prev = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^8.0.0\n  fs-extra: ^10.0.0';
+    const curr = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^9.5.2\n  fs-extra: ^11.3.0';
+    (readFileMock as Mock).mockReturnValueOnce(curr);
+    (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
+
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes.sort()).toEqual(['execa', 'fs-extra']);
+  });
+
+  test('diffWorkspaceCatalog returns empty array if no changes', () => {
+    const prev = 'packages:\n  - packages/**\n\ncatalog:\n  execa: ^9.5.2\n  fs-extra: ^11.3.0';
+    const curr = prev;
+    (readFileMock as Mock).mockReturnValueOnce(curr);
+    (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
+
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual([]);
+  });
+
+  test('diffWorkspaceCatalog returns empty array if catalog key is missing', () => {
+    const prev = 'packages:\n  - packages/**\n\n';
+    const curr = 'packages:\n  - packages/**\n\n';
+    (readFileMock as Mock).mockReturnValueOnce(curr);
+    (childProcesses.execSync as Mock).mockReturnValueOnce(prev);
+
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual([]);
+  });
+
+  test('diffWorkspaceCatalog returns empty array if all methods fail', () => {
+    (readFileMock as Mock).mockImplementationOnce(() => {
       throw new Error('fail');
-    }) // fail YAML parse
-    .mockImplementationOnce(() => {
-      throw new Error('fail');
-    }); // fail git diff
+    });
+    (childProcesses.execSync as Mock)
+      .mockImplementationOnce(() => {
+        throw new Error('fail');
+      }) // fail YAML parse
+      .mockImplementationOnce(() => {
+        throw new Error('fail');
+      }); // fail git diff
 
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes).toEqual([]);
-});
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual([]);
+  });
 
-test('diffWorkspaceCatalog adds dependency from indented diff line when YAML shows no changes', () => {
-  const prev = 'packages:\n  - packages/**\n\ncatalog:\n  foo: ^1.0.0';
-  const curr = 'packages:\n  - packages/**\n\ncatalog:\n  foo: ^1.0.0';
-  (readFileMock as Mock).mockReturnValueOnce(curr);
-  (childProcesses.execSync as Mock)
-    .mockReturnValueOnce(prev) // previous YAML
-    .mockReturnValueOnce('+  bar: ^2.0.0\n'); // diff output
+  test('diffWorkspaceCatalog adds dependency from indented diff line when YAML shows no changes', () => {
+    const prev = 'packages:\n  - packages/**\n\ncatalog:\n  foo: ^1.0.0';
+    const curr = 'packages:\n  - packages/**\n\ncatalog:\n  foo: ^1.0.0';
+    (readFileMock as Mock).mockReturnValueOnce(curr);
+    (childProcesses.execSync as Mock)
+      .mockReturnValueOnce(prev) // previous YAML
+      .mockReturnValueOnce('+  bar: ^2.0.0\n'); // diff output
 
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes).toEqual(['bar']);
-});
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual(['bar']);
+  });
 
-test('diffWorkspaceCatalog adds dependency from dot notation diff line when YAML shows no changes', () => {
-  const prev = 'packages:\n  - packages/**\n\ncatalog:\n  foo: ^1.0.0';
-  const curr = 'packages:\n  - packages/**\n\ncatalog:\n  foo: ^1.0.0';
-  (readFileMock as Mock).mockReturnValueOnce(curr);
-  (childProcesses.execSync as Mock)
-    .mockReturnValueOnce(prev) // previous YAML
-    .mockReturnValueOnce('+ catalog.baz: ^3.0.0\n'); // diff output
+  test('diffWorkspaceCatalog adds dependency from dot notation diff line when YAML shows no changes', () => {
+    const prev = 'packages:\n  - packages/**\n\ncatalog:\n  foo: ^1.0.0';
+    const curr = 'packages:\n  - packages/**\n\ncatalog:\n  foo: ^1.0.0';
+    (readFileMock as Mock).mockReturnValueOnce(curr);
+    (childProcesses.execSync as Mock)
+      .mockReturnValueOnce(prev) // previous YAML
+      .mockReturnValueOnce('+ catalog.baz: ^3.0.0\n'); // diff output
 
-  const changes = diffWorkspaceCatalog('v1.0.0');
-  expect(changes).toEqual(['baz']);
+    const changes = diffWorkspaceCatalog('v1.0.0');
+    expect(changes).toEqual(['baz']);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes weren't always being detected when they were found in named catalogs

## Motivation and Context

Git diffs was previously only detecting changes in the default `catalog` and named `catalogs` weren't being processed

## How Has This Been Tested?

add unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
