### PR TITLE
fix: zeptomatch should be installed as dep not devDeps, fixes #1076

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,8 @@
     "write-file-atomic": "^6.0.0",
     "write-json-file": "catalog:",
     "write-package": "catalog:",
-    "yaml": "catalog:"
+    "yaml": "catalog:",
+    "zeptomatch": "catalog:"
   },
   "devDependencies": {
     "@types/clone-deep": "^4.0.4",
@@ -79,8 +80,7 @@
     "@types/write-file-atomic": "^4.0.3",
     "npm-registry-fetch": "catalog:",
     "yargs": "catalog:",
-    "yargs-parser": "catalog:",
-    "zeptomatch": "catalog:"
+    "yargs-parser": "catalog:"
   },
   "funding": {
     "type": "ko_fi",

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -64,7 +64,8 @@
     "slash": "catalog:",
     "tinyrainbow": "catalog:",
     "uuid": "catalog:",
-    "write-json-file": "catalog:"
+    "write-json-file": "catalog:",
+    "zeptomatch": "catalog:"
   },
   "devDependencies": {
     "@npm/types": "^2.1.0",
@@ -77,7 +78,6 @@
     "write-package": "catalog:",
     "yaml": "catalog:",
     "yargs": "catalog:",
-    "yargs-parser": "catalog:",
-    "zeptomatch": "catalog:"
+    "yargs-parser": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,9 @@ importers:
       yaml:
         specifier: 'catalog:'
         version: 2.8.0
+      zeptomatch:
+        specifier: 'catalog:'
+        version: 2.0.2
     devDependencies:
       '@types/clone-deep':
         specifier: ^4.0.4
@@ -413,9 +416,6 @@ importers:
       yargs-parser:
         specifier: 'catalog:'
         version: 22.0.0
-      zeptomatch:
-        specifier: 'catalog:'
-        version: 2.0.2
 
   packages/diff:
     dependencies:
@@ -806,6 +806,9 @@ importers:
       write-json-file:
         specifier: 'catalog:'
         version: 6.0.0
+      zeptomatch:
+        specifier: 'catalog:'
+        version: 2.0.2
     devDependencies:
       '@npm/types':
         specifier: ^2.1.0
@@ -840,9 +843,6 @@ importers:
       yargs-parser:
         specifier: 'catalog:'
         version: 22.0.0
-      zeptomatch:
-        specifier: 'catalog:'
-        version: 2.0.2
 
   packages/watch:
     dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The migration to zeptomatch in previous PR #1074 incorrectly installed it as `devDependencies` when it should really be installed as `dependencies`

## Motivation and Context

fixes #1076

## How Has This Been Tested?

previous unit tests are fine

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
