### PR TITLE
fix: all dependencies with Catalog protocol should be replaced

### DIFF
--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -743,7 +743,7 @@ describe('Package', () => {
 
     describe('Version with `catalog:` protocol', () => {
       it('works with `catalog:` protocol', () => {
-        const pkg = factory({
+        const node = factory({
           dependencies: {
             a: 'catalog:^1.0.0',
             b: '^2.2.0',
@@ -753,9 +753,9 @@ describe('Package', () => {
         const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.catalogSpec = 'catalog:';
 
-        pkg.updateDependencyCatalogProtocol(resolved);
+        node.resolveDependencyCatalogProtocol(node.pkg, { catalog: { a: '^1.0.0' }, catalogs: {} });
 
-        expect(pkg.toJSON()).toMatchInlineSnapshot(`
+        expect(node.toJSON()).toMatchInlineSnapshot(`
           {
             "dependencies": {
               "a": "^1.0.0",
@@ -766,7 +766,7 @@ describe('Package', () => {
       });
 
       it('works with `catalog:` protocol in multiple location like dependencies and peerDependencies', () => {
-        const pkg = factory({
+        const node = factory({
           dependencies: {
             a: 'catalog:',
             b: 'catalog:devDependencies',
@@ -779,15 +779,10 @@ describe('Package', () => {
           },
         });
 
-        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
-        resolvedA.catalogSpec = 'catalog:';
-        const resolvedB: NpaResolveResult = npa.resolve('b', '^2.2.0', '.');
-        resolvedB.catalogSpec = 'catalog:devDependencies';
+        node.resolveDependencyCatalogProtocol(node.pkg, { catalog: { a: '^1.0.0' }, catalogs: { devDependencies: { b: '^2.2.0' } } });
+        node.resolveDependencyCatalogProtocol(node.pkg, { catalog: { a: '^1.0.0' }, catalogs: { devDependencies: { b: '^2.2.0' } } });
 
-        pkg.updateDependencyCatalogProtocol(resolvedA);
-        pkg.updateDependencyCatalogProtocol(resolvedB);
-
-        expect(pkg.toJSON()).toMatchInlineSnapshot(`
+        expect(node.toJSON()).toMatchInlineSnapshot(`
           {
             "dependencies": {
               "a": "^1.0.0",
@@ -950,7 +945,7 @@ describe('Package', () => {
 
     describe('Publish with `catalog:` protocol', () => {
       it('should replace `catalog:` protocol with what it found in npa', () => {
-        const pkg = factory({
+        const node = factory({
           dependencies: {
             a: 'catalog:',
             b: 'catalog:devDependencies',
@@ -961,15 +956,10 @@ describe('Package', () => {
           },
         });
 
-        const resolvedA: NpaResolveResult = npa.resolve('a', '1.0.0', '.');
-        resolvedA.catalogSpec = 'catalog:';
-        const resolvedB: NpaResolveResult = npa.resolve('b', '^2.2.0', '.');
-        resolvedB.catalogSpec = 'catalog:devDependencies';
+        node.resolveDependencyCatalogProtocol(node.pkg, { catalog: { a: '1.0.0' }, catalogs: { devDependencies: { b: '^2.2.0' } } });
+        node.resolveDependencyCatalogProtocol(node.pkg, { catalog: { a: '1.0.0' }, catalogs: { devDependencies: { b: '^2.2.0' } } });
 
-        pkg.updateDependencyCatalogProtocol(resolvedA);
-        pkg.updateDependencyCatalogProtocol(resolvedB);
-
-        expect(pkg.toJSON()).toMatchInlineSnapshot(`
+        expect(node.toJSON()).toMatchInlineSnapshot(`
           {
             "dependencies": {
               "a": "1.0.0",

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -24,6 +24,7 @@ import {
   prereleaseIdFromVersion,
   promptConfirmation,
   pulseTillDone,
+  readWorkspaceCatalogConfig,
   runTopologically,
   throwIfUncommitted,
   ValidationError,
@@ -665,27 +666,13 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
   // resolve `catalog:` protocol from both local/external dependencies and translates them to their actual version target/range
   resolveDependencyWithCatalogProtocols() {
+    const { catalog, catalogs } = readWorkspaceCatalogConfig(this.options.npmClient || 'npm');
+
     // detect if any of the packages to publish have `catalog:` protocol in their dependencies
-    const publishingPackagesWithCatalogs = this.updates.filter(
-      (node: PackageGraphNode) =>
-        Array.from<NpaResolveResult>(node.externalDependencies.values()).some((resolved) => resolved.catalogSpec) ||
-        Array.from<NpaResolveResult>(node.localDependencies.values()).some((resolved) => resolved.catalogSpec)
-    );
-
-    return pMap(publishingPackagesWithCatalogs, (node: PackageGraphNode) => {
-      // regardless of where the version comes from, we can't publish 'catalog:' specs, it has to be transformed for any dependencies
-      // e.g. considering version is `^1.2.3` and we have a global `catalog:` it will be converted to version "^1.2.3" with strict match
-
-      // update catalog version with global catalog version of external dependencies
-      const externalDeps = Array.from<NpaResolveResult>(node.externalDependencies.values()).filter((node) => node.catalogSpec);
-      const localDeps = Array.from<NpaResolveResult>(node.localDependencies.values()).filter((node) => node.catalogSpec);
-      for (const deps of [externalDeps, localDeps]) {
-        for (const resolved of deps) {
-          // it no longer matters if we mutate the shared Package instance
-          node.pkg.updateDependencyCatalogProtocol(resolved);
-        }
-      }
-
+    // regardless of where the version comes from, we can't publish 'catalog:' specs, it has to be transformed for any dependencies
+    // e.g. considering version is `^1.2.3` and we have a global `catalog:` it will be converted to version "^1.2.3" with strict match
+    return pMap(this.updates, (node: PackageGraphNode) => {
+      node.pkg.resolveDependencyCatalogProtocol(node.pkg, { catalog, catalogs });
       // writing changes to disk handled in serializeChanges()
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Anytime a dependency that has `catalog:` protocol is found, it should be replaced with the correct semver range found in the global catalog. 

## Motivation and Context

I found that using `npm-package-arg` wasn't always finding all dependencies that have `catalog:` protocols and by such in some rare occasions a couple of catalog semver range remained. This only happened on packages that had catalog on the same dependency name in multiple dependency types (e.g. dependency `"react": "catalog:"` found in 3 different categories like `dependencies`, `devDependencies` and `peerDependencies`)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
