### PR TITLE
fix(publish): ensure README file names are populated on package.json

### DIFF
--- a/packages/publish/src/lib/npm-publish.ts
+++ b/packages/publish/src/lib/npm-publish.ts
@@ -61,7 +61,7 @@ export async function npmPublish(
 
     const [tarData, npmCliPackageJson] = await Promise.all([
       readFile(tarFilePath),
-      await PackageJson.load(dirname(manifestLocation)),
+      await PackageJson.prepare(dirname(manifestLocation)),
     ]);
 
     const manifestContent = npmCliPackageJson.content;


### PR DESCRIPTION
## Description
As per Lerna's [PR 4211](https://github.com/lerna/lerna/pull/4211)

> #4133 reported an issue about `README.md` not being visible in verdaccio when publishing. Looking into the issue I found #1843 that says that `verdaccio` requires `readmeFilename` field to exist on the package.json that is published.
> 
> with the 8.1.5 release, the [read-package-json](https://www.npmjs.com/package/read-package-json) was swapped out for [@npmcli/package-json](https://www.npmjs.com/package/@npmcli/package-json), and the `npm-publish.ts` file was updated to use `load`, but it should be using `prepare` since the npm-publish needs to normalize the package.json data and the documentation states that `prepare` should be used before publishing.
> 
## Motivation and Context
As per Lerna's PR 

> Currently if you run the project locally and visit the verdaccio web ui there is no README.md file. Any user using verdaccio can't see their README.md files when publishing to their private registry due to how the npm-publish file was updated.
> 
> You can re-create the issue locally:
> 
> 1. Run `npm run e2e-build-package-publish`
> 2. View the packages in the verdaccio web ui, all packages show up with the following content for the README:
> 
> <img alt="lerna-before" width="1831" height="1681" src="https://private-user-images.githubusercontent.com/3385622/472869220-0850afdd-d0bd-400d-9798-1a91180cc88f.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTQ2MTg3MzYsIm5iZiI6MTc1NDYxODQzNiwicGF0aCI6Ii8zMzg1NjIyLzQ3Mjg2OTIyMC0wODUwYWZkZC1kMGJkLTQwMGQtOTc5OC0xYTkxMTgwY2M4OGYucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDgwOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA4MDhUMDIwMDM2WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NTZiMzBiZTNiOWZmMzA1YWFjNzAzYzY3ZjNkOThhNDlkNGI1YTBjM2QxYmU4YjYzMmRlM2M1YTQzMTIzOWViYiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.cw6nE-Trb5p5j1Zx8VOQYo3d6cHJz0ZhJ7req_GrGN8">
## How Has This Been Tested?
> * npm-publish.spec.ts was updated to include a test for `readmeFilename` and `_prepared`
> * Documentation from [@npmcli/package-json](https://www.npmjs.com/package/@npmcli/package-json) suggests this should be used instead of `load()` for publishing.
> 
## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
 
## Checklist:
* [x]  My code follows the code style of this project.
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x]  I have read the **CONTRIBUTING** document.
* [x]  I have added tests to cover my changes.
* [x]  All new and existing tests passed. *
