### PR TITLE
fix(core): prevent prototype pollution in config handling

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,6 +26,12 @@
       "problemMatcher": []
     },
     {
+      "label": "Run Vitest E2E tests",
+      "type": "shell",
+      "command": "pnpm run test:e2e",
+      "problemMatcher": []
+    },
+    {
       "label": "[dry-run] new Version (from dist)",
       "type": "shell",
       "command": "pnpm run dist-roll-version-dry-run",

--- a/packages/core/src/project/__tests__/apply-extends.spec.ts
+++ b/packages/core/src/project/__tests__/apply-extends.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { applyExtends } from '../lib/apply-extends.js';
+
+describe('applyExtends', () => {
+  afterEach(() => {
+    delete (Object.prototype as any).polluted;
+    delete (Object as any).polluted;
+    delete (Object.prototype.toString as any).polluted;
+  });
+
+  it('merges ordinary nested configuration', () => {
+    const result = applyExtends({ command: { version: { yes: true } } }, process.cwd());
+
+    expect(result).toEqual({ command: { version: { yes: true } } });
+  });
+
+  it('stores __proto__ as an ordinary own property without polluting Object.prototype', () => {
+    const input = JSON.parse('{"__proto__":{"polluted":true}}');
+
+    const result = applyExtends(input, process.cwd());
+
+    expect((Object.prototype as any).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(Object.getOwnPropertyDescriptor(result, '__proto__')?.value).toEqual({ polluted: true });
+  });
+
+  it('stores constructor as an ordinary own property without modifying Object', () => {
+    const input = JSON.parse('{"constructor":{"polluted":true}}');
+
+    const result = applyExtends(input, process.cwd());
+
+    expect((Object as any).polluted).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(result, 'constructor')?.value).toEqual({ polluted: true });
+  });
+
+  it('stores toString as an ordinary own property without modifying the built-in function', () => {
+    const input = JSON.parse('{"toString":{"polluted":true}}');
+
+    const result = applyExtends(input, process.cwd());
+
+    expect((Object.prototype.toString as any).polluted).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(result, 'toString')?.value).toEqual({ polluted: true });
+  });
+});

--- a/packages/core/src/project/lib/shallow-extend.ts
+++ b/packages/core/src/project/lib/shallow-extend.ts
@@ -8,13 +8,26 @@ export function shallowExtend(json: { [key: string]: any }, defaults: { [key: st
 
     if (Array.isArray(val)) {
       // always clobber arrays, merging isn't worth unexpected complexity
-      obj[key] = val.slice();
+      defineOwnProperty(obj, key, val.slice());
     } else if (val && typeof val === 'object') {
-      obj[key] = shallowExtend(val, obj[key]);
+      // Never recurse into an inherited property. Special keys such as
+      // "__proto__", "constructor", and "toString" otherwise resolve to
+      // built-in objects and allow configuration data to mutate them.
+      const currentValue = Object.hasOwn(obj, key) ? obj[key] : {};
+      defineOwnProperty(obj, key, shallowExtend(val, currentValue));
     } else {
-      obj[key] = val;
+      defineOwnProperty(obj, key, val);
     }
 
     return obj;
   }, defaults);
+}
+
+function defineOwnProperty(target: { [key: string]: any }, key: string, value: any) {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
 }

