### PR TITLE
feat(publish): support npm staged publishing via `--stage`

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -421,6 +421,9 @@
             "tempTag": {
               "$ref": "#/$defs/commandOptions/publish/tempTag"
             },
+            "stage": {
+              "$ref": "#/$defs/commandOptions/publish/stage"
+            },
             "noVerifyAccess": {
               "$ref": "#/$defs/commandOptions/publish/noVerifyAccess"
             },
@@ -1016,6 +1019,9 @@
     "tempTag": {
       "$ref": "#/$defs/commandOptions/publish/tempTag"
     },
+    "stage": {
+      "$ref": "#/$defs/commandOptions/publish/stage"
+    },
     "noVerifyAccess": {
       "$ref": "#/$defs/commandOptions/publish/noVerifyAccess"
     },
@@ -1362,6 +1368,10 @@
         "tempTag": {
           "type": "boolean",
           "description": "During `lerna publish`, when true, create a temporary tag while publishing."
+        },
+        "stage": {
+          "type": "boolean",
+          "description": "During `lerna publish`, when true, publish packages to the npm staging area instead of making them immediately available. The staged versions must later be approved by a maintainer (via `npm stage approve`) before becoming publicly installable. Note: this option is incompatible with `tempTag` since staged dist-tags are immutable."
         },
         "noVerifyAccess": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-publish-commands.ts
+++ b/packages/cli/src/cli-commands/cli-publish-commands.ts
@@ -121,6 +121,11 @@ export default {
         describe: 'Create a temporary tag while publishing.',
         type: 'boolean',
       },
