### PR TITLE
chore: avoid clearing the entire process.env in tests

### DIFF
--- a/packages/core/src/corepack/__tests__/exec-package-manager.spec.ts
+++ b/packages/core/src/corepack/__tests__/exec-package-manager.spec.ts
@@ -18,7 +18,7 @@ const execSyncActual = (await vi.importActual<any>('../../child-process')).execS
 
 describe('.execPackageManagerSync()', () => {
   beforeEach(() => {
-    process.env = {};
+    delete process.env.COREPACK_ROOT;
   });
 
   describe('mock child processes', () => {
@@ -60,7 +60,7 @@ describe('.execPackageManagerSync()', () => {
 
 describe('.execPackageManager()', () => {
   beforeEach(() => {
-    process.env = {};
+    delete process.env.COREPACK_ROOT;
   });
 
   describe('mock child processes', () => {

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -80,7 +80,8 @@ describe.each([
   ['gitlab', createGitLabClient],
 ])('--create-release %s', (type: any, client: any) => {
   beforeEach(() => {
-    process.env = {};
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
   });
 
   it('does not create a release if --no-push is passed', async () => {
@@ -277,7 +278,8 @@ describe('--create-release [unrecognized]', () => {
 
 describe('create --github-release without providing GH_TOKEN or GITHUB_TOKEN', () => {
   beforeEach(() => {
-    process.env = {};
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
   });
 
   it('should create a GitHub Release link with prefilled data when GH_TOKEN env var is not provided', async () => {
@@ -300,7 +302,8 @@ describe.each([
   const bumpOnlyTextPkg4 = `**Note:** Version bump only for package package-4`;
 
   beforeEach(() => {
-    process.env = {};
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
     (updateChangelog as Mock).mockImplementation((pkg) => {
       const filePath = join(pkg.location, 'CHANGELOG.md');
       if (pkg.name === 'package-4') {

--- a/packages/version/src/git-clients/__tests__/github-client.spec.ts
+++ b/packages/version/src/git-clients/__tests__/github-client.spec.ts
@@ -11,7 +11,10 @@ import { createGitHubClient, parseGitRepo } from '../github-client.js';
 
 describe('createGitHubClient', () => {
   beforeEach(() => {
-    process.env = {};
+    delete process.env.GH_TOKEN;
+    delete process.env.GHE_VERSION;
+    delete process.env.GHE_API_URL;
+    delete process.env.GITHUB_TOKEN;
   });
 
   it('does not error if GH_TOKEN env var is set', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

avoid clearing `process.env = {}` since that cancels temp dir creation with `tmpdir()` or `process.env.TEMP`

## Motivation and Context

`tmpdir()` was returning `undefined` on Windows platform but was working in Ubuntu (CI), the issue was caused by the clearing of `process.env` making the `tmpdir()` unusable

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
