### PR TITLE
docs: correct documentation for --force-publish flag usage

### DIFF
--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -598,6 +598,9 @@ lerna version --force-publish=package-2,package-4
 
 # force all packages to be versioned
 lerna version --force-publish "*"
+
+# Force all packages to a specific version (e.g., 1.0.1)
+lerna version 1.0.1 --force-publish "*"
 ```
 
 When run with this flag, `lerna version` will force publish the specified packages (comma-separated) or all packages using `*`.

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -597,7 +597,7 @@ If `package B`, being a child of `package A`, has changes they will normally bot
 lerna version --force-publish=package-2,package-4
 
 # force all packages to be versioned
-lerna version --force-publish
+lerna version --force-publish "*"
 ```
 
 When run with this flag, `lerna version` will force publish the specified packages (comma-separated) or all packages using `*`.


### PR DESCRIPTION
Hey maintainers,

I ran into an issue where the `version` command behaves unexpectedly when using the `--force-publish` flag with a specific version number. I've corrected the documentation to prevent confusion for other users.

**The Problem**

When running a command like `lerna version --force-publish <version>`, for example:

```bash
lerna version --force-publish 4.9.3
```

Lerna-lite misinterprets `4.9.3` as a package name to be force-published, not as the target version. This results in the following warning and subsequent failure, as no changed packages are found:

```
lerna-lite WARN force-publish 4.9.3
lerna-lite success No changed packages to version
```

**The Solution**

The correct syntax is to provide the version number as the primary argument to `lerna version` and then use a glob pattern (like `*`) for the `--force-publish` flag to apply the version bump to all packages.

The correct command is:

```bash
lerna version 4.9.3 --force-publish "*"
```

I have updated the documentation to reflect this correct usage. This change clarifies the command's syntax and ensures it works as expected.

Cheers