+      stage: {
+        describe:
+          'Publish packages to the npm staging area instead of making them immediately available. The staged versions must later be approved by a maintainer (via `npm stage approve`) before becoming publicly installable.',
+        type: 'boolean',
+      },
       'no-verify-access': {
         // proxy for --verify-access
         describe: 'Do not verify package read-write access for current npm user.',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -438,6 +438,13 @@ export interface PublishCommandOption extends VersionCommandOption {
   /** Create a temporary tag while publishing. */
   tempTag?: boolean;
 
+  /**
+   * Publish packages to the npm staging area (npm staged publishing) instead of making them immediately available.
+   * The staged versions must later be approved by a maintainer (via `npm stage approve`) before becoming publicly installable.
+   * Note: this option is incompatible with `--temp-tag` since staged dist-tags are immutable.
+   */
+  stage?: boolean;
+
   /** Do not verify package read-write access for current npm user. */
   noVerifyAccess?: boolean;
 

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -421,8 +421,10 @@ npm stage approve <stageId>
 ```
 
 You can also list or reject staged versions with `npm stage list` and
-`npm stage reject`. When `--summary-file` is used, the generated summary will
-include the `stageId` for each staged package.
+`npm stage reject`. When `--stage` is used, lerna-lite prints the `stageId` of
+each staged package as well as a link to the npmjs.com **Staged Packages** page
+(where you can review and approve them with 2FA). When `--summary-file` is used,
+the generated summary will include the `stageId` for each staged package.
 
 > **Note:** `--stage` is not compatible with `--temp-tag` since staged
 dist-tags are immutable. A warning will be shown if both options are combined.

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -102,6 +102,7 @@ $ lerna publish --scope my-component test
     - [`--registry <url>`](#--registry-url)
     - [`--tag-version-prefix`](#--tag-version-prefix)
     - [`--temp-tag`](#--temp-tag)
+    - [`--stage`](#--stage)
     - [`--throttle`](#--throttle)
     - [`--summary-file <dir>`](#--summary-file)
     - [`--verify-access`](#--verify-access)
@@ -396,6 +397,36 @@ new version(s) to the dist-tag configured by [`--dist-tag`](#--dist-tag-tag) (de
 This is not generally necessary, as lerna will publish packages in topological
 order (all dependencies before dependents) by default.
 
+### `--stage`
+
+When passed, this flag will publish all changed packages to the npm staging
+area instead of making them immediately available. This is equivalent to
+running `npm stage publish` for each packed package while still applying
+lerna-lite's `publishConfig` manifest overrides, lifecycle scripts, provenance
+and OIDC pipeline.
+
+```sh
+lerna publish --stage
+lerna publish from-package --stage
+lerna publish from-git --stage
+```
+
+This is the recommended secure flow for CI/OIDC publishing: CI can stage
+tarballs without an interactive 2FA prompt, while final release approval still
+requires maintainer proof-of-presence. The staged versions must later be
+approved by a maintainer before becoming publicly installable:
+
+```sh
+npm stage approve <stageId>
+```
+
+You can also list or reject staged versions with `npm stage list` and
+`npm stage reject`. When `--summary-file` is used, the generated summary will
+include the `stageId` for each staged package.
+
+> **Note:** `--stage` is not compatible with `--temp-tag` since staged
+dist-tags are immutable. A warning will be shown if both options are combined.
+
 ### `--summary-file`
 
 ```sh
@@ -418,6 +449,18 @@ When run with this flag, a json summary report will be generated after all packa
   {
     "packageName": "package2",
     "version": "v2.0.1-alpha"
+  }
+]
+```
+
+When [`--stage`](#--stage) is also used, the summary will include the `stageId` of each staged package:
+
+```json
+[
+  {
+    "packageName": "package1",
+    "version": "v1.0.1-alpha",
+    "stageId": "123e4567-e89b-12d3-a456-426614174000"
   }
 ]
 ```

--- a/packages/publish/src/__tests__/npm-publish.spec.ts
+++ b/packages/publish/src/__tests__/npm-publish.spec.ts
@@ -233,6 +233,32 @@ describe('npm-publish', () => {
     );
   });
 
+  it('passes stage option through to libnpmpublish', async () => {
+    const opts = { stage: true };
+
+    await npmPublish(pkg, tarFilePath, opts, conf);
+
+    expect(publish).toHaveBeenCalledWith(
+      mockManifest,
+      mockTarData,
+      expect.objectContaining({
+        stage: true,
+      })
+    );
+  });
+
+  it('defaults stage to undefined when not provided', async () => {
+    await npmPublish(pkg, tarFilePath, {}, conf);
+
+    expect(publish).toHaveBeenCalledWith(
+      mockManifest,
+      mockTarData,
+      expect.not.objectContaining({
+        stage: true,
+      })
+    );
+  });
+
   it('calls publish lifecycles with stdio inherit', async () => {
     const options = expect.objectContaining({
       projectScope: '@scope',

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -728,11 +728,26 @@ describe('PublishCommand', () => {
 
       await new PublishCommand(createArgv(cwd, '--stage'));
 
-      expect(logOutput).toHaveBeenCalledWith('The following packages were staged for npm staged publishing (approve them with `npm stage approve`):');
+      expect(logOutput).toHaveBeenCalledWith(
+        'The following packages were staged for npm staged publishing. Approve each one with `npm stage approve <stageId>` (or review them on npmjs.com):'
+      );
       expect(logOutput).toHaveBeenCalledWith(expect.stringContaining('package-1: stage-111'));
       expect(logOutput).toHaveBeenCalledWith(expect.stringContaining('package-2: stage-333'));
       expect(logOutput).toHaveBeenCalledWith(expect.stringContaining('package-3: stage-444'));
       expect(logOutput).toHaveBeenCalledWith(expect.stringContaining('package-4: stage-222'));
+    });
+
+    it('prints the npmjs.com staged-packages web UI URL when the npm username is known', async () => {
+      const cwd = await initFixture('normal');
+      (npmPublish as typeof npmPublishMock)
+        .mockResolvedValueOnce({ stageId: 'stage-111' })
+        .mockResolvedValueOnce({ stageId: 'stage-222' })
+        .mockResolvedValueOnce({ stageId: 'stage-333' })
+        .mockResolvedValueOnce({ stageId: 'stage-444' });
+
+      await new PublishCommand(createArgv(cwd, '--stage'));
+
+      expect(logOutput).toHaveBeenCalledWith('Review & approve them at: https://www.npmjs.com/settings/lerna-test/staged-packages');
     });
 
     it('includes the stageId in the summary file', async () => {

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -695,6 +695,80 @@ describe('PublishCommand', () => {
     });
   });
 
+  describe('--stage', () => {
+    it('passes stage: true to npmPublish for every package', async () => {
+      const cwd = await initFixture('normal');
+
+      await new PublishCommand(createArgv(cwd, '--stage'));
+
+      expect(npmPublish).toHaveBeenCalledTimes(4);
+      for (const call of (npmPublish as Mock).mock.calls) {
+        expect(call[2]).toEqual(expect.objectContaining({ stage: true }));
+      }
+    });
+
+    it('does not set stage when the option is not provided', async () => {
+      const cwd = await initFixture('normal');
+
+      await new PublishCommand(createArgv(cwd));
+
+      expect(npmPublish).toHaveBeenCalledTimes(4);
+      for (const call of (npmPublish as Mock).mock.calls) {
+        expect(call[2]).toEqual(expect.not.objectContaining({ stage: true }));
+      }
+    });
+
+    it('prints the stageId returned by npmPublish', async () => {
+      const cwd = await initFixture('normal');
+      (npmPublish as typeof npmPublishMock)
+        .mockResolvedValueOnce({ stageId: 'stage-111' })
+        .mockResolvedValueOnce({ stageId: 'stage-222' })
+        .mockResolvedValueOnce({ stageId: 'stage-333' })
+        .mockResolvedValueOnce({ stageId: 'stage-444' });
+
+      await new PublishCommand(createArgv(cwd, '--stage'));
+
+      expect(logOutput).toHaveBeenCalledWith('The following packages were staged for npm staged publishing (approve them with `npm stage approve`):');
+      expect(logOutput).toHaveBeenCalledWith(expect.stringContaining('package-1: stage-111'));
+      expect(logOutput).toHaveBeenCalledWith(expect.stringContaining('package-2: stage-333'));
+      expect(logOutput).toHaveBeenCalledWith(expect.stringContaining('package-3: stage-444'));
+      expect(logOutput).toHaveBeenCalledWith(expect.stringContaining('package-4: stage-222'));
+    });
+
+    it('includes the stageId in the summary file', async () => {
+      const cwd = await initFixture('normal');
+      (npmPublish as typeof npmPublishMock)
+        .mockResolvedValueOnce({ stageId: 'stage-111' })
+        .mockResolvedValueOnce({ stageId: 'stage-222' })
+        .mockResolvedValueOnce({ stageId: 'stage-333' })
+        .mockResolvedValueOnce({ stageId: 'stage-444' });
+
+      await new PublishCommand(createArgv(cwd, '--stage', '--summary-file', './outputs'));
+
+      const expectedJsonResponse = [
+        { packageName: 'package-1', version: '1.0.1', stageId: 'stage-111' },
+        { packageName: 'package-2', version: '1.0.1', stageId: 'stage-333' },
+        { packageName: 'package-3', version: '1.0.1', stageId: 'stage-444' },
+        { packageName: 'package-4', version: '1.0.1', stageId: 'stage-222' },
+      ];
+      expect(outputFileSync).toHaveBeenCalledWith(
+        pathJoin(process.cwd(), 'outputs/lerna-publish-summary.json'),
+        JSON.stringify(expectedJsonResponse)
+      );
+    });
+
+    it('warns when combined with --temp-tag', async () => {
+      const cwd = await initFixture('normal');
+
+      await new PublishCommand(createArgv(cwd, '--stage', '--temp-tag'));
+
+      const logMessages = loggingOutput('warn');
+      expect(logMessages).toContain(
+        '--stage is not compatible with --temp-tag: staged dist-tags are immutable and the temporary tag will not be moved to the configured dist-tag after approval. Publishing will proceed with the staged tag.'
+      );
+    });
+  });
+
   describe('--verify-access', () => {
     beforeEach(() => {
       vi.clearAllMocks();

--- a/packages/publish/src/interfaces.ts
+++ b/packages/publish/src/interfaces.ts
@@ -26,6 +26,12 @@ export interface LibNpmPublishOptions extends KebabCase<fetch.FetchOptions> {
   /* Passed to libnpmpublish as `opts.defaultTag` to preserve npm v6 back-compat */
   tag?: string;
   registry?: string;
+  /**
+   * When true, publishes the package to the npm staging area instead of making it immediately available.
+   * The registry response will include a `stageId` (UUID) that can be used to approve or reject the staged version later.
+   * @see https://docs.npmjs.com/staged-publishing/
+   */
+  stage?: boolean;
 }
 
 export interface PackagePublishConfig {

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -80,6 +80,8 @@ export class PublishCommand extends Command<PublishCommandOption> {
   packagesToBeLicensed?: Package[] = [];
   /** Map of package name to npm staging `stageId` (UUID) when `--stage` is used */
   stageIds = new Map<string, string>();
+  /** npm username used to build the npmjs.com staged-packages web UI URL when `--stage` is used */
+  npmUsername?: string;
   runPackageLifecycle!: (pkg: Package, stage: string) => Promise<void>;
   runRootLifecycle!: (stage: string) => Promise<void> | void;
   verifyAccess?: boolean = false;
@@ -605,11 +607,22 @@ export class PublishCommand extends Command<PublishCommandOption> {
       return chain;
     }
 
+    // when staged publishing is enabled, fetch the npm username (best-effort) so we
+    // can build the npmjs.com staged-packages web UI URL shown in the publish output
+    if (this.options.stage && !this.options.dryRun && !this.verifyAccess) {
+      chain = chain.then(() => getNpmUsername(this.conf.snapshot).catch(() => undefined));
+      chain = chain.then((username: string | undefined) => {
+        this.npmUsername = username;
+      });
+    }
+
     if (this.verifyAccess) {
       // validate user has valid npm credentials first,
       // by far the most common form of failed execution
       chain = chain.then(() => getNpmUsername(this.conf.snapshot));
       chain = chain.then((username: string) => {
+        // keep the username around to build the staged-packages web UI URL when `--stage` is used
+        this.npmUsername = username;
         // if no username was retrieved, don't bother validating
         if (username) {
           return verifyNpmPackageAccess(this.packagesToPublish ?? [], username, this.conf.snapshot);
@@ -1029,9 +1042,15 @@ export class PublishCommand extends Command<PublishCommandOption> {
       }
       // print npm staging `stageId`(s) when staged publishing is enabled
       if (this.stageIds.size > 0) {
-        logOutput('The following packages were staged for npm staged publishing (approve them with `npm stage approve`):');
+        logOutput(
+          'The following packages were staged for npm staged publishing. Approve each one with `npm stage approve <stageId>` (or review them on npmjs.com):'
+        );
         const message = Array.from(this.stageIds.entries()).map(([pkg, stageId]) => ` - ${pkg}: ${stageId}`);
         logOutput(message.join(EOL));
+        // a single actionable link to the npmjs.com staged-packages web UI when we know the username
+        if (this.npmUsername && this.conf.get('registry') === 'https://registry.npmjs.org/') {
+          logOutput(`Review & approve them at: https://www.npmjs.com/settings/${this.npmUsername}/staged-packages`);
+        }
       }
       tracker.finish();
     });

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -78,6 +78,8 @@ export class PublishCommand extends Command<PublishCommandOption> {
   packagesToPublish: Package[] = [];
   publishedPackages: Package[] = [];
   packagesToBeLicensed?: Package[] = [];
+  /** Map of package name to npm staging `stageId` (UUID) when `--stage` is used */
+  stageIds = new Map<string, string>();
   runPackageLifecycle!: (pkg: Package, stage: string) => Promise<void>;
   runRootLifecycle!: (stage: string) => Promise<void> | void;
   verifyAccess?: boolean = false;
@@ -161,6 +163,13 @@ export class PublishCommand extends Command<PublishCommandOption> {
       throw new ValidationError('ENOTSATISFIED', 'Cannot use --build-metadata in conjunction with --canary option.');
     } else if (this.options.canary) {
       this.logger.info('canary', 'enabled');
+    }
+
+    if (this.options.stage && this.options.tempTag) {
+      this.logger.warn(
+        'stage',
+        '--stage is not compatible with --temp-tag: staged dist-tags are immutable and the temporary tag will not be moved to the configured dist-tag after approval. Publishing will proceed with the staged tag.'
+      );
     }
 
     // npmSession and user-agent are consumed by npm-registry-fetch (via libnpmpublish)
@@ -293,7 +302,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
       await this.resetChanges();
     }
 
