### PR TITLE
fix(deps): replace `string-width` with `fast-string-width`

### DIFF
--- a/packages/npmlog/package.json
+++ b/packages/npmlog/package.json
@@ -39,10 +39,10 @@
     "aproba": "^2.1.0",
     "color-support": "^1.1.3",
     "console-control-strings": "^1.1.0",
+    "fast-string-width": "^2.0.0",
     "has-unicode": "catalog:",
     "set-blocking": "^2.0.0",
     "signal-exit": "^4.1.0",
-    "string-width": "^7.2.0",
     "wide-align": "^1.1.5"
   },
   "devDependencies": {

--- a/packages/npmlog/src/gauge/progress-bar.ts
+++ b/packages/npmlog/src/gauge/progress-bar.ts
@@ -3,7 +3,7 @@
  */
 
 import validate from 'aproba';
-import stringWidth from 'string-width';
+import stringWidth from 'fast-string-width';
 
 import renderTemplate from './render-template.js';
 import { wideTruncate } from './wide-truncate.js';

--- a/packages/npmlog/src/gauge/template-item.ts
+++ b/packages/npmlog/src/gauge/template-item.ts
@@ -2,7 +2,7 @@
  * Inlined from deprecated package https://github.com/npm/gauge/blob/f8092518a47ac6a96027ae3ad97d0251ffe7643b
  */
 
-import stringWidth from 'string-width';
+import stringWidth from 'fast-string-width';
 
 function isPercent(num) {
   if (typeof num !== 'string') {

--- a/packages/npmlog/src/gauge/wide-truncate.ts
+++ b/packages/npmlog/src/gauge/wide-truncate.ts
@@ -4,7 +4,7 @@
 
 import { stripVTControlCharacters } from 'node:util';
 
-import stringWidth from 'string-width';
+import stringWidth from 'fast-string-width';
 
 export function wideTruncate(str: string, target: number) {
   if (stringWidth(str) === 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,9 @@ importers:
       console-control-strings:
         specifier: ^1.1.0
         version: 1.1.0
+      fast-string-width:
+        specifier: ^2.0.0
+        version: 2.0.0
       has-unicode:
         specifier: 'catalog:'
         version: 2.0.1
@@ -547,9 +550,6 @@ importers:
       signal-exit:
         specifier: ^4.1.0
         version: 4.1.0
-      string-width:
-        specifier: ^7.2.0
-        version: 7.2.0
       wide-align:
         specifier: ^1.1.5
         version: 1.1.5
@@ -2190,6 +2190,12 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-string-truncated-width@2.0.1:
+    resolution: {integrity: sha512-Pl/IUsHVYft5xJvj6JaNv77Eg7BSva53V0SA7wPy5x3FfM7zgORdpGkUZiWoSJFuvK6qNVdh//lx1g3SYIJ10g==}
+
+  fast-string-width@2.0.0:
+    resolution: {integrity: sha512-MetuLALooM2IyKKu9xUQsI7n5ftbhQbhDUX/ROcvtlHNHkwDaB87fEwMhXxiUVKEpdAlBE3E1hvyiti7zUvVfQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -5033,6 +5039,12 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-string-truncated-width@2.0.1: {}
+
+  fast-string-width@2.0.0:
+    dependencies:
+      fast-string-truncated-width: 2.0.1
 
   fastq@1.19.1:
     dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

replace `string-width` with a smaller alternative `fast-string-width` in our `npmlog` inline package

## Motivation and Context

`fast-string-width` has a [pkg-size](https://pkg-size.dev/fast-string-width) of 15Kb with only has 2 dependencies and `string-width` has a [pkg-size](https://pkg-size.dev/string-width) of 65Kb with 5 dependencies. 

This change was suggested by the e18e initiative to lower package size
https://github.com/e18e/ecosystem-issues/issues/194

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
