### PR TITLE
chore: replace deprecated typescript-eslint config fn

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,11 +1,12 @@
 import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
-import n from 'eslint-plugin-n';
-import eslintPrettier from 'eslint-config-prettier';
-import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import vitest from '@vitest/eslint-plugin';
+import { defineConfig } from 'eslint/config';
+import n from 'eslint-plugin-n';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslintPrettier from 'eslint-config-prettier';
+import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: ['**/*.{js,mjs,json,md}', '**/*/*.d.ts', '**/dist/*', '**/__helpers__/**/*.*', '**/__mocks__/**/*.*'],
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace a simple typescript-eslint config with newer approach

## Motivation and Context

Just migrate a typescript-eslint config call to the newer approach since the previous approach was tagged as deprecated, see
https://typescript-eslint.io/packages/typescript-eslint/#config-deprecated

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
