### PR TITLE
Fix example of --dry-run in version README.md

### DIFF
--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -603,7 +603,7 @@ Displays the git command that would be performed without actually executing it, 
 > **Note** changelogs will still be created (when enabled) even in dry-run mode, so it could be useful to see what gets created without them being committed (however, make sure to revert the changes and roll back your version in `lerna.json` once you're satisfied with the output).
 
 ```sh
-$ lerna run watch --dry-run
+$ lerna version --dry-run
 ```
 
 ### `--git-tag-command <cmd>`


### PR DESCRIPTION
The example given for the flag --dry-run was using the run/watch command rather than version

## Description

The example given for the flag --dry-run was using the run/watch command rather than version

## Motivation and Context

 I believe the documented command was wrong and correcting would reduce confusion in the future.

## How Has This Been Tested?

By running the documented example locally

## Types of changes

- [ x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
