### PR TITLE
chore(tests): remove test flakiness by updating test

### DIFF
--- a/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
+++ b/packages/version/src/conventional-commits/__tests__/__snapshots__/conventional-commits.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`conventional-commits > updateChangelog() > creates changelog with chang
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 1.1.0 (YYYY-MM-DD)
+## 1.1.0 (YYYY-MM-DD)
 
 ### Features
 

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -496,8 +496,13 @@ describe('conventional-commits', () => {
 
       const [leafChangelogContent, rootChangelogContent] = await Promise.all([getFileContent(leafChangelog), getFileContent(rootChangelog)]);
 
-      expect(leafChangelogContent).toMatchSnapshot('leaf');
-      expect(rootChangelogContent).toMatchSnapshot('root');
+      // the snapshot test is a little flaky, it could be either (`# 1.1.0 (YYYY-MM-DD)` or `## 1.1.0 (YYYY-MM-DD)`)
+      // so let's normalize this version header line
+      const normalizedLeafContent = leafChangelogContent.replace(/^# (1\.1\.0 $\d{4}-\d{2}-\d{2}$)/m, '## $1');
+      const normalizedRootContent = rootChangelogContent.replace(/^# (1\.1\.0 $\d{4}-\d{2}-\d{2}$)/m, '## $1');
+
+      expect(normalizedLeafContent).toMatchSnapshot('leaf');
+      expect(normalizedRootContent).toMatchSnapshot('root');
     });
 
     it('updates fixed changelogs', async () => {

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -498,8 +498,8 @@ describe('conventional-commits', () => {
 
       // the snapshot test is a little flaky, it could be either (`# 1.1.0 (YYYY-MM-DD)` or `## 1.1.0 (YYYY-MM-DD)`)
       // so let's normalize this version header line
-      const normalizedLeafContent = leafChangelogContent.replace(/^# 1\.1\.0 \([0-9Y]{4}-[0-9M]{2}-[0-9D]{2}\)/m, '## $1');
-      const normalizedRootContent = rootChangelogContent.replace(/^# 1\.1\.0 \([0-9Y]{4}-[0-9M]{2}-[0-9D]{2}\)/m, '## $1');
+      const normalizedLeafContent = leafChangelogContent.replace(/^# (1\.1\.0 \([0-9Y]{4}-[0-9M]{2}-[0-9D]{2}\))/m, '## $1');
+      const normalizedRootContent = rootChangelogContent.replace(/^# (1\.1\.0 \([0-9Y]{4}-[0-9M]{2}-[0-9D]{2}\))/m, '## $1');
 
       expect(normalizedLeafContent).toMatchSnapshot('leaf');
       expect(normalizedRootContent).toMatchSnapshot('root');

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -498,8 +498,8 @@ describe('conventional-commits', () => {
 
       // the snapshot test is a little flaky, it could be either (`# 1.1.0 (YYYY-MM-DD)` or `## 1.1.0 (YYYY-MM-DD)`)
       // so let's normalize this version header line
-      const normalizedLeafContent = leafChangelogContent.replace(/^# (1\.1\.0 $\d{4}-\d{2}-\d{2}$)/m, '## $1');
-      const normalizedRootContent = rootChangelogContent.replace(/^# (1\.1\.0 $\d{4}-\d{2}-\d{2}$)/m, '## $1');
+      const normalizedLeafContent = leafChangelogContent.replace(/^# 1\.1\.0 \([0-9Y]{4}-[0-9M]{2}-[0-9D]{2}\)/m, '## $1');
+      const normalizedRootContent = rootChangelogContent.replace(/^# 1\.1\.0 \([0-9Y]{4}-[0-9M]{2}-[0-9D]{2}\)/m, '## $1');
 
       expect(normalizedLeafContent).toMatchSnapshot('leaf');
       expect(normalizedRootContent).toMatchSnapshot('root');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

remove test flakiness from conventional-changelog test file

## Motivation and Context

update the test to remove flakiness (it rarely failed remotely, though it does sometime, however it nearly always failed locally), with this code update the test with snapshot will pass with either an h1 or an h2 `# 1.1.0 (YYYY-MM-DD)` or `## 1.1.0 (YYYY-MM-DD)` 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