--- a/packages/core/src/utils/__tests__/conf.spec.ts
+++ b/packages/core/src/utils/__tests__/conf.spec.ts
@@ -9,6 +9,18 @@ import * as defaults from '../defaults.js';
 import { toNerfDart } from '../npm-conf.js';
 
 describe('conf', () => {
+  describe('add()', () => {
+    it.each(['__proto__', 'constructor', 'toString'])('should preserve the special key %s as an own config property', (key) => {
+      const conf = new Conf(Object.assign({}, defaults));
+      const data = JSON.parse(`{"${key}":{"enabled":true}}`);
+
+      conf.add(data, 'cli');
+
+      expect(Object.hasOwn(data, key)).toBe(true);
+      expect(conf.get(key, 'cli')).toEqual({ enabled: true });
+    });
+  });
+
   describe('addEnv()', () => {
     it('should skip npm_config_ env variables with empty/falsy values', () => {
       const conf = new Conf(Object.assign({}, defaults));

--- a/packages/core/src/utils/__tests__/config-chain.spec.ts
+++ b/packages/core/src/utils/__tests__/config-chain.spec.ts
@@ -15,6 +15,9 @@ describe('ConfigChain', () => {
   });
 
   afterEach(() => {
+    delete (Object.prototype as any).data;
+    delete (Object as any).data;
+    delete (Object.prototype.toString as any).data;
     vi.clearAllMocks();
   });
 
@@ -53,6 +56,21 @@ describe('ConfigChain', () => {
     it('should return this for chaining', () => {
       const result = cc.add({ foo: 'bar' }, 'test');
       expect(result).toBe(cc);
+    });
+
+    it.each([
+      ['__proto__', Object.prototype],
+      ['constructor', Object],
+      ['toString', Object.prototype.toString],
+    ])('should store the special source name %s without modifying its inherited built-in', (sourceName, builtIn) => {
+      const data = { foo: 'bar' };
+
+      cc.add(data, sourceName as string);
+
+      expect(Object.getPrototypeOf(cc.sources)).toBeNull();
+      expect(Object.hasOwn(cc.sources, sourceName)).toBe(true);
+      expect(cc.sources[sourceName].data).toBe(data);
+      expect(Object.hasOwn(builtIn, 'data')).toBe(false);
     });
 
     it('should replace marker placeholder with data (like addFile pattern)', () => {
@@ -151,6 +169,15 @@ describe('ConfigChain', () => {
     it('should throw error if source does not exist', () => {
       expect(() => cc.set('foo', 'bar', 'newsource')).toThrow('not found newsource');
     });
+
+    it.each(['__proto__', 'constructor', 'toString'])('should store the special key %s as an own property', (key) => {
+      cc.add({}, 'test');
+
+      cc.set(key, 'value', 'test');
+
+      expect(cc.get(key, 'test')).toBe('value');
+      expect(Object.hasOwn(cc.sources.test.data!, key)).toBe(true);
+    });
   });
 
   describe('del', () => {
@@ -242,6 +269,16 @@ describe('ConfigChain', () => {
       expect(snap.__source__).toBeUndefined();
       expect(snap.foo).toBe('bar'); // Regular data comes through
     });
+
+    it('should copy __proto__ as an own property without changing the snapshot prototype', () => {
+      cc.add(JSON.parse('{"__proto__":{"polluted":true}}'), 'test');
+
+      const snap = cc.snapshot;
+
+      expect(Object.getPrototypeOf(snap)).toBe(Object.prototype);
+      expect(Object.getOwnPropertyDescriptor(snap, '__proto__')?.value).toEqual({ polluted: true });
+      expect((Object.prototype as any).polluted).toBeUndefined();
+    });
   });
 
   describe('addEnv', () => {
@@ -285,6 +322,25 @@ describe('ConfigChain', () => {
     it('should return this for chaining', () => {
       const result = cc.addEnv('test_', {});
       expect(result).toBe(cc);
+    });
+
+    it('should ignore inherited environment properties', () => {
+      const env = Object.create({ test_inherited: 'ignored' });
+      env.test_own = 'included';
+
+      cc.addEnv('test_', env);
+
+      expect(cc.get('own')).toBe('included');
+      expect(cc.get('inherited')).toBeUndefined();
+    });
+
+    it('should preserve __proto__ from the environment as an own config property', () => {
+      const env = JSON.parse('{"test___proto__":"value"}');
+
+      cc.addEnv('test_', env);
+
+      expect(cc.get('__proto__')).toBe('value');
+      expect(Object.hasOwn(cc.sources.env.data!, '__proto__')).toBe(true);
     });
   });
 
@@ -512,5 +568,14 @@ f=1.23
     expect(parsed.d).toBeUndefined();
     expect(parsed.e).toBe(123);
     expect(parsed.f).toBeCloseTo(1.23);
+  });
+
+  it.each(['__proto__', 'constructor', 'toString'])('parses the special key %s as an own property', (key) => {
+    const cc = new ConfigChain();
+
+    const parsed = cc.parse(`${key}=value`, 'test.ini');
+
+    expect(Object.hasOwn(parsed, key)).toBe(true);
+    expect(parsed[key]).toBe('value');
   });
 });

--- a/packages/core/src/utils/conf.ts
+++ b/packages/core/src/utils/conf.ts
@@ -32,7 +32,12 @@ export class Conf extends ConfigChain {
       const newField = parseField(data[x], newKey);
 
       delete data[x];
-      data[newKey] = newField;
+      Object.defineProperty(data, newKey, {
+        configurable: true,
+        enumerable: true,
+        value: newField,
+        writable: true,
+      });
     }
 
     return super.add(data, marker);

--- a/packages/core/src/utils/config-chain.ts
+++ b/packages/core/src/utils/config-chain.ts
@@ -39,7 +39,7 @@ function parseIni(content: string): Record<string, any> {
         value = parseFloat(value);
       }
 
-      result[key] = value;
+      defineOwnProperty(result, key, value);
     }
   }
 
@@ -53,7 +53,7 @@ function parseIni(content: string): Record<string, any> {
 export class ConfigChain {
   list: Array<Record<string, any>> = [];
   base: Record<string, any> = {};
-  sources: Record<string, { path?: string; type?: string; data?: Record<string, any> }> = {};
+  sources: Record<string, { path?: string; type?: string; data?: Record<string, any> }> = Object.create(null);
 
   constructor(base?: Record<string, any>) {
     if (base) {
@@ -107,7 +107,7 @@ export class ConfigChain {
       }
     }
 
-    target[key] = value;
+    defineOwnProperty(target, key, value);
     return this;
   }
 
@@ -139,7 +139,7 @@ export class ConfigChain {
   add(data: Record<string, any>, marker?: string | { __source__: string }): this {
     const sourceName = typeof marker === 'string' ? marker : marker?.__source__;
 
-    if (marker && typeof marker === 'object' && '__source__' in marker) {
+    if (marker && typeof marker === 'object' && Object.hasOwn(marker, '__source__')) {
       // Replace placeholder marker with actual data
       const i = this.list.indexOf(marker as any);
       if (i !== -1) {
@@ -190,8 +190,8 @@ export class ConfigChain {
     const prefixLength = prefix.length;
 
     for (const key in env) {
-      if (key.indexOf(prefix) === 0 && env[key] !== undefined) {
-        data[key.substring(prefixLength)] = env[key];
+      if (Object.hasOwn(env, key) && key.indexOf(prefix) === 0 && env[key] !== undefined) {
+        defineOwnProperty(data, key.substring(prefixLength), env[key]);
       }
     }
 
@@ -233,16 +233,31 @@ export class ConfigChain {
     const result: Record<string, any> = {};
 
     if (this.base) {
-      Object.assign(result, this.base);
+      assignOwnProperties(result, this.base);
     }
 
     for (let i = this.list.length - 1; i >= 0; i--) {
       const config = this.list[i];
-      if (config && typeof config === 'object' && !('__source__' in config)) {
-        Object.assign(result, config);
+      if (config && typeof config === 'object' && !Object.hasOwn(config, '__source__')) {
+        assignOwnProperties(result, config);
       }
     }
 
     return result;
   }
+}
+
+function assignOwnProperties(target: Record<string, any>, source: Record<string, any>) {
+  for (const key of Object.keys(source)) {
+    defineOwnProperty(target, key, source[key]);
+  }
+}
+
+function defineOwnProperty(target: Record<string, any>, key: string, value: any) {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
 }


### PR DESCRIPTION
## Description

Harden project and npm configuration handling against prototype pollution.

- Prevent recursive configuration merges from traversing inherited properties.
- Store special keys such as `__proto__`, `constructor`, and `toString` as ordinary own properties.
- Use a prototype-free dictionary for configuration source names.
- Safely copy configuration properties into snapshots and parsed configuration objects.
- Ignore inherited properties when reading environment configuration.
- Add focused regression tests covering malicious and ordinary keys.

## Motivation and Context

Externally controlled configuration keys could resolve to inherited JavaScript properties instead of creating new entries.

During recursive project configuration merging, this could modify `Object.prototype`, `Object`, or inherited built-in functions. Special configuration source names could similarly modify built-in objects through the source registry.

These changes prevent those mutations while preserving normal object behavior and existing configuration merge semantics.

## AI Model
Analysis, reproduction verification, and remediation assistance were
provided using OpenAI Codex 5.6 Sol.

## How Has This Been Tested?

Tested with Node.js 24 using:

- Focused security tests: 111 passed.
- Complete `@lerna-lite/core` suite: 679 passed, 2 skipped.
- TypeScript core build and complete packages build.
- Oxlint on all modified files.
- Oxfmt formatting checks.
- Generated JavaScript reproductions for `__proto__`, `constructor`, and `toString`.
- `git diff --check`.

The complete monorepo test run reached 1,734 passing tests and 6 skipped tests. Fifteen unrelated environment-dependent tests failed in untouched npmlog, pnpm, and publish paths.

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.