-    if (this.options.tempTag) {
+    if (this.options.tempTag && !this.options.stage) {
       await this.npmUpdateAsLatest();
     }
 
@@ -310,10 +319,16 @@ export class PublishCommand extends Command<PublishCommandOption> {
     if (this.options.summaryFile !== undefined) {
       const filePath = this.getSummaryFilePath();
       const jsonObject = publishedPackagesSorted.map((pkg) => {
-        return {
+        const summary: { packageName: string; version: string; stageId?: string } = {
           packageName: pkg.name,
           version: pkg.version,
         };
+        // include the npm staging `stageId` when staged publishing is enabled
+        const stageId = this.stageIds.get(pkg.name);
+        if (stageId) {
+          summary.stageId = stageId;
+        }
+        return summary;
       });
       logOutput(jsonObject);
       try {
@@ -907,6 +922,8 @@ export class PublishCommand extends Command<PublishCommandOption> {
       // if we skip temp tags we should tag with the proper value immediately
       tag: this.options.tempTag ? 'lerna-temp' : this.conf.get('tag'),
       'git-dry-run': this.options.dryRun || false,
+      // npm staged publishing: upload tarballs to the staging area instead of publishing immediately
+      stage: this.options.stage || false,
     });
 
     let q: Queue | undefined = undefined;
@@ -938,6 +955,11 @@ export class PublishCommand extends Command<PublishCommandOption> {
         // Collect provenance URL if present
         if (publishResult?.transparencyLogUrl) {
           provenanceUrls.set(pkg.name, publishResult.transparencyLogUrl);
+        }
+
+        // Collect npm staging `stageId` when staged publishing is enabled
+        if (publishResult?.stageId) {
+          this.stageIds.set(pkg.name, publishResult.stageId);
         }
 
         tracker.success('published', pkg.name, pkg.version);
@@ -1003,6 +1025,12 @@ export class PublishCommand extends Command<PublishCommandOption> {
       if (provenanceUrls.size > 0) {
         logOutput('The following Provenance transparency log entries were created during publishing:');
         const message = Array.from(provenanceUrls.entries()).map(([pkg, url]) => ` - ${pkg}: ${url}`);
+        logOutput(message.join(EOL));
+      }
+      // print npm staging `stageId`(s) when staged publishing is enabled
+      if (this.stageIds.size > 0) {
+        logOutput('The following packages were staged for npm staged publishing (approve them with `npm stage approve`):');
+        const message = Array.from(this.stageIds.entries()).map(([pkg, stageId]) => ` - ${pkg}: ${stageId}`);
         logOutput(message.join(EOL));
       }
       tracker.finish();


### PR DESCRIPTION
Closes #1398

## Summary

Adds support for npm [staged publishing](https://docs.npmjs.com/staged-publishing/) to `lerna publish` via a new `--stage` boolean option (also configurable in `lerna.json` under `command.publish.stage`).

When enabled, lerna-lite runs the normal versioning, packing, `publishConfig` overrides, lifecycle, provenance and OIDC pipeline, but calls `libnpmpublish.publish()` with `stage: true` — equivalent to `npm stage publish` for each packed package. This lets monorepos combine lerna-lite's `publishConfig` manifest overrides with npm's staged-publishing + Trusted Publishing (stage-only) security model.

## Changes

- **`packages/core`**: add `stage?: boolean` to `PublishCommandOption`
- **`packages/cli`**: add `--stage` to the publish command builder + JSON schema
- **`packages/publish`**:
  - add `stage?: boolean` to `LibNpmPublishOptions`
  - pass `stage` through `npmPublish()` → `libnpmpublish`
  - capture the `stageId` returned by the registry and print each one to the console, along with a single link to the npmjs.com **Staged Packages** page (`https://www.npmjs.com/settings/<user>/staged-packages`) for review/approval
  - include `stageId` in the `--summary-file` JSON output
  - warn when `--stage` is combined with `--temp-tag` (staged dist-tags are immutable) and skip the temp-tag dance in that case
- **docs**: document `--stage` in the publish README

## Usage

```sh
lerna publish --stage
lerna publish from-package --stage
lerna publish from-git --stage
```

```json
{
  "command": {
    "publish": {
      "stage": true
    }
  }
}
```

## Notes

Approval is per-`stageId` — there is no bulk approve. Each staged package is approved individually with 2FA via `npm stage approve <stage-id>` or the npmjs.com **Staged Packages** tab. `npm stage list <pkg>` can filter by package name. `npm stage approve` / `reject` / `list` remain registry-management actions performed via the npm CLI — the lerna-lite need is only staging during the existing monorepo publish flow.

## Testing

- Added unit tests for `npmPublish` (stage passthrough) and `PublishCommand` (stage flag, stageId console output + web UI URL, stageId in summary file, temp-tag warning)
- `pnpm lint`, `pnpm lint-type`, `pnpm format:check`, `pnpm build` and the full `pnpm test` suite (1727 tests) all pass
