### PR TITLE
fix(version): support modern changelog preset writer guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/node": "catalog:devDependencies",
     "@types/yargs": "^17.0.35",
     "@vitest/coverage-v8": "^5.0.0-rc.2",
-    "conventional-changelog-conventionalcommits": "^10.3.0",
+    "conventional-changelog-conventionalcommits": "^10.4.0",
     "cross-env": "^10.1.0",
     "empathic": "^2.0.1",
     "eslint-plugin-local-import-ext": "0.2.0",

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset-template.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset-template.ts
@@ -1,0 +1,14 @@
+import parserOpts from './parser-opts.js';
+import whatBump from './what-bump.js';
+import writerOpts from './writer-opts.js';
+
+const { mainTemplate, ...legacyWriterOpts } = writerOpts;
+
+export default {
+  parser: parserOpts,
+  whatBump,
+  writer: {
+    ...legacyWriterOpts,
+    template: mainTemplate,
+  },
+};

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/preset-without-template.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/preset-without-template.ts
@@ -1,0 +1,10 @@
+import parserOpts from './parser-opts.js';
+import whatBump from './what-bump.js';
+
+export default {
+  parser: parserOpts,
+  whatBump,
+  writer: {
+    groupBy: 'type',
+  },
+};

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -585,6 +585,25 @@ describe('conventional-commits', () => {
       expect(changelogContent).toContain('feat: support function-based preset writer partials');
     });
 
+    it('supports modern presets with a legacy writer guard', async () => {
+      const cwd = (await initFixture('fixed')) as string;
+      const [pkg1] = await Project.getPackages(cwd);
+
+      await gitTag(cwd, 'v1.0.0');
+
+      await pkg1.set('changed', 1).serialize();
+      await gitAdd(cwd, pkg1.manifestLocation);
+      await gitCommit(cwd, 'feat: support modern preset writer guards');
+
+      await pkg1.set('version', '1.0.1').serialize();
+
+      const changelog = await updateChangelog(pkg1, 'fixed', {
+        changelogPreset: 'conventionalcommits',
+      });
+
+      expect(changelog.newEntry).toContain('support modern preset writer guards');
+    });
+
     it('updates fixed changelogs', async () => {
       const cwd = await initFixture('fixed');
       const rootPkg = {

--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -560,6 +560,20 @@ describe('conventional-commits', () => {
       expect(changelogContent).toContain('<a name="1.0.1"></a>');
     });
 
+    it('supports preset writer templates defined as strings', async () => {
+      const cwd = await initFixture('fixed');
+      const config = await GetChangelogConfig.getChangelogConfig('./scripts/local-preset-template', cwd);
+
+      expect(config.writer?.template).toBeTypeOf('function');
+    });
+
+    it('supports preset writers without a template', async () => {
+      const cwd = await initFixture('fixed');
+      const config = await GetChangelogConfig.getChangelogConfig('./scripts/preset-without-template', cwd);
+
+      expect(config.writer).toMatchObject({ groupBy: 'type' });
+    });
+
     it('supports preset writer partials defined as functions mixed with a string mainTemplate', async () => {
       const cwd = (await initFixture('fixed')) as string;
 

--- a/packages/version/src/conventional-commits/get-changelog-config.ts
+++ b/packages/version/src/conventional-commits/get-changelog-config.ts
@@ -17,7 +17,13 @@ function normalizeWriterConfig(config: ChangelogConfig): ChangelogConfig {
   // Legacy preset compatibility shim.
   // Remove this entire branch in the next major when we require function-based templates only.
   const legacyTemplateSource =
-    typeof writer.template === 'string' ? writer.template : typeof writer.mainTemplate === 'string' ? writer.mainTemplate : '';
+    typeof writer.template === 'string'
+      ? writer.template
+      : typeof writer.template === 'function'
+        ? ''
+        : typeof writer.mainTemplate === 'string'
+          ? writer.mainTemplate
+          : '';
 
   if (legacyTemplateSource) {
     const handlebars = Handlebars.create();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: ^5.0.0-rc.2
         version: 5.0.0-rc.2(vitest@5.0.0-rc.2)
       conventional-changelog-conventionalcommits:
-        specifier: ^10.3.0
-        version: 10.3.0
+        specifier: ^10.4.0
+        version: 10.4.0
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -640,6 +640,10 @@ packages:
 
   '@conventional-changelog/template@1.3.0':
     resolution: {integrity: sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==}
+    engines: {node: '>=22'}
+
+  '@conventional-changelog/template@1.4.0':
+    resolution: {integrity: sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==}
     engines: {node: '>=22'}
 
   '@cypress/request@4.0.1':
@@ -1892,8 +1896,8 @@ packages:
     resolution: {integrity: sha512-0MWQLVUT1oVCsUGs9aAWteBVxPlLwJTn5VbQH7B0B3fDizZgrJ9QGnKl/2mp1+5P7153GCBCjO/v1aKJ6eysCg==}
     engines: {node: '>=22'}
 
-  conventional-changelog-conventionalcommits@10.3.0:
-    resolution: {integrity: sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==}
+  conventional-changelog-conventionalcommits@10.4.0:
+    resolution: {integrity: sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==}
     engines: {node: '>=22'}
 
   conventional-changelog-preset-loader@6.0.1:
@@ -3751,6 +3755,8 @@ snapshots:
 
   '@conventional-changelog/template@1.3.0': {}
 
+  '@conventional-changelog/template@1.4.0': {}
+
   '@cypress/request@4.0.1':
     dependencies:
       aws-sign2: 0.7.0
@@ -4922,9 +4928,9 @@ snapshots:
     dependencies:
       '@conventional-changelog/template': 1.3.0
 
-  conventional-changelog-conventionalcommits@10.3.0:
+  conventional-changelog-conventionalcommits@10.4.0:
     dependencies:
-      '@conventional-changelog/template': 1.3.0
+      '@conventional-changelog/template': 1.4.0
 
   conventional-changelog-preset-loader@6.0.1: {}
 


### PR DESCRIPTION
## Description

Update changelog preset normalization to preserve modern function-based templates when presets also expose a legacy `mainTemplate` compatibility guard.

Upgrade the test preset to `conventional-changelog-conventionalcommits@10.4.0`.

## Motivation and Context

`conventional-changelog-conventionalcommits@10.4.0` adds a legacy-writer guard through `mainTemplate`. Lerna-Lite incorrectly interpreted this as a legacy template and triggered a false compatibility error, even when `conventional-changelog-writer@9` was installed.

## How Has This Been Tested?

- 50 conventional-commits tests passed.
- Added a regression test covering `conventionalcommits@10.4.0`.
- Formatting check passed.
- Oxlint passed.
- TypeScript build passed.
- The full suite could not complete because sandbox restrictions blocked unrelated child-process and registry tests.

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.