### PR TITLE
fix: add missing npmClient needed for Catalog while newing QueryGraph

### DIFF
--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -137,6 +137,7 @@ export interface QueryGraphConfig {
   /** Whether or not to reject dependency cycles */
   rejectCycles?: boolean;
   premajorVersionBump?: 'default' | 'force-patch';
+  npmClient?: NpmClient;
 }
 
 export interface TopologicalConfig extends QueryGraphConfig {

--- a/packages/core/src/utils/query-graph.ts
+++ b/packages/core/src/utils/query-graph.ts
@@ -44,10 +44,10 @@ export class QueryGraph {
    */
   constructor(
     packages: Package[],
-    { graphType = 'allDependencies', localDependencies = 'auto', rejectCycles } = {} as QueryGraphConfig
+    { graphType = 'allDependencies', localDependencies = 'auto', rejectCycles, npmClient } = {} as QueryGraphConfig
   ) {
     // Create dependency graph
-    this.graph = new PackageGraph(packages, graphType as 'allDependencies' | 'dependencies', localDependencies);
+    this.graph = new PackageGraph(packages, graphType as 'allDependencies' | 'dependencies', localDependencies, npmClient);
 
     // Evaluate cycles
     this.cycles = this.graph.collapseCycles(rejectCycles);

--- a/packages/core/src/utils/run-topologically.ts
+++ b/packages/core/src/utils/run-topologically.ts
@@ -17,10 +17,10 @@ import { QueryGraph } from './query-graph.js';
 export function runTopologically<T = any>(
   packages: Package[],
   runner: (pkg: Package) => Promise<T>,
-  { concurrency, graphType, rejectCycles } = {} as TopologicalConfig
+  { concurrency, graphType, rejectCycles, npmClient = 'npm' } = {} as TopologicalConfig
 ) {
   const queue = new PQueue({ concurrency });
-  const graph = new QueryGraph(packages, { graphType, rejectCycles });
+  const graph = new QueryGraph(packages, { graphType, rejectCycles, npmClient });
 
   return new Promise((resolve, reject) => {
     const returnValues: any[] = [];

--- a/packages/exec/src/exec-command.ts
+++ b/packages/exec/src/exec-command.ts
@@ -157,6 +157,7 @@ export class ExecCommand extends Command<ExecCommandOption & FilterOptions> {
     let chain: Promise<any> = runTopologically(this.filteredPackages, runner, {
       concurrency: this.concurrency,
       rejectCycles: this.options.rejectCycles,
+      npmClient: this.options.npmClient,
     });
 
     if (profiler!) {

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -831,6 +831,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
        * by setting the `graphType` option to `dependencies`.
        */
       graphType: this.options.graphType === 'dependencies' ? 'dependencies' : 'allDependencies',
+      npmClient: this.options.npmClient,
     });
   }
 

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -185,6 +185,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
     let chain: Promise<any> = runTopologically(this.packagesWithScript, runner, {
       concurrency: this.concurrency,
       rejectCycles: this.options.rejectCycles,
+      npmClient: this.options.npmClient,
     });
 
     if (profiler!) {

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -749,6 +749,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
         concurrency: this.concurrency,
         rejectCycles: this.options.rejectCycles,
         graphType: 'allDependencies',
+        npmClient: this.options.npmClient,
       })
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix a small regression causing console warning that was showing Catalog not found:
`"No version found in "default" catalog for ..."`

## Motivation and Context

Looks like I missed adding `npmClient` when instantiating QueryGraph called by PackageGraph which in term didn't properly load Catalogs because of the missing `npmClient` (which is now used to determine where to load Catalogs from)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
