### PR TITLE
fix(deps): replace console-control-strings/color-support w/tinyrainbow in npmlog

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
-      "args": ["run", "${relativeFile}", "--no-color", "--pool", "forks", "--no-watch", "--config", "./vitest/vitest.config.ts"],
+      "args": ["run", "${relativeFile}", "--pool", "forks", "--no-watch", "--config", "./vitest/vitest.config.ts"],
       "smartStep": true,
       "console": "integratedTerminal"
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,17 @@
       "console": "integratedTerminal"
     },
     {
+      "name": "Vitest with Color (npmlog) - Debug Current Test File",
+      "type": "node",
+      "request": "launch",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+      "args": ["run", "${relativeFile}", "--pool", "forks", "--no-watch", "--config", "./vitest/vitest.color.config.ts"],
+      "smartStep": true,
+      "console": "integratedTerminal"
+    },
+    {
       "name": "Version command debugger",
       "type": "node",
       "request": "launch",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "test": "vitest --coverage --config ./vitest/vitest.config.ts",
     "test:watch": "vitest --watch --config ./vitest/vitest.config.ts",
     "posttest": "pnpm clean:temp",
-    "test:coverage:update": "vitest --coverage --update --config ./vitest/vitest.config.ts"
+    "test:coverage:update": "vitest --coverage --update --config ./vitest/vitest.config.ts",
+    "test:npmlog-color": "vitest run packages/npmlog/src/__tests__/npmlog-basic.spec.ts --config ./vitest/vitest.color.config.ts",
+    "test:npmlog-plumbing": "vitest run packages/npmlog/src/gauge/__tests__/plumbing.spec.ts --config ./vitest/vitest.color.config.ts"
   },
   "homepage": "https://github.com/lerna-lite/lerna-lite",
   "repository": {

--- a/packages/core/src/filter-packages/lib/filter-packages.ts
+++ b/packages/core/src/filter-packages/lib/filter-packages.ts
@@ -1,7 +1,6 @@
 import util from 'node:util';
 
-import type { Package } from '@lerna-lite/core';
-import { ValidationError } from '@lerna-lite/core';
+import { type Package, ValidationError } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import zeptomatch from 'zeptomatch';
 

--- a/packages/npmlog/package.json
+++ b/packages/npmlog/package.json
@@ -43,8 +43,5 @@
     "signal-exit": "^4.1.0",
     "tinyrainbow": "catalog:dependencies",
     "wide-align": "^1.1.5"
-  },
-  "devDependencies": {
-    "strip-ansi": "^7.1.2"
   }
 }

--- a/packages/npmlog/package.json
+++ b/packages/npmlog/package.json
@@ -43,5 +43,8 @@
     "signal-exit": "^4.1.0",
     "tinyrainbow": "catalog:dependencies",
     "wide-align": "^1.1.5"
+  },
+  "devDependencies": {
+    "strip-ansi": "^7.1.2"
   }
 }

