### PR TITLE
fix: supports catalogs.default

### DIFF
--- a/packages/core/src/package-graph/package-graph.ts
+++ b/packages/core/src/package-graph/package-graph.ts
@@ -111,7 +111,8 @@ export class PackageGraph extends Map<string, PackageGraphNode> {
         if (isCatalogSpec) {
           originalCatalogSpec = spec;
           spec = spec.replace(/^catalog:/, '');
-          const catalogVersion = spec === '' || spec === 'default' ? catalog[depName] : catalogs[spec]?.[depName];
+          const catalogVersion =
+            spec === '' || spec === 'default' ? (catalog[depName] ?? catalogs?.default?.[depName]) : catalogs[spec]?.[depName];
 
           if (catalogVersion) {
             spec = catalogVersion;

--- a/packages/core/src/utils/catalog-utils.ts
+++ b/packages/core/src/utils/catalog-utils.ts
@@ -6,10 +6,18 @@ import { parse as yamlParse } from 'yaml';
 import type { NpmClient } from '../models/interfaces.js';
 import { looselyJsonParse } from './object-utils.js';
 
-export type CatalogConfig = {
-  catalog: Record<string, string>;
-  catalogs: Record<string, Record<string, string>>;
-};
+export type CatalogConfig =
+  | {
+      catalog: Record<string, string>;
+      catalogs: Record<string, Record<string, string>>;
+    }
+  | {
+      catalog: Record<string, never>;
+      catalogs: {
+        default: Record<string, string>;
+        [key: string]: Record<string, string>;
+      };
+    };
 
 /**
  * Extract catalog config from `pnpm-workspace.yaml` located in the project root.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `pnpm catalog` implementation only looks at catalog when dependency versions are set to `catalog:` or `catalog:default`.

However when using named catalog, `default` catalog can either be `catalog` or `catalogs.default`

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In this PR I fallback to `catalogs.default[depName]` when catalog doesn't contain the expected version.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

We currently use a patched version of lerna `@lerna-lite/core@4.4.1` with this change in production, and I added a few unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [x] All new and existing tests passed.
