### PR TITLE
fix(version): relax GitHub comment rate limiting

### DIFF
--- a/packages/version/src/__tests__/comment-resolved-items.spec.ts
+++ b/packages/version/src/__tests__/comment-resolved-items.spec.ts
@@ -693,7 +693,7 @@ describe('commentResolvedItems', () => {
     expect(uniqueNumbers).toContain(457);
 
     // Verify that each unique number appears only once in the results
-    const numberCounts = results.reduce((acc, result) => {
+    const numberCounts = results.reduce((acc: { [key: number]: number }, result) => {
       acc[result.number] = (acc[result.number] || 0) + 1;
       return acc;
     }, {});

--- a/packages/version/src/lib/comment-resolved-items.ts
+++ b/packages/version/src/lib/comment-resolved-items.ts
@@ -153,10 +153,10 @@ export async function commentResolvedItems({
   const hostURL = `https://${repo.host}/${repository}`;
   const releaseUrl = getReleaseUrlFallback(repo.host, repository, tag);
 
-  // Create a rate limiter for GitHub API
+  // Keep a healthy buffer below GitHub's documented content-creation guidance
+  // while avoiding the much more restrictive Search API pacing.
   const rateLimiter = new RateLimiter({
-    maxCalls: 30, // 30 calls per minute
-    firstRunMaxCalls: 26, // call/min since we need to remove 4 calls that were called earlier (1x graphql, 1x linked issues, 1x all isssues, 1x PRs)
+    maxCalls: 50, // 50 comment creations per minute leaves margin below GitHub's documented 80/minute guidance
     perMilliseconds: 60000, // per minute
   });
 


### PR DESCRIPTION
## Description

Reduce the GitHub comment throttling used by `commentResolvedItems()` so release comment posting completes faster for larger batches of issues and pull requests.

This change increases the limiter from 30 comments per minute to 50 comments per minute and removes the reduced first-pass limit that was subtracting earlier search/GraphQL requests from the comment budget.

## Motivation and Context

Commenting on resolved issues and PRs was slower than necessary because the current limiter was pacing comment creation similarly to GitHub's Search API rate limit.

GitHub documents a separate search rate limit and a higher general content-creation limit for comment creation, so the previous 30/minute limit was more conservative than needed. Moving to 50/minute keeps a reasonable safety buffer while improving release-time throughput.

## How Has This Been Tested?

Ran the targeted test suite for this code path:

- `./node_modules/.bin/vitest run packages/version/src/__tests__/comment-resolved-items.spec.ts --config ./vitest/vitest.config.ts`

Results:

- `1` test file passed
- `16` tests passed

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.