--- a/packages/npmlog/package.json
+++ b/packages/npmlog/package.json
@@ -37,12 +37,11 @@
   },
   "dependencies": {
     "aproba": "^2.1.0",
-    "color-support": "^1.1.3",
-    "console-control-strings": "^1.1.0",
     "fast-string-width": "^3.0.1",
     "has-unicode": "catalog:",
     "set-blocking": "^2.0.0",
     "signal-exit": "^4.1.0",
+    "tinyrainbow": "catalog:dependencies",
     "wide-align": "^1.1.5"
   },
   "devDependencies": {

--- a/packages/npmlog/src/__tests__/npmlog-basic.spec.ts
+++ b/packages/npmlog/src/__tests__/npmlog-basic.spec.ts
@@ -567,6 +567,11 @@ describe('Basic Tests', () => {
       log.stream = s;
     });
 
+    test('no style', () => {
+      const o = log._format('test message');
+      expect(o).toBe('test message');
+    });
+
     test('fg', () => {
       log.enableColor();
       const o = log._format('test message', { bg: 'blue' });

--- a/packages/npmlog/src/__tests__/npmlog-basic.spec.ts
+++ b/packages/npmlog/src/__tests__/npmlog-basic.spec.ts
@@ -570,7 +570,7 @@ describe('Basic Tests', () => {
 
     test('no style', () => {
       const o = log._format('test message');
-      expect(o).toBe('test message\x1b[0m\x1b[0m'); // text + reset
+      expect(o).toBe(normalizeAnsi('test message\x1b[0m\x1b[0m')); // text + reset
     });
 
     test('fg', () => {

--- a/packages/npmlog/src/__tests__/npmlog-basic.spec.ts
+++ b/packages/npmlog/src/__tests__/npmlog-basic.spec.ts
@@ -2,8 +2,8 @@
  * Adapted from https://github.com/npm/npmlog/blob/756bd05d01e7e4841fba25204d6b85dfcffeba3c/test/basic.js
  */
 import { Stream, Writable } from 'node:stream';
+import { stripVTControlCharacters } from 'node:util';
 
-import stripAnsi from 'strip-ansi';
 import c from 'tinyrainbow';
 import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -14,7 +14,7 @@ function normalizeAnsi(str: string) {
   if (c.isColorSupported) {
     return str;
   }
-  return stripAnsi(str);
+  return stripVTControlCharacters(str);
 }
 
 const result: any[] = [];

--- a/packages/npmlog/src/__tests__/npmlog-basic.spec.ts
+++ b/packages/npmlog/src/__tests__/npmlog-basic.spec.ts
@@ -23,24 +23,25 @@ const logInfoEvents: any[] = [];
 const logPrefixEvents: any[] = [];
 
 const resultExpect = [
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[7msill\x1b[27m\x1b[0m\x1b[0m \x1b[35msilly prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[36mverb\x1b[39m\x1b[0m\x1b[0m \x1b[35mverbose prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[32minfo\x1b[39m\x1b[0m\x1b[0m \x1b[35minfo prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[32mtiming\x1b[39m\x1b[0m\x1b[0m \x1b[35mtiming prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[32mhttp\x1b[39m\x1b[0m\x1b[0m \x1b[35mhttp prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[36mnotice\x1b[39m\x1b[0m\x1b[0m \x1b[35mnotice prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[43m\x1b[30mWARN\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[35mwarn prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[31mERR!\x1b[39m\x1b[0m\x1b[0m \x1b[35merror prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[32minfo\x1b[39m\x1b[0m\x1b[0m \x1b[35minfo prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[32mtiming\x1b[39m\x1b[0m\x1b[0m \x1b[35mtiming prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[32mhttp\x1b[39m\x1b[0m\x1b[0m \x1b[35mhttp prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[36mnotice\x1b[39m\x1b[0m\x1b[0m \x1b[35mnotice prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[43m\x1b[30mWARN\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[35mwarn prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[31mERR!\x1b[39m\x1b[0m\x1b[0m \x1b[35merror prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[31mERR!\x1b[39m\x1b[0m\x1b[0m \x1b[35m404\x1b[39m\x1b[0m\x1b[0m This is a longer\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[31mERR!\x1b[39m\x1b[0m\x1b[0m \x1b[35m404\x1b[39m\x1b[0m\x1b[0m message, with some details\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[31mERR!\x1b[39m\x1b[0m\x1b[0m \x1b[35m404\x1b[39m\x1b[0m\x1b[0m and maybe a stack.\n',
-  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[31mERR!\x1b[39m\x1b[0m\x1b[0m \x1b[35m404\x1b[39m\x1b[0m\x1b[0m \n',
+  '\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[7msill\x1b[27m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35msilly prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[36mverb\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mverbose prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[32minfo\x1b[39m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35minfo prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[32mtiming\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mtiming prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[32mhttp\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mhttp prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[36mnotice\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mnotice prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[43m\x1b[30mWARN\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mwarn prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[31mERR!\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35merror prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[32minfo\x1b[39m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35minfo prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[32mtiming\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mtiming prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[32mhttp\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mhttp prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[36mnotice\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mnotice prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[43m\x1b[30mWARN\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35mwarn prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[31mERR!\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35merror prefix\x1b[39m\x1b[0m\x1b[0m x = {"foo":{"bar":"baz"}}\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[31mERR!\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35m404\x1b[39m\x1b[0m\x1b[0m This is a longer\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[31mERR!\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35m404\x1b[39m\x1b[0m\x1b[0m message, with some details\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[31mERR!\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35m404\x1b[39m\x1b[0m\x1b[0m and maybe a stack.\n',
+  '\x1b[0m\x1b[0m\x1b[40m\x1b[37mnpm\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[40m\x1b[31mERR!\x1b[39m\x1b[49m\x1b[0m\x1b[0m \x1b[0m\x1b[0m\x1b[35m404\x1b[39m\x1b[0m\x1b[0m \n',
+  '\x1b[0m\x1b[0m',
 ];
 
 const logPrefixEventsExpect = [
@@ -569,7 +570,7 @@ describe('Basic Tests', () => {
 
     test('no style', () => {
       const o = log._format('test message');
-      expect(o).toBe('test message');
+      expect(o).toBe('test message\x1b[0m\x1b[0m'); // text + reset
     });
 
     test('fg', () => {

--- a/packages/npmlog/src/__tests__/npmlog-progress.spec.ts
+++ b/packages/npmlog/src/__tests__/npmlog-progress.spec.ts
@@ -70,7 +70,7 @@ describe('log module', () => {
       },
     } as unknown as Gauge;
 
-    // In the original implementation, the tests were performed using tap which does not set color, so force disable it in jest too to keep assertions consistent
+    // In the original implementation, the tests were performed using tap which does not set color, so force disable it in vitest too to keep assertions consistent
     log.useColor = () => false;
     log.disableProgress();
     log.resume();

--- a/packages/npmlog/src/gauge/__tests__/index.spec.ts
+++ b/packages/npmlog/src/gauge/__tests__/index.spec.ts
@@ -5,14 +5,19 @@ import { describe, expect, it } from 'vitest';
 
 import { Gauge } from '../index.js';
 
-function Sink(this: any) {
-  Writable.call(this, {});
+class Sink extends Writable {
+  isTTY: boolean = false;
+  columns: number = 80;
+
+  constructor() {
+    super({});
+  }
+
+  // `_write` just acknowledges the chunk
+  _write(_data: any, _enc: any, cb: () => void): void {
+    cb();
+  }
 }
-Sink.prototype = Object.create(Writable.prototype);
-Sink.prototype.constructor = Sink;
-Sink.prototype._write = function (data: any, enc: any, cb: () => void) {
-  cb();
-};
 
 const results: any = new EventEmitter();
 function MockPlumbing(theme: any, template: any, columns: any) {
@@ -50,7 +55,7 @@ describe('defaults', () => {
     }
     gauge.disable();
 
-    gauge = new Gauge(new Sink());
+    gauge = new (Gauge as any)(new Sink() as any);
     expect(gauge._tty).toBeUndefined();
     gauge.disable();
   });

--- a/packages/npmlog/src/gauge/__tests__/plumbing.spec.ts
+++ b/packages/npmlog/src/gauge/__tests__/plumbing.spec.ts
@@ -1,6 +1,15 @@
+import stripAnsi from 'strip-ansi';
+import c from 'tinyrainbow';
 import { describe, expect, it, vi } from 'vitest';
 
 import { Plumbing } from '../plumbing.js';
+
+function normalizeAnsi(str: string) {
+  if (c.isColorSupported) {
+    return str;
+  }
+  return stripAnsi(str);
+}
 
 vi.mock('../render-template.js', () => ({
   default: (width: string, template: any, values: { x: any }) => {
@@ -9,11 +18,6 @@ vi.mock('../render-template.js', () => ({
       values.x = values.x;
     } // pull in from parent object for stringify
     return 'w:' + width + ', t:' + JSON.stringify(template) + ', v:' + JSON.stringify(values);
-  },
-}));
-vi.mock('tinyrainbow', () => ({
-  default: {
-    reset: () => 'COLOR:reset',
   },
 }));
 
@@ -56,26 +60,31 @@ describe('Plumbing static methods', () => {
   });
 
   it('show', () => {
-    expect(plumbing.show({ name: 'test' })).toBe('w:10, t:[{"type":"name"}], v:{"name":"test"}COLOR:resetERASECR');
+    const output = plumbing.show({ name: 'test' });
+    expect(output).toBe(normalizeAnsi('w:10, t:[{"type":"name"}], v:{"name":"test"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
   });
 
   it('width', () => {
     const defaultWidth = new Plumbing(theme, template);
-    expect(defaultWidth.show({ name: 'test' })).toBe('w:80, t:[{"type":"name"}], v:{"name":"test"}COLOR:resetERASECR');
+    const output = defaultWidth.show({ name: 'test' });
+    expect(output).toBe(normalizeAnsi('w:80, t:[{"type":"name"}], v:{"name":"test"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
   });
 
   it('setTheme', () => {
     plumbing.setTheme({ x: 'abc' });
-    expect(plumbing.show({ name: 'test' })).toBe('w:10, t:[{"type":"name"}], v:{"name":"test","x":"abc"}COLOR:resetERASECR');
+    const output = plumbing.show({ name: 'test' });
+    expect(output).toBe(normalizeAnsi('w:10, t:[{"type":"name"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
   });
 
   it('setTemplate', () => {
     plumbing.setTemplate([{ type: 'name' }, { type: 'x' }]);
-    expect(plumbing.show({ name: 'test' })).toBe('w:10, t:[{"type":"name"},{"type":"x"}], v:{"name":"test","x":"abc"}COLOR:resetERASECR');
+    const output = plumbing.show({ name: 'test' });
+    expect(output).toBe(normalizeAnsi('w:10, t:[{"type":"name"},{"type":"x"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
   });
 
   it('setWidth', () => {
     plumbing.setWidth(20);
-    expect(plumbing.show({ name: 'test' })).toBe('w:20, t:[{"type":"name"},{"type":"x"}], v:{"name":"test","x":"abc"}COLOR:resetERASECR');
+    const output = plumbing.show({ name: 'test' });
+    expect(output).toBe(normalizeAnsi('w:20, t:[{"type":"name"},{"type":"x"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
   });
 });

--- a/packages/npmlog/src/gauge/__tests__/plumbing.spec.ts
+++ b/packages/npmlog/src/gauge/__tests__/plumbing.spec.ts
@@ -1,4 +1,5 @@
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'node:util';
+
 import c from 'tinyrainbow';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -8,7 +9,7 @@ function normalizeAnsi(str: string) {
   if (c.isColorSupported) {
     return str;
   }
-  return stripAnsi(str);
+  return stripVTControlCharacters(str);
 }
 
 vi.mock('../render-template.js', () => ({
@@ -43,7 +44,7 @@ describe('Plumbing static methods', () => {
 
   it('show', () => {
     const output = plumbing.show({ name: 'test' });
-    const result = normalizeAnsi('w:10, t:[{"type":"name"}], v:{"name":"test"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G')
+    const result = normalizeAnsi('w:10, t:[{"type":"name"}], v:{"name":"test"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G');
     expect(output).toEqual(result);
   });
 

--- a/packages/npmlog/src/gauge/__tests__/plumbing.spec.ts
+++ b/packages/npmlog/src/gauge/__tests__/plumbing.spec.ts
@@ -11,15 +11,32 @@ vi.mock('../render-template.js', () => ({
     return 'w:' + width + ', t:' + JSON.stringify(template) + ', v:' + JSON.stringify(values);
   },
 }));
-vi.mock('console-control-strings', () => ({
+vi.mock('tinyrainbow', () => ({
   default: {
-    eraseLine: () => 'ERASE',
-    gotoSOL: () => 'CR',
-    color: (to: string) => 'COLOR:' + to,
-    hideCursor: () => 'HIDE',
-    showCursor: () => 'SHOW',
+    reset: () => 'COLOR:reset',
   },
 }));
+
+// Mock console control codes
+vi.mock('../plumbing.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../plumbing.js')>();
+  return {
+    ...actual,
+    Plumbing: class extends actual.Plumbing {
+      hideCursor() {
+        return 'HIDE';
+      }
+
+      showCursor() {
+        return 'SHOW';
+      }
+
+      hide() {
+        return 'CRERASE';
+      }
+    },
+  };
+});
 
 const template = [{ type: 'name' }];
 const theme = {};

--- a/packages/npmlog/src/gauge/__tests__/plumbing.spec.ts
+++ b/packages/npmlog/src/gauge/__tests__/plumbing.spec.ts
@@ -21,70 +21,57 @@ vi.mock('../render-template.js', () => ({
   },
 }));
 
-// Mock console control codes
-vi.mock('../plumbing.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../plumbing.js')>();
-  return {
-    ...actual,
-    Plumbing: class extends actual.Plumbing {
-      hideCursor() {
-        return 'HIDE';
-      }
-
-      showCursor() {
-        return 'SHOW';
-      }
-
-      hide() {
-        return 'CRERASE';
-      }
-    },
-  };
-});
-
 const template = [{ type: 'name' }];
 const theme = {};
 const plumbing = new Plumbing(theme, template, 10);
 
 describe('Plumbing static methods', () => {
   it('showCursor', () => {
-    expect(plumbing.showCursor()).toBe('SHOW');
+    const expected = '\x1b[?25h';
+    expect(plumbing.showCursor()).toBe(expected);
   });
 
   it('hideCursor', () => {
-    expect(plumbing.hideCursor()).toBe('HIDE');
+    const expected = '\x1b[?25l';
+    expect(plumbing.hideCursor()).toBe(expected);
   });
 
   it('hide', () => {
-    expect(plumbing.hide()).toBe('CRERASE');
+    const expected = '\x1b[0G\x1b[2K';
+    expect(plumbing.hide()).toBe(expected);
   });
 
   it('show', () => {
     const output = plumbing.show({ name: 'test' });
-    expect(output).toBe(normalizeAnsi('w:10, t:[{"type":"name"}], v:{"name":"test"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
+    const result = normalizeAnsi('w:10, t:[{"type":"name"}], v:{"name":"test"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G')
+    expect(output).toEqual(result);
   });
 
   it('width', () => {
     const defaultWidth = new Plumbing(theme, template);
     const output = defaultWidth.show({ name: 'test' });
-    expect(output).toBe(normalizeAnsi('w:80, t:[{"type":"name"}], v:{"name":"test"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
+    const result = normalizeAnsi('w:80, t:[{"type":"name"}], v:{"name":"test"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G');
+    expect(output).toEqual(result);
   });
 
   it('setTheme', () => {
     plumbing.setTheme({ x: 'abc' });
     const output = plumbing.show({ name: 'test' });
-    expect(output).toBe(normalizeAnsi('w:10, t:[{"type":"name"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
+    const result = normalizeAnsi('w:10, t:[{"type":"name"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G');
+    expect(output).toEqual(result);
   });
 
   it('setTemplate', () => {
     plumbing.setTemplate([{ type: 'name' }, { type: 'x' }]);
     const output = plumbing.show({ name: 'test' });
-    expect(output).toBe(normalizeAnsi('w:10, t:[{"type":"name"},{"type":"x"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
+    const result = normalizeAnsi('w:10, t:[{"type":"name"},{"type":"x"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G');
+    expect(output).toEqual(result);
   });
 
   it('setWidth', () => {
     plumbing.setWidth(20);
     const output = plumbing.show({ name: 'test' });
-    expect(output).toBe(normalizeAnsi('w:20, t:[{"type":"name"},{"type":"x"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G'));
+    const result = normalizeAnsi('w:20, t:[{"type":"name"},{"type":"x"}], v:{"name":"test","x":"abc"}\x1b[0m\x1b[0m\x1b[2K\x1b[0G');
+    expect(output).toEqual(result);
   });
 });

--- a/packages/npmlog/src/gauge/has-color.ts
+++ b/packages/npmlog/src/gauge/has-color.ts
@@ -2,6 +2,6 @@
  * Inlined from deprecated package https://github.com/npm/gauge/blob/f8092518a47ac6a96027ae3ad97d0251ffe7643b
  */
 
-import colorSupport from 'color-support';
+import c from 'tinyrainbow';
 
-export default colorSupport().hasBasic;
+export default c.isColorSupported;

--- a/packages/npmlog/src/gauge/plumbing.ts
+++ b/packages/npmlog/src/gauge/plumbing.ts
@@ -59,11 +59,10 @@ export class Plumbing {
       values[key] = status[key];
     }
 
-    return (
-      renderTemplate(this.width, this.template, values).trim() +
-      c.reset('') +
-      '\x1b[2K' + // Erase line
-      '\x1b[0G' // Move to SOL
-    );
+    let out = renderTemplate(this.width, this.template, values).trim() + c.reset('');
+    if (c.isColorSupported) {
+      out += '\x1b[2K' + '\x1b[0G';
+    }
+    return out;
   }
 }

--- a/packages/npmlog/src/gauge/plumbing.ts
+++ b/packages/npmlog/src/gauge/plumbing.ts
@@ -23,7 +23,6 @@ export class Plumbing {
     this.width = width;
     this.template = template;
   }
-
   setTheme(theme) {
     validate('O', [theme]);
     this.theme = theme;
@@ -40,19 +39,18 @@ export class Plumbing {
   }
 
   hideCursor() {
-    // Note: tinyrainbow doesn't have direct console control methods
-    // You might need to use process.stdout.write or a separate library for cursor control
-    return '\x1B[?25l';
+    // ANSI: Hide cursor
+    return '\x1b[?25l';
   }
 
   showCursor() {
-    // Corresponding show cursor ANSI escape code
-    return '\x1B[?25h';
+    // ANSI: Show cursor
+    return '\x1b[?25h';
   }
 
   hide() {
-    // Go to start of line and erase line
-    return '\x1B[G\x1B[K';
+    // ANSI: Move to SOL and erase line
+    return '\x1b[0G\x1b[2K';
   }
 
   show(status) {
@@ -63,9 +61,9 @@ export class Plumbing {
 
     return (
       renderTemplate(this.width, this.template, values).trim() +
-      c.reset() +
-      '\x1B[K' + // Erase line (equivalent to consoleControl.eraseLine())
-      '\x1B[G' // Go to start of line (equivalent to consoleControl.gotoSOL())
+      c.reset('') +
+      '\x1b[2K' + // Erase line
+      '\x1b[0G' // Move to SOL
     );
   }
 }

--- a/packages/npmlog/src/gauge/plumbing.ts
+++ b/packages/npmlog/src/gauge/plumbing.ts
@@ -3,7 +3,7 @@
  */
 
 import validate from 'aproba';
-import consoleControl from 'console-control-strings';
+import c from 'tinyrainbow';
 
 import renderTemplate from './render-template.js';
 
@@ -23,6 +23,7 @@ export class Plumbing {
     this.width = width;
     this.template = template;
   }
+
   setTheme(theme) {
     validate('O', [theme]);
     this.theme = theme;
@@ -39,15 +40,19 @@ export class Plumbing {
   }
 
   hideCursor() {
-    return consoleControl.hideCursor();
+    // Note: tinyrainbow doesn't have direct console control methods
+    // You might need to use process.stdout.write or a separate library for cursor control
+    return '\x1B[?25l';
   }
 
   showCursor() {
-    return consoleControl.showCursor();
+    // Corresponding show cursor ANSI escape code
+    return '\x1B[?25h';
   }
 
   hide() {
-    return consoleControl.gotoSOL() + consoleControl.eraseLine();
+    // Go to start of line and erase line
+    return '\x1B[G\x1B[K';
   }
 
   show(status) {
@@ -58,9 +63,10 @@ export class Plumbing {
 
     return (
       renderTemplate(this.width, this.template, values).trim() +
-      consoleControl.color('reset') +
-      consoleControl.eraseLine() +
-      consoleControl.gotoSOL()
+      c.reset() +
+      '\x1B[K' +  // Erase line (equivalent to consoleControl.eraseLine())
+      '\x1B[G'    // Go to start of line (equivalent to consoleControl.gotoSOL())
     );
   }
 }
+

--- a/packages/npmlog/src/gauge/plumbing.ts
+++ b/packages/npmlog/src/gauge/plumbing.ts
@@ -64,9 +64,8 @@ export class Plumbing {
     return (
       renderTemplate(this.width, this.template, values).trim() +
       c.reset() +
-      '\x1B[K' +  // Erase line (equivalent to consoleControl.eraseLine())
-      '\x1B[G'    // Go to start of line (equivalent to consoleControl.gotoSOL())
+      '\x1B[K' + // Erase line (equivalent to consoleControl.eraseLine())
+      '\x1B[G' // Go to start of line (equivalent to consoleControl.gotoSOL())
     );
   }
 }
-

--- a/packages/npmlog/src/gauge/themes.ts
+++ b/packages/npmlog/src/gauge/themes.ts
@@ -2,7 +2,7 @@
  * Inlined from deprecated package https://github.com/npm/gauge/blob/f8092518a47ac6a96027ae3ad97d0251ffe7643b
  */
 
-import { color } from 'console-control-strings';
+import c from 'tinyrainbow';
 
 import ThemeSet from './theme-set.js';
 
@@ -21,12 +21,12 @@ themes.addTheme('ASCII', {
 
 themes.addTheme('colorASCII', themes.getTheme('ASCII'), {
   progressbarTheme: {
-    preComplete: color('bgBrightWhite', 'brightWhite'),
+    preComplete: c.bgWhite(c.white('')),
     complete: '#',
-    postComplete: color('reset'),
-    preRemaining: color('bgBrightBlack', 'brightBlack'),
+    postComplete: c.reset(),
+    preRemaining: c.bgBlack(c.black('')),
     remaining: '.',
-    postRemaining: color('reset'),
+    postRemaining: c.reset(),
   },
 });
 
@@ -43,12 +43,12 @@ themes.addTheme('brailleSpinner', {
 
 themes.addTheme('colorBrailleSpinner', themes.getTheme('brailleSpinner'), {
   progressbarTheme: {
-    preComplete: color('bgBrightWhite', 'brightWhite'),
+    preComplete: c.bgWhite(c.white('')),
     complete: '#',
-    postComplete: color('reset'),
-    preRemaining: color('bgBrightBlack', 'brightBlack'),
+    postComplete: c.reset(),
+    preRemaining: c.bgBlack(c.black('')),
     remaining: '⠂',
-    postRemaining: color('reset'),
+    postRemaining: c.reset(),
   },
 });
 

--- a/packages/npmlog/src/npmlog.ts
+++ b/packages/npmlog/src/npmlog.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'node:events';
 import type { WriteStream } from 'node:tty';
 import { format } from 'node:util';
 
-import consoleControl from 'console-control-strings';
+import c from 'tinyrainbow';
 import setBlocking from 'set-blocking';
 
 import { TrackerGroup } from './are-we-there-yet/tracker-group.js';
@@ -81,13 +81,13 @@ export class Logger extends EventEmitter {
     this.progressEnabled = this.gauge.isEnabled();
 
     this.addLevel('silly', -Infinity, { inverse: true }, 'sill');
-    this.addLevel('verbose', 1000, { fg: 'cyan', bg: 'black' }, 'verb');
+    this.addLevel('verbose', 1000, { fg: 'cyan' }, 'verb');
     this.addLevel('info', 2000, { fg: 'green' });
-    this.addLevel('timing', 2500, { fg: 'green', bg: 'black' });
-    this.addLevel('http', 3000, { fg: 'green', bg: 'black' });
-    this.addLevel('notice', 3500, { fg: 'cyan', bg: 'black' });
+    this.addLevel('timing', 2500, { fg: 'green' });
+    this.addLevel('http', 3000, { fg: 'green' });
+    this.addLevel('notice', 3500, { fg: 'cyan' });
     this.addLevel('warn', 4000, { fg: 'black', bg: 'yellow' }, 'WARN');
-    this.addLevel('error', 5000, { fg: 'red', bg: 'black' }, 'ERR!');
+    this.addLevel('error', 5000, { fg: 'red' }, 'ERR!');
     this.addLevel('silent', Infinity);
 
     this.on('error', () => {});

--- a/packages/npmlog/src/npmlog.ts
+++ b/packages/npmlog/src/npmlog.ts
@@ -299,44 +299,44 @@ export class Logger extends EventEmitter {
     let output = msg;
 
     // Apply styling step by step
-    if (style) {
-      // Apply foreground color first
-      if (style.fg) {
-        const colorMethodName = style.fg as keyof typeof c;
-        const colorMethod = c[colorMethodName];
-        if (typeof colorMethod === 'function') {
-          output = colorMethod(output);
-        }
-      }
+    style ??= {};
 
-      // Apply background color (if supported)
-      if (style.bg) {
-        const bgColorMethodName = `bg${style.bg[0].toUpperCase() + style.bg.slice(1)}` as keyof typeof c;
-        const bgColorMethod = c[bgColorMethodName];
-        if (typeof bgColorMethod === 'function') {
-          output = bgColorMethod(output);
-        }
+    // Apply foreground color first
+    if (style.fg) {
+      const colorMethodName = style.fg as keyof typeof c;
+      const colorMethod = c[colorMethodName];
+      if (typeof colorMethod === 'function') {
+        output = colorMethod(output);
       }
+    }
 
-      // Apply bold
-      if (style.bold) {
-        output = c.bold(output);
+    // Apply background color (if supported)
+    if (style.bg) {
+      const bgColorMethodName = `bg${style.bg[0].toUpperCase() + style.bg.slice(1)}` as keyof typeof c;
+      const bgColorMethod = c[bgColorMethodName];
+      if (typeof bgColorMethod === 'function') {
+        output = bgColorMethod(output);
       }
+    }
 
-      // Apply underline
-      if (style.underline) {
-        output = c.underline(output);
-      }
+    // Apply bold
+    if (style.bold) {
+      output = c.bold(output);
+    }
 
-      // Apply inverse
-      if (style.inverse) {
-        output = c.inverse(output);
-      }
+    // Apply underline
+    if (style.underline) {
+      output = c.underline(output);
+    }
 
-      // ---------- reset ----------
-      if (this.useColor()) {
-        output += c.reset('');
-      }
+    // Apply inverse
+    if (style.inverse) {
+      output = c.inverse(output);
+    }
+
+    // ---------- reset ----------
+    if (this.useColor()) {
+      output += c.reset('');
     }
 
     return output;

--- a/packages/npmlog/src/npmlog.ts
+++ b/packages/npmlog/src/npmlog.ts
@@ -81,13 +81,13 @@ export class Logger extends EventEmitter {
     this.progressEnabled = this.gauge.isEnabled();
 
     this.addLevel('silly', -Infinity, { inverse: true }, 'sill');
-    this.addLevel('verbose', 1000, { fg: 'cyan' }, 'verb');
+    this.addLevel('verbose', 1000, { fg: 'cyan', bg: 'black' }, 'verb');
     this.addLevel('info', 2000, { fg: 'green' });
-    this.addLevel('timing', 2500, { fg: 'green' });
-    this.addLevel('http', 3000, { fg: 'green' });
-    this.addLevel('notice', 3500, { fg: 'cyan' });
+    this.addLevel('timing', 2500, { fg: 'green', bg: 'black' });
+    this.addLevel('http', 3000, { fg: 'green', bg: 'black' });
+    this.addLevel('notice', 3500, { fg: 'cyan', bg: 'black' });
     this.addLevel('warn', 4000, { fg: 'black', bg: 'yellow' }, 'WARN');
-    this.addLevel('error', 5000, { fg: 'red' }, 'ERR!');
+    this.addLevel('error', 5000, { fg: 'red', bg: 'black' }, 'ERR!');
     this.addLevel('silent', Infinity);
 
     this.on('error', () => {});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,12 +546,6 @@ importers:
       aproba:
         specifier: ^2.1.0
         version: 2.1.0
-      color-support:
-        specifier: ^1.1.3
-        version: 1.1.3
-      console-control-strings:
-        specifier: ^1.1.0
-        version: 1.1.0
       fast-string-width:
         specifier: ^3.0.1
         version: 3.0.1
@@ -564,6 +558,9 @@ importers:
       signal-exit:
         specifier: ^4.1.0
         version: 4.1.0
+      tinyrainbow:
+        specifier: catalog:dependencies
+        version: 3.0.3
       wide-align:
         specifier: ^1.1.5
         version: 1.1.5
@@ -1764,10 +1761,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
-
   columnify@1.6.0:
     resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
     engines: {node: '>=8.0.0'}
@@ -1787,9 +1780,6 @@ packages:
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
-
-  console-control-strings@1.1.0:
-    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   conventional-changelog-angular@8.0.0:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
@@ -4475,8 +4465,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-support@1.1.3: {}
-
   columnify@1.6.0:
     dependencies:
       strip-ansi: 6.0.1
@@ -4499,8 +4487,6 @@ snapshots:
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
-
-  console-control-strings@1.1.0: {}
 
   conventional-changelog-angular@8.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,10 +564,6 @@ importers:
       wide-align:
         specifier: ^1.1.5
         version: 1.1.5
-    devDependencies:
-      strip-ansi:
-        specifier: ^7.1.2
-        version: 7.1.2
 
   packages/profiler:
     dependencies:
@@ -3134,10 +3130,6 @@ packages:
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
-
-  strip-ansi@7.1.2:
-    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
   strip-final-newline@4.0.0:
@@ -5795,10 +5787,6 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-ansi@7.1.0:
-    dependencies:
-      ansi-regex: 6.2.0
-
-  strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,6 +564,10 @@ importers:
       wide-align:
         specifier: ^1.1.5
         version: 1.1.5
+    devDependencies:
+      strip-ansi:
+        specifier: ^7.1.2
+        version: 7.1.2
 
   packages/profiler:
     dependencies:
@@ -1086,8 +1090,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@napi-rs/wasm-runtime@1.0.5':
-    resolution: {integrity: sha512-TBr9Cf9onSAS2LQ2+QHx6XcC6h9+RIzJgbqG3++9TUZSH204AwEy5jg3BTQ0VATsyoGj4ee49tN/y6rvaOOtcg==}
+  '@napi-rs/wasm-runtime@1.0.6':
+    resolution: {integrity: sha512-DXj75ewm11LIWUk198QSKUTxjyRjsBwk09MuMk5DGK+GDUtyPhhEHOGP/Xwwj3DjQXXkivoBirmOnKrLfc0+9g==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1234,98 +1238,98 @@ packages:
     resolution: {integrity: sha512-Z7x2dZOmznihvdvCvLKMl+nswtOSVxS2H2ocar+U9xx6iMfTp0VGIrX6a4xB1v80IwOPC7dT1LXIJrY70Xu3Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@oxc-project/types@0.93.0':
-    resolution: {integrity: sha512-yNtwmWZIBtJsMr5TEfoZFDxIWV6OdScOpza/f5YxbqUMJk+j6QX3Cf3jgZShGEFYWQJ5j9mJ6jM0tZHu2J9Yrg==}
+  '@oxc-project/types@0.94.0':
+    resolution: {integrity: sha512-+UgQT/4o59cZfH6Cp7G0hwmqEQ0wE+AdIwhikdwnhWI9Dp8CgSY081+Q3O67/wq3VJu8mgUEB93J9EHHn70fOw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.41':
-    resolution: {integrity: sha512-Edflndd9lU7JVhVIvJlZhdCj5DkhYDJPIRn4Dx0RUdfc8asP9xHOI5gMd8MesDDx+BJpdIT/uAmVTearteU/mQ==}
+  '@rolldown/binding-android-arm64@1.0.0-beta.42':
+    resolution: {integrity: sha512-W5ZKF3TP3bOWuBfotAGp+UGjxOkGV7jRmIRbBA7NFjggx7Oi6vOmGDqpHEIX7kDCiry1cnIsWQaxNvWbMdkvzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.41':
-    resolution: {integrity: sha512-XGCzqfjdk7550PlyZRTBKbypXrB7ATtXhw/+bjtxnklLQs0mKP/XkQVOKyn9qGKSlvH8I56JLYryVxl0PCvSNw==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.42':
+    resolution: {integrity: sha512-abw/wtgJA8OCgaTlL+xJxnN/Z01BwV1rfzIp5Hh9x+IIO6xOBfPsQ0nzi0+rWx3TyZ9FZXyC7bbC+5NpQ9EaXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.41':
-    resolution: {integrity: sha512-Ho6lIwGJed98zub7n0xcRKuEtnZgbxevAmO4x3zn3C3N4GVXZD5xvCvTVxSMoeBJwTcIYzkVDRTIhylQNsTgLQ==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.42':
+    resolution: {integrity: sha512-Y/UrZIRVr8CvXVEB88t6PeC46r1K9/QdPEo2ASE/b/KBEyXIx+QbM6kv9QfQVWU2Atly2+SVsQzxQsIvuk3lZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.41':
-    resolution: {integrity: sha512-ijAZETywvL+gACjbT4zBnCp5ez1JhTRs6OxRN4J+D6AzDRbU2zb01Esl51RP5/8ZOlvB37xxsRQ3X4YRVyYb3g==}
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.42':
+    resolution: {integrity: sha512-zRM0oOk7BZiy6DoWBvdV4hyEg+j6+WcBZIMHVirMEZRu8hd18kZdJkg+bjVMfCEhwpWeFUfBfZ1qcaZ5UdYzlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.41':
-    resolution: {integrity: sha512-EgIOZt7UildXKFEFvaiLNBXm+4ggQyGe3E5Z1QP9uRcJJs9omihOnm897FwOBQdCuMvI49iBgjFrkhH+wMJ2MA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.42':
+    resolution: {integrity: sha512-6RjFaC52QNwo7ilU8C5H7swbGlgfTkG9pudXwzr3VYyT18s0C9gLg3mvc7OMPIGqNxnQ0M5lU8j6aQCk2DTRVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.41':
-    resolution: {integrity: sha512-F8bUwJq8v/JAU8HSwgF4dztoqJ+FjdyjuvX4//3+Fbe2we9UktFeZ27U4lRMXF1vxWtdV4ey6oCSqI7yUrSEeg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.42':
+    resolution: {integrity: sha512-LMYHM5Sf6ROq+VUwHMDVX2IAuEsWTv4SnlFEedBnMGpvRuQ14lCmD4m5Q8sjyAQCgyha9oghdGoK8AEg1sXZKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
-    resolution: {integrity: sha512-MioXcCIX/wB1pBnBoJx8q4OGucUAfC1+/X1ilKFsjDK05VwbLZGRgOVD5OJJpUQPK86DhQciNBrfOKDiatxNmg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.42':
+    resolution: {integrity: sha512-/bNTYb9aKNhzdbPn3O4MK2aLv55AlrkUKPE4KNfBYjkoZUfDr4jWp7gsSlvTc5A/99V1RCm9axvt616ZzeXGyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
-    resolution: {integrity: sha512-m66M61fizvRCwt5pOEiZQMiwBL9/y0bwU/+Kc4Ce/Pef6YfoEkR28y+DzN9rMdjo8Z28NXjsDPq9nH4mXnAP0g==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.42':
+    resolution: {integrity: sha512-n/SLa4h342oyeGykZdch7Y3GNCNliRPL4k5wkeZ/5eQZs+c6/ZG1SHCJQoy7bZcmxiMyaXs9HoFmv1PEKrZgWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
-    resolution: {integrity: sha512-yRxlSfBvWnnfrdtJfvi9lg8xfG5mPuyoSHm0X01oiE8ArmLRvoJGHUTJydCYz+wbK2esbq5J4B4Tq9WAsOlP1Q==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.42':
+    resolution: {integrity: sha512-4PSd46sFzqpLHSGdaSViAb1mk55sCUMpJg+X8ittXaVocQsV3QLG/uydSH8RyL0ngHX5fy3D70LcCzlB15AgHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
-    resolution: {integrity: sha512-PHVxYhBpi8UViS3/hcvQQb9RFqCtvFmFU1PvUoTRiUdBtgHA6fONNHU4x796lgzNlVSD3DO/MZNk1s5/ozSMQg==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.42':
+    resolution: {integrity: sha512-BmWoeJJyeZXmZBcfoxG6J9+rl2G7eO47qdTkAzEegj4n3aC6CBIHOuDcbE8BvhZaEjQR0nh0nJrtEDlt65Q7Sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.41':
-    resolution: {integrity: sha512-OAfcO37ME6GGWmj9qTaDT7jY4rM0T2z0/8ujdQIJQ2x2nl+ztO32EIwURfmXOK0U1tzkyuaKYvE34Pug/ucXlQ==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.42':
+    resolution: {integrity: sha512-2Ft32F7uiDTrGZUKws6CLNTlvTWHC33l4vpXrzUucf9rYtUThAdPCOt89Pmn13tNX6AulxjGEP2R0nZjTSW3eQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.41':
-    resolution: {integrity: sha512-NIYGuCcuXaq5BC4Q3upbiMBvmZsTsEPG9k/8QKQdmrch+ocSy5Jv9tdpdmXJyighKqm182nh/zBt+tSJkYoNlg==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
+    resolution: {integrity: sha512-hC1kShXW/z221eG+WzQMN06KepvPbMBknF0iGR3VMYJLOe9gwnSTfGxFT5hf8XrPv7CEZqTWRd0GQpkSHRbGsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.41':
-    resolution: {integrity: sha512-kANdsDbE5FkEOb5NrCGBJBCaZ2Sabp3D7d4PRqMYJqyLljwh9mDyYyYSv5+QNvdAmifj+f3lviNEUUuUZPEFPw==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.42':
+    resolution: {integrity: sha512-AICBYromawouGjj+GS33369E8Vwhy6UwhQEhQ5evfS8jPCsyVvoICJatbDGDGH01dwtVGLD5eDFzPicUOVpe4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.41':
-    resolution: {integrity: sha512-UlpxKmFdik0Y2VjZrgUCgoYArZJiZllXgIipdBRV1hw6uK45UbQabSTW6Kp6enuOu7vouYWftwhuxfpE8J2JAg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
+    resolution: {integrity: sha512-XpZ0M+tjoEiSc9c+uZR7FCnOI0uxDRNs1elGOMjeB0pUP1QmvVbZGYNsyLbLoP4u7e3VQN8rie1OQ8/mB6rcJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.41':
-    resolution: {integrity: sha512-ycMEPrS3StOIeb87BT3/+bu+blEtyvwQ4zmo2IcJQy0Rd1DAAhKksA0iUZ3MYSpJtjlPhg0Eo6mvVS6ggPhRbw==}
+  '@rolldown/pluginutils@1.0.0-beta.42':
+    resolution: {integrity: sha512-N7pQzk9CyE7q0bBN/q0J8s6Db279r5kUZc6d7/wWRe9/zXqC52HQovVyu6iXPIDY4BEzzgbVLhVFXrOuGJ22ZQ==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -2969,8 +2973,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rolldown-vite@7.1.15:
-    resolution: {integrity: sha512-3Vc9x/pnTBjTD2e5sQiVFOvZlouQBSvuxYhlQPUyNoNPSShs6LN/65eKnJsTj9vZDZju/YjMZ5ZPrbOW/n4FDA==}
+  rolldown-vite@7.1.16:
+    resolution: {integrity: sha512-cK6tCmZyEC0KRAcXTjQ+ara+wkqmaE7WUoI0ZfZzDuvaRaZ3mtvbhTJc4cH+PjKRok++++Z1bZZaNlf3+SnnGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3009,8 +3013,8 @@ packages:
       yaml:
         optional: true
 
-  rolldown@1.0.0-beta.41:
-    resolution: {integrity: sha512-U+NPR0Bkg3wm61dteD2L4nAM1U9dtaqVrpDXwC36IKRHpEO/Ubpid4Nijpa2imPchcVNHfxVFwSSMJdwdGFUbg==}
+  rolldown@1.0.0-beta.42:
+    resolution: {integrity: sha512-xaPcckj+BbJhYLsv8gOqezc8EdMcKKe/gk8v47B0KPvgABDrQ0qmNPAiT/gh9n9Foe0bUkEv2qzj42uU5q1WRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3130,6 +3134,10 @@ packages:
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
   strip-final-newline@4.0.0:
@@ -3649,7 +3657,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.0.5':
+  '@napi-rs/wasm-runtime@1.0.6':
     dependencies:
       '@emnapi/core': 1.5.0
       '@emnapi/runtime': 1.5.0
@@ -3887,56 +3895,56 @@ snapshots:
 
   '@oxc-project/runtime@0.92.0': {}
 
-  '@oxc-project/types@0.93.0': {}
+  '@oxc-project/types@0.94.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.41':
+  '@rolldown/binding-android-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.41':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.41':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.41':
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.41':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.41':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.41':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.42':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.5
+      '@napi-rs/wasm-runtime': 1.0.6
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.41':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.41':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.41':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.41': {}
+  '@rolldown/pluginutils@1.0.0-beta.42': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -4226,13 +4234,13 @@ snapshots:
       chai: 6.0.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.0-beta.13(rolldown-vite@7.1.15(@types/node@22.18.6)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.0-beta.13(rolldown-vite@7.1.16(@types/node@22.18.6)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.0-beta.13
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: rolldown-vite@7.1.15(@types/node@22.18.6)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.16(@types/node@22.18.6)(yaml@2.8.1)
 
   '@vitest/pretty-format@4.0.0-beta.13':
     dependencies:
@@ -5632,40 +5640,40 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rolldown-vite@7.1.15(@types/node@22.18.6)(yaml@2.8.1):
+  rolldown-vite@7.1.16(@types/node@22.18.6)(yaml@2.8.1):
     dependencies:
       '@oxc-project/runtime': 0.92.0
       fdir: 6.5.0(picomatch@4.0.3)
       lightningcss: 1.30.2
       picomatch: 4.0.3
       postcss: 8.5.6
-      rolldown: 1.0.0-beta.41
+      rolldown: 1.0.0-beta.42
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.18.6
       fsevents: 2.3.3
       yaml: 2.8.1
 
-  rolldown@1.0.0-beta.41:
+  rolldown@1.0.0-beta.42:
     dependencies:
-      '@oxc-project/types': 0.93.0
-      '@rolldown/pluginutils': 1.0.0-beta.41
+      '@oxc-project/types': 0.94.0
+      '@rolldown/pluginutils': 1.0.0-beta.42
       ansis: 4.2.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-beta.41
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.41
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.41
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.41
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.41
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.41
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.41
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.41
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.41
-      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.41
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.41
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.41
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.41
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.41
+      '@rolldown/binding-android-arm64': 1.0.0-beta.42
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.42
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.42
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.42
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.42
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.42
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.42
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.42
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.42
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.42
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.42
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.42
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.42
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.42
 
   run-parallel@1.2.0:
     dependencies:
@@ -5787,6 +5795,10 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.2.0
+
+  strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.0
 
@@ -5937,7 +5949,7 @@ snapshots:
   vitest@4.0.0-beta.13(@types/node@22.18.6)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.0-beta.13
-      '@vitest/mocker': 4.0.0-beta.13(rolldown-vite@7.1.15(@types/node@22.18.6)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.0-beta.13(rolldown-vite@7.1.16(@types/node@22.18.6)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.0-beta.13
       '@vitest/runner': 4.0.0-beta.13
       '@vitest/snapshot': 4.0.0-beta.13
@@ -5955,7 +5967,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 2.0.0
       tinyrainbow: 3.0.3
-      vite: rolldown-vite@7.1.15(@types/node@22.18.6)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.16(@types/node@22.18.6)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.6

--- a/vitest/vitest.color.config.ts
+++ b/vitest/vitest.color.config.ts
@@ -1,0 +1,33 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    cache: false,
+    clearMocks: true,
+    deps: {
+      interopDefault: false,
+    },
+    environment: 'node',
+    pool: 'forks',
+    testTimeout: 60000,
+    setupFiles: ['./vitest/silence-logging.ts', './helpers/npm/set-npm-userconfig.ts'],
+    watch: false,
+    coverage: {
+      include: ['packages/**/*.ts'],
+      exclude: [
+        ...configDefaults.exclude,
+        '**/dist/**',
+        '**/helpers/**',
+        '**/models/**',
+        '**/__fixtures__/**',
+        '**/__helpers__/**',
+        '**/__mocks__/**',
+        '**/__tests__/**',
+        '**/index.ts',
+        '**/interfaces.ts',
+        '**/models.ts',
+      ],
+      provider: 'v8',
+    },
+  },
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

in the npmlog package, we can replace `console-control-strings` and `color-support` with `tinyrainbow` (a fork of `picocolors`) which we already use in the core package and everywhere else

## Motivation and Context

We already use `tinyrainbow` in the core file and it's much smaller than these other 2 dependencies that are only used in npmlog package, so let's do the migration to use less and smaller deps. Since we already use `tinyrainbow` in the core, then this would pretty much mean that we would drop the equivalent of 2 dependencies.

Also in the next major version, we'll completely drop `tinyrainbow` and go with native code `util.styleText()` and so this is a good preparation towards that goal

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
