### PR TITLE
feat(publish): support opt-in npm web authentication (2FA security key) when publishing

### DIFF
--- a/e2e/publish/publish-web-auth.spec.ts
+++ b/e2e/publish/publish-web-auth.spec.ts
@@ -1,0 +1,179 @@
+import { once } from 'node:events';
+import { writeFile } from 'node:fs/promises';
+import { createServer, type IncomingHttpHeaders, type Server, type ServerResponse } from 'node:http';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Fixture } from '../../e2e-utils/src/index.js';
+
+interface FakeRegistry {
+  authUrl: string;
+  close: () => Promise<void>;
+  donePolls: () => number;
+  publishRequests: IncomingHttpHeaders[];
+  registry: string;
+}
+
+describe('lerna-publish with web authentication', () => {
+  let fixture: Fixture;
+  let fakeRegistry: FakeRegistry;
+
+  beforeEach(async () => {
+    fakeRegistry = await createFakeRegistry();
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT!,
+      name: 'lerna-publish-web-auth',
+      packageManager: 'npm',
+      initializeGit: true,
+      lernaInit: true,
+      installDependencies: false,
+    });
+  });
+
+  afterEach(async () => {
+    await fixture.destroy();
+    await fakeRegistry.close();
+  });
+
+  it('completes a registry web-auth challenge and retries publish with the returned OTP', async () => {
+    await preparePublish('web-auth-e2e');
+
+    const result = await runPublish('--auth-type web');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.combinedOutput).toContain(fakeRegistry.authUrl);
+    expect(fakeRegistry.donePolls()).toBe(2);
+    expect(fakeRegistry.publishRequests).toHaveLength(2);
+    expect(fakeRegistry.publishRequests[0]).toMatchObject({
+      authorization: 'Bearer test-token',
+      'npm-auth-type': 'web',
+      'npm-command': 'publish',
+    });
+    expect(fakeRegistry.publishRequests[0]['npm-otp']).toBeUndefined();
+    expect(fakeRegistry.publishRequests[1]).toMatchObject({
+      'npm-auth-type': 'web',
+      'npm-command': 'publish',
+      'npm-otp': 'web-otp-token',
+    });
+  });
+
+  it('uses legacy authentication when an OTP is supplied explicitly', async () => {
+    await preparePublish('explicit-otp-e2e');
+
+    const result = await runPublish('--auth-type web --otp 123456');
+
+    expect(result.exitCode).toBe(0);
+    expect(fakeRegistry.donePolls()).toBe(0);
+    expect(fakeRegistry.publishRequests).toHaveLength(1);
+    expect(fakeRegistry.publishRequests[0]).toMatchObject({
+      'npm-auth-type': 'legacy',
+      'npm-command': 'publish',
+      'npm-otp': '123456',
+    });
+  });
+
+  async function preparePublish(packageName: string): Promise<void> {
+    await fixture.createPackage({ name: packageName, version: '1.0.0' });
+    await writeFile(
+      fixture.getWorkspacePath('.npmrc'),
+      `registry=${fakeRegistry.registry}
+//${new URL(fakeRegistry.registry).host}/:_authToken=test-token
+browser=false
+`
+    );
+    await fixture.createInitialGitCommit();
+    await fixture.exec('git tag v1.0.0');
+  }
+
+  async function runPublish(args: string) {
+    const lernaPath = join(process.cwd(), 'packages', 'cli', 'dist', 'cli.js');
+    const wrapperPath = fixture.getWorkspacePath('run-lerna-with-tty.mjs');
+    await writeFile(
+      wrapperPath,
+      `Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+await import(${JSON.stringify(pathToFileURL(lernaPath).href)});
+`
+    );
+
+    return fixture.exec(`node ${wrapperPath} publish from-git --registry=${fakeRegistry.registry} -y ${args}`, {
+      silenceError: true,
+    });
+  }
+});
+
+async function createFakeRegistry(): Promise<FakeRegistry> {
+  const publishRequests: IncomingHttpHeaders[] = [];
+  let donePolls = 0;
+  let registry = '';
+
+  const server = createServer((request, response) => {
+    request.resume();
+    request.once('end', () => {
+      const url = new URL(request.url ?? '/', registry);
+
+      if (request.method === 'GET' && url.pathname === '/-/web-auth/done') {
+        donePolls++;
+        if (donePolls === 1) {
+          sendJson(response, 202, { pending: true }, { 'retry-after': '0.001' });
+        } else {
+          sendJson(response, 200, { token: 'web-otp-token' });
+        }
+        return;
+      }
+
+      if (request.method === 'PUT') {
+        publishRequests.push(request.headers);
+
+        if (request.headers['npm-otp'] || request.headers['npm-auth-type'] !== 'web') {
+          sendJson(response, 201, { ok: true });
+          return;
+        }
+
+        sendJson(
+          response,
+          401,
+          {
+            error: 'one-time pass required',
+            authUrl: `${registry}-/web-auth/login`,
+            doneUrl: `${registry}-/web-auth/done`,
+          },
+          { 'www-authenticate': 'OTP' }
+        );
+        return;
+      }
+
+      sendJson(response, 404, { error: 'not found' });
+    });
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Fake registry did not bind to a TCP port');
+  }
+  registry = `http://127.0.0.1:${address.port}/`;
+
+  return {
+    authUrl: `${registry}-/web-auth/login`,
+    close: () => closeServer(server),
+    donePolls: () => donePolls,
+    publishRequests,
+    registry,
+  };
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown, headers: Record<string, string> = {}): void {
+  response.writeHead(status, { 'content-type': 'application/json', ...headers });
+  response.end(JSON.stringify(body));
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -355,6 +355,9 @@
             "arboristLoadOptions": {
               "$ref": "#/$defs/commandOptions/publish/arboristLoadOptions"
             },
+            "authType": {
+              "$ref": "#/$defs/commandOptions/publish/authType"
+            },
             "canary": {
               "$ref": "#/$defs/commandOptions/publish/canary"
             },
@@ -992,6 +995,9 @@
     "canary": {
       "$ref": "#/$defs/commandOptions/publish/canary"
     },
+    "authType": {
+      "$ref": "#/$defs/commandOptions/publish/authType"
+    },
     "distTag": {
       "$ref": "#/$defs/commandOptions/publish/distTag"
     },
@@ -1306,6 +1312,12 @@
         "arboristLoadOptions": {
           "type": "object",
           "description": "During `lerna publish`, Arborist options associated to the `arborist.loadActual(options)` method."
+        },
+        "authType": {
+          "type": "string",
+          "enum": ["legacy", "web"],
+          "description": "During `lerna publish`, authentication flow to use for npm registry requests.",
+          "default": "legacy"
         },
         "canary": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-publish-commands.ts
+++ b/packages/cli/src/cli-commands/cli-publish-commands.ts
@@ -19,6 +19,12 @@ export default {
   describe: 'Publish packages in the current project.',
   builder: (yargs: any) => {
     const opts = {
+      'auth-type': {
+        choices: ['legacy', 'web'],
+        defaultDescription: 'legacy',
+        describe: 'Authentication flow to use for npm registry requests.',
+        type: 'string',
+      },
       c: {
         describe: 'Publish packages after every successful merge using the sha as part of the tag.',
         alias: 'canary',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -365,6 +365,9 @@ export interface PublishCommandOption extends VersionCommandOption {
    */
   arboristLoadOptions?: ArboristLoadOption;
 
+  /** Authentication flow to use for npm registry requests. */
+  authType?: 'legacy' | 'web';
+
   /** alias to `--canary` */
   c?: boolean;
 

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -13,7 +13,7 @@ export const types = {
   also: [null, 'dev', 'development'],
   audit: Boolean,
   'audit-level': ['low', 'moderate', 'high', 'critical'],
-  'auth-type': ['legacy', 'sso', 'saml', 'oauth'],
+  'auth-type': ['legacy', 'web', 'sso', 'saml', 'oauth'],
   'bin-links': Boolean,
   browser: [null, String],
   ca: [null, String, Array],

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -82,6 +82,7 @@ $ lerna publish --scope my-component test
     - [semver `--bump from-git`](#semver---bump-from-git)
     - [semver `--bump from-package`](#semver---bump-from-package)
   - [Options](#options)
+    - [`--auth-type`](#--auth-type)
     - [`--arborist-load-options`](#--arborist-load-options)
     - [`--canary`](#--canary)
     - [`--cleanup-temp-files`](#--cleanup-temp-files)    
@@ -236,6 +237,22 @@ Configured via `lerna.json`:
 }
 ```
 
+### `--auth-type`
+
+Lerna-Lite uses the `legacy` npm authentication flow by default. Accounts that use a security key or passkey for two-factor authentication can opt into browser-based authentication:
+
+```sh
+lerna publish --auth-type web
+```
+
+When the npm registry requests two-factor authentication, Lerna-Lite prints the authentication URL, opens it in the configured browser, and waits for the challenge to complete before retrying the publish. Set npm's `browser` config to `false` to print the URL without opening a browser:
+
+```sh
+npm_config_browser=false lerna publish --auth-type web
+```
+
+The option can also be configured as `authType: "web"` under `command.publish` in `lerna.json`, or as `auth-type=web` in `.npmrc`. Supplying `--otp` always selects the legacy flow.
+
 ### `--ignore-scripts`
 
 When passed, this flag will disable running [lifecycle scripts](#lifecycle-scripts) during `lerna publish`.
@@ -288,6 +305,8 @@ lerna publish --otp 123456
 ```
 
 > Please keep in mind that one-time passwords expire within 30 seconds of their generation. If it expires during publish operations, a prompt will request a refreshed value before continuing.
+
+Security keys and passkeys do not provide a code to enter. Use [`--auth-type web`](#--auth-type) for those accounts.
 
 ### `--preid`
 

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -368,7 +368,7 @@ describe('PublishCommand', () => {
       expect(npmPublish).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'package-1' }),
         '/TEMP_DIR/package-1-MOCKED.tgz',
-        expect.objectContaining({ otp }),
+        expect.objectContaining({ authType: 'legacy', otp }),
         expect.objectContaining({ root: expect.any(Object) }),
         expect.objectContaining({ otp })
       );
@@ -439,6 +439,68 @@ describe('PublishCommand', () => {
         expect.objectContaining({ otp: undefined })
       );
       expect(getOneTimePassword).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('--auth-type', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('keeps legacy registry authentication as the default', async () => {
+      const testDir = await initFixture('normal');
+
+      await new PublishCommand(createArgv(testDir));
+
+      expect(npmPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'package-1' }),
+        '/TEMP_DIR/package-1-MOCKED.tgz',
+        expect.objectContaining({
+          'auth-type': 'legacy',
+          authType: 'legacy',
+          npmCommand: 'publish',
+          userAgent: expect.stringMatching(/^lerna\//),
+        }),
+        expect.objectContaining({ root: expect.any(Object) }),
+        expect.objectContaining({ otp: undefined })
+      );
+    });
+
+    it('advertises web authentication when explicitly requested', async () => {
+      const testDir = await initFixture('normal');
+
+      await new PublishCommand(createArgv(testDir, '--auth-type', 'web'));
+
+      expect(npmPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'package-1' }),
+        '/TEMP_DIR/package-1-MOCKED.tgz',
+        expect.objectContaining({ 'auth-type': 'web', authType: 'web', npmCommand: 'publish' }),
+        expect.objectContaining({ root: expect.any(Object) }),
+        expect.objectContaining({ otp: undefined })
+      );
+    });
+
+    it('does not preemptively request a typed OTP in web mode', async () => {
+      const testDir = await initFixture('normal');
+      (getTwoFactorAuthRequired as Mock).mockResolvedValueOnce(true);
+
+      await new PublishCommand(createArgv(testDir, '--auth-type', 'web', '--verify-access'));
+
+      expect(getOneTimePassword).not.toHaveBeenCalled();
+    });
+
+    it('forces legacy authentication when an OTP is supplied', async () => {
+      const testDir = await initFixture('normal');
+
+      await new PublishCommand(createArgv(testDir, '--auth-type', 'web', '--otp', '123456'));
+
+      expect(npmPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'package-1' }),
+        '/TEMP_DIR/package-1-MOCKED.tgz',
+        expect.objectContaining({ 'auth-type': 'legacy', authType: 'legacy', otp: 123456 }),
+        expect.objectContaining({ root: expect.any(Object) }),
+        expect.objectContaining({ otp: 123456 })
+      );
     });
   });
 
@@ -575,12 +637,12 @@ describe('PublishCommand', () => {
       const auth = Buffer.from(data).toString('base64');
 
       // await lernaPublish(testDir)("--legacy-auth", auth);
-      await new PublishCommand(createArgv(testDir, '--legacy-auth', auth));
+      await new PublishCommand(createArgv(testDir, '--legacy-auth', auth, '--auth-type', 'web'));
 
       expect(npmPublish).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'package-1' }),
         '/TEMP_DIR/package-1-MOCKED.tgz',
-        expect.objectContaining({ 'auth-type': 'legacy', _auth: auth }),
+        expect.objectContaining({ 'auth-type': 'web', authType: 'web', _auth: auth }),
         expect.objectContaining({ root: expect.any(Object) }),
         expect.objectContaining({ otp: undefined })
       );

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -174,15 +174,19 @@ export class PublishCommand extends Command<PublishCommandOption> {
       );
     }
 
-    // npmSession and user-agent are consumed by npm-registry-fetch (via libnpmpublish)
+    // npmSession, npmCommand, and userAgent are consumed by npm-registry-fetch
+    // (via libnpmpublish) and sent as request headers.
     this.logger.verbose('session', this.npmSession);
     this.logger.verbose('user-agent', this.userAgent);
 
     this.conf = npmConf({
       lernaCommand: 'publish',
       _auth: this.options.legacyAuth,
+      'auth-type': this.options.authType,
       npmSession: this.npmSession,
+      npmCommand: 'publish',
       npmVersion: this.userAgent,
+      userAgent: this.userAgent,
       otp: this.options.otp,
       registry: this.options.registry,
       'ignore-prepublish': this.options.ignorePrepublish,
@@ -191,6 +195,14 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
     // cache to hold a one-time-password across publishes
     this.otpCache = { otp: this.conf.get('otp') };
+
+    // Keep browser-based authentication opt-in for backwards compatibility.
+    // An explicit OTP always uses the classic authentication flow.
+    if (this.otpCache.otp) {
+      this.conf.set('auth-type', 'legacy', 'cli');
+    }
+    const authType = this.conf.get('auth-type') === 'web' ? 'web' : 'legacy';
+    this.conf.set('authType', authType, 'cli');
 
     this.conf.set('user-agent', this.userAgent, 'cli');
 
@@ -926,7 +938,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
     let chain: Promise<any> = Promise.resolve();
 
     // if account-level 2FA is enabled, prime the OTP cache
-    if (this.twoFactorAuthRequired) {
+    if (this.twoFactorAuthRequired && this.conf.get('authType') !== 'web') {
       chain = chain.then(() => this.requestOneTimePassword());
     }
 
@@ -982,7 +994,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
         return pkg;
       } catch (err: any) {
-        if (err.code === 'EOTP') {
+        if (err.code === 'EOTP' && this.conf.get('authType') !== 'web') {
           this.logger.warn('OTP expired, requesting a new OTP...');
           await this.requestOneTimePassword(); // Re-request OTP
           return pulseTillDone(

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -47,6 +47,7 @@
     "git-url-parse": "^16.1.0",
     "handlebars": "^4.7.9",
     "npm-package-arg": "catalog:",
+    "npm-registry-fetch": "catalog:",
     "verkit": "catalog:",
     "write-json-file": "catalog:dependencies",
     "zeptomatch": "catalog:dependencies"

--- a/packages/version/src/utils/__tests__/otplease.spec.ts
+++ b/packages/version/src/utils/__tests__/otplease.spec.ts
@@ -2,10 +2,15 @@ import { promptTextInput } from '@lerna-lite/core';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 import { getOneTimePassword, otplease } from '../otplease.js';
+import { getWebAuthOneTimePassword } from '../web-auth.js';
 
 vi.mock('@lerna-lite/core', async () => ({
   ...(await vi.importActual<any>('@lerna-lite/core')), // return the other real methods, below we'll mock only 2 of the methods
   promptTextInput: (await vi.importActual<any>('../../../../core/src/__mocks__/prompt')).promptTextInput,
+}));
+vi.mock('../web-auth.js', async () => ({
+  ...(await vi.importActual('../web-auth.js')),
+  getWebAuthOneTimePassword: vi.fn(),
 }));
 
 // global mock setup
@@ -55,6 +60,30 @@ describe('@lerna/otplease', () => {
     expect(promptTextInput).toHaveBeenCalled();
     expect(result).toBe(obj);
     expect(otpCache.otp).toBe('123456');
+  });
+
+  it('completes a web authentication challenge and caches its token', async () => {
+    const otpCache = { otp: undefined };
+    const result = {};
+    const authUrl = 'https://www.npmjs.com/auth/cli/abc123';
+    const doneUrl = 'https://registry.npmjs.org/-/v1/done?sessionId=abc123';
+    const opts = { registry: 'https://registry.npmjs.org/' };
+    const fn = vi.fn((requestOpts: { otp?: string }) => {
+      if (requestOpts.otp === 'web-otp-token') {
+        return result;
+      }
+      throw Object.assign(new Error('OTP required for authentication'), {
+        code: 'EOTP',
+        body: { authUrl, doneUrl },
+      });
+    });
+
+    (getWebAuthOneTimePassword as Mock).mockResolvedValueOnce('web-otp-token');
+
+    await expect(otplease(fn as any, opts, otpCache)).resolves.toBe(result);
+    expect(getWebAuthOneTimePassword).toHaveBeenCalledWith({ authUrl, doneUrl }, expect.objectContaining(opts));
+    expect(promptTextInput).not.toHaveBeenCalled();
+    expect(otpCache.otp).toBe('web-otp-token');
   });
 
   it('uses cache if opts does not have own otp', async () => {

--- a/packages/version/src/utils/__tests__/web-auth.spec.ts
+++ b/packages/version/src/utils/__tests__/web-auth.spec.ts
@@ -11,12 +11,16 @@ vi.mock('npm-registry-fetch');
 
 const mockedFetch = fetch as unknown as Mock;
 
-type FakeChild = EventEmitter & { unref: Mock };
+interface FakeChild {
+  on: (event: string, listener: (...args: unknown[]) => void) => FakeChild;
+  emit: (event: string, ...args: unknown[]) => boolean;
+  unref: Mock;
+}
 let spawnSpy: ReturnType<typeof vi.spyOn>;
 let spawnedChildren: FakeChild[];
 
 function fakeChild(): FakeChild {
-  const child = new EventEmitter() as FakeChild;
+  const child = new EventEmitter() as unknown as FakeChild;
   child.unref = vi.fn();
   spawnedChildren.push(child);
   return child;
@@ -57,6 +61,7 @@ describe('web-auth', () => {
     it('rejects incomplete, unsafe, and non-EOTP challenges', () => {
       expect(getWebAuthChallenge({ code: 'EOTP', body: { authUrl } })).toBeUndefined();
       expect(getWebAuthChallenge({ code: 'EOTP', body: { authUrl: 'javascript:alert(1)', doneUrl } })).toBeUndefined();
+      expect(getWebAuthChallenge({ code: 'EOTP', body: { authUrl: 'https://[invalid', doneUrl } })).toBeUndefined();
       expect(getWebAuthChallenge({ code: 'E404', body: { authUrl, doneUrl } })).toBeUndefined();
       expect(getWebAuthChallenge(undefined)).toBeUndefined();
     });
@@ -101,6 +106,24 @@ describe('web-auth', () => {
       expect(spawnSpy).toHaveBeenCalledWith('firefox', [challenge.authUrl], expect.objectContaining({ stdio: 'ignore', windowsHide: true }));
     });
 
+    it('uses the Windows start command when running on Windows', async () => {
+      const platform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      mockedFetch.mockResolvedValueOnce(response(200, { token: 'web-otp-token' }));
+
+      try {
+        await getWebAuthOneTimePassword(challenge, opts);
+      } finally {
+        Object.defineProperty(process, 'platform', { value: platform });
+      }
+
+      expect(spawnSpy).toHaveBeenCalledWith(
+        'start',
+        ['""', `"${challenge.authUrl}"`],
+        expect.objectContaining({ shell: true, stdio: 'ignore', windowsHide: true })
+      );
+    });
+
     it('does not fail or change the exit code when the browser opener fails', async () => {
       const verbose = vi.spyOn(log, 'verbose').mockImplementation(() => log);
       const exitCode = process.exitCode;
@@ -112,6 +135,17 @@ describe('web-auth', () => {
       await expect(pending).resolves.toBe('web-otp-token');
       expect(process.exitCode).toBe(exitCode);
       expect(verbose).toHaveBeenCalledWith('web-auth', expect.stringContaining('ENOENT'));
+    });
+
+    it('does not fail when the browser opener exits unsuccessfully', async () => {
+      const verbose = vi.spyOn(log, 'verbose').mockImplementation(() => log);
+      mockedFetch.mockResolvedValueOnce(response(200, { token: 'web-otp-token' }));
+
+      const pending = getWebAuthOneTimePassword(challenge, opts);
+      spawnedChildren[0].emit('exit', 127);
+
+      await expect(pending).resolves.toBe('web-otp-token');
+      expect(verbose).toHaveBeenCalledWith('web-auth', expect.stringContaining('exited with code 127'));
     });
 
     it('does not fail when spawning the browser throws synchronously', async () => {

--- a/packages/version/src/utils/__tests__/web-auth.spec.ts
+++ b/packages/version/src/utils/__tests__/web-auth.spec.ts
@@ -1,0 +1,138 @@
+import childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+import { log } from '@lerna-lite/npmlog';
+import fetch from 'npm-registry-fetch';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { getWebAuthChallenge, getWebAuthOneTimePassword } from '../web-auth.js';
+
+vi.mock('npm-registry-fetch');
+
+const mockedFetch = fetch as unknown as Mock;
+
+type FakeChild = EventEmitter & { unref: Mock };
+let spawnSpy: ReturnType<typeof vi.spyOn>;
+let spawnedChildren: FakeChild[];
+
+function fakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.unref = vi.fn();
+  spawnedChildren.push(child);
+  return child;
+}
+
+function response(status: number, body?: unknown, headers: Record<string, string> = {}) {
+  return {
+    status,
+    headers: new Headers(headers),
+    json: () => Promise.resolve(body),
+  };
+}
+
+describe('web-auth', () => {
+  beforeEach(() => {
+    spawnedChildren = [];
+    spawnSpy = vi.spyOn(childProcess, 'spawn').mockImplementation(() => fakeChild() as never);
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    vi.resetAllMocks();
+  });
+
+  describe('getWebAuthChallenge()', () => {
+    const authUrl = 'https://www.npmjs.com/auth/cli/abc123';
+    const doneUrl = 'https://registry.npmjs.org/-/v1/done?sessionId=abc123';
+
+    it('returns a valid challenge from an EOTP error', () => {
+      const error = Object.assign(new Error('OTP required for authentication'), {
+        code: 'EOTP',
+        body: { authUrl, doneUrl },
+      });
+
+      expect(getWebAuthChallenge(error)).toEqual({ authUrl, doneUrl });
+    });
+
+    it('rejects incomplete, unsafe, and non-EOTP challenges', () => {
+      expect(getWebAuthChallenge({ code: 'EOTP', body: { authUrl } })).toBeUndefined();
+      expect(getWebAuthChallenge({ code: 'EOTP', body: { authUrl: 'javascript:alert(1)', doneUrl } })).toBeUndefined();
+      expect(getWebAuthChallenge({ code: 'E404', body: { authUrl, doneUrl } })).toBeUndefined();
+      expect(getWebAuthChallenge(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('getWebAuthOneTimePassword()', () => {
+    const challenge = {
+      authUrl: 'https://www.npmjs.com/auth/cli/abc123',
+      doneUrl: 'https://registry.npmjs.org/-/v1/done?sessionId=abc123',
+    };
+    const opts = {
+      registry: 'https://registry.npmjs.org/',
+      '//registry.npmjs.org/:_authToken': 'token',
+    };
+
+    it('opens the authentication URL and polls until a token is returned', async () => {
+      mockedFetch
+        .mockResolvedValueOnce(response(202, undefined, { 'retry-after': '0.001' }))
+        .mockResolvedValueOnce(response(200, { token: 'web-otp-token' }));
+
+      await expect(getWebAuthOneTimePassword(challenge, opts)).resolves.toBe('web-otp-token');
+
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(spawnedChildren[0].unref).toHaveBeenCalled();
+      expect(mockedFetch).toHaveBeenCalledTimes(2);
+      expect(mockedFetch).toHaveBeenLastCalledWith(challenge.doneUrl, expect.objectContaining({ ...opts, method: 'GET', cache: false }));
+    });
+
+    it('does not open a browser when npm browser config is false', async () => {
+      mockedFetch.mockResolvedValueOnce(response(200, { token: 'web-otp-token' }));
+
+      await expect(getWebAuthOneTimePassword(challenge, { ...opts, browser: false })).resolves.toBe('web-otp-token');
+
+      expect(spawnSpy).not.toHaveBeenCalled();
+    });
+
+    it('uses a configured browser command', async () => {
+      mockedFetch.mockResolvedValueOnce(response(200, { token: 'web-otp-token' }));
+
+      await getWebAuthOneTimePassword(challenge, { ...opts, browser: 'firefox' });
+
+      expect(spawnSpy).toHaveBeenCalledWith('firefox', [challenge.authUrl], expect.objectContaining({ stdio: 'ignore', windowsHide: true }));
+    });
+
+    it('does not fail or change the exit code when the browser opener fails', async () => {
+      const verbose = vi.spyOn(log, 'verbose').mockImplementation(() => log);
+      const exitCode = process.exitCode;
+      mockedFetch.mockResolvedValueOnce(response(200, { token: 'web-otp-token' }));
+
+      const pending = getWebAuthOneTimePassword(challenge, opts);
+      spawnedChildren[0].emit('error', Object.assign(new Error('spawn xdg-open ENOENT'), { code: 'ENOENT' }));
+
+      await expect(pending).resolves.toBe('web-otp-token');
+      expect(process.exitCode).toBe(exitCode);
+      expect(verbose).toHaveBeenCalledWith('web-auth', expect.stringContaining('ENOENT'));
+    });
+
+    it('does not fail when spawning the browser throws synchronously', async () => {
+      spawnSpy.mockImplementation(() => {
+        throw new Error('EACCES');
+      });
+      mockedFetch.mockResolvedValueOnce(response(200, { token: 'web-otp-token' }));
+
+      await expect(getWebAuthOneTimePassword(challenge, opts)).resolves.toBe('web-otp-token');
+    });
+
+    it('rejects a successful response without a token', async () => {
+      mockedFetch.mockResolvedValueOnce(response(200, { nope: true }));
+
+      await expect(getWebAuthOneTimePassword(challenge, opts)).rejects.toThrow('expected a token');
+    });
+
+    it('rejects an unexpected response status', async () => {
+      mockedFetch.mockResolvedValueOnce(response(204));
+
+      await expect(getWebAuthOneTimePassword(challenge, opts)).rejects.toThrow('unexpected status 204');
+    });
+  });
+});

--- a/packages/version/src/utils/otplease.ts
+++ b/packages/version/src/utils/otplease.ts
@@ -1,6 +1,8 @@
 import { promptTextInput } from '@lerna-lite/core';
+import { log } from '@lerna-lite/npmlog';
 
 import type { OneTimePasswordCache } from '../interfaces.js';
+import { getWebAuthChallenge, getWebAuthOneTimePassword } from './web-auth.js';
 
 // basic single-entry semaphore
 const semaphore: any = {
@@ -30,7 +32,9 @@ const semaphore: any = {
 };
 
 /**
- * Attempt to execute Promise callback, prompting for OTP if necessary.
+ * Attempt to execute Promise callback, obtaining an OTP if necessary.
+ * Security key and passkey challenges are completed in a browser, while
+ * classic authenticator challenges prompt for a one-time password.
  * @template {Record<string, unknown>} T
  * @param {(opts: T) => Promise<unknown>} fn
  * @param {T} _opts The options to be passed to `fn`
@@ -72,7 +76,7 @@ function attempt<T extends Record<string, unknown>>(
           semaphore.release();
           return attempt(fn, { ...opts, ...otpCache }, otpCache);
         }
-        return getOneTimePassword()
+        return requestOneTimePassword(err, opts)
           .then(
             (otp) => {
               // update the otp and release the lock so that waiting
@@ -95,6 +99,17 @@ function attempt<T extends Record<string, unknown>>(
       });
     }
   });
+}
+
+function requestOneTimePassword(error: unknown, opts: Record<string, unknown>): Promise<string> {
+  const challenge = getWebAuthChallenge(error);
+
+  if (challenge) {
+    return getWebAuthOneTimePassword(challenge, opts);
+  }
+
+  log.silly('otplease', 'registry did not offer a web-auth challenge, prompting for a one-time password');
+  return getOneTimePassword();
 }
 
 /**

--- a/packages/version/src/utils/web-auth.ts
+++ b/packages/version/src/utils/web-auth.ts
@@ -1,0 +1,127 @@
+import childProcess from 'node:child_process';
+
+import { log } from '@lerna-lite/npmlog';
+import fetch from 'npm-registry-fetch';
+
+export interface WebAuthChallenge {
+  authUrl: string;
+  doneUrl: string;
+}
+
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
+/** Return a browser-based authentication challenge from an npm EOTP error. */
+export function getWebAuthChallenge(error: unknown): WebAuthChallenge | undefined {
+  const { code, body } = (error ?? {}) as { code?: unknown; body?: unknown };
+
+  if (code !== 'EOTP' || body === null || typeof body !== 'object') {
+    return undefined;
+  }
+
+  const { authUrl, doneUrl } = body as { authUrl?: unknown; doneUrl?: unknown };
+
+  if (!isHttpUrl(authUrl) || !isHttpUrl(doneUrl)) {
+    return undefined;
+  }
+
+  return { authUrl, doneUrl };
+}
+
+/** Open the challenge in a browser, poll for its token, and return that token as an OTP. */
+export async function getWebAuthOneTimePassword(
+  { authUrl, doneUrl }: WebAuthChallenge,
+  opts: Record<string, unknown>
+): Promise<string> {
+  log.notice('', 'This operation requires two-factor authentication. Authenticate your account at:');
+  log.notice('', authUrl);
+
+  // Browser opening is best-effort. The URL is printed first so users in SSH,
+  // containers, or other headless environments can open it themselves.
+  openInBrowser(authUrl, opts.browser);
+
+  return pollForToken(doneUrl, opts);
+}
+
+function isHttpUrl(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  try {
+    return /^https?:$/.test(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}
+
+function openInBrowser(url: string, browser: unknown): void {
+  if (browser === false) {
+    return;
+  }
+
+  const onError = (error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    log.verbose('web-auth', `Unable to open browser automatically: ${message}`);
+  };
+
+  // The registry URL is passed as one argument. Encoding it prevents shell
+  // metacharacters from being interpreted by the Windows `start` command.
+  const target = encodeURI(url);
+
+  try {
+    const child =
+      typeof browser === 'string'
+        ? childProcess.spawn(browser, [target], { stdio: 'ignore', windowsHide: true })
+        : process.platform === 'win32'
+          ? childProcess.spawn('start', ['""', `"${target}"`], {
+              shell: true,
+              stdio: 'ignore',
+              windowsHide: true,
+            })
+          : childProcess.spawn(process.platform === 'darwin' ? 'open' : 'xdg-open', [target], {
+              stdio: 'ignore',
+            });
+
+    child.on('error', onError);
+    child.on('exit', (code) => {
+      if (code) {
+        onError(new Error(`opener exited with code ${code}`));
+      }
+    });
+    child.unref();
+  } catch (error) {
+    onError(error);
+  }
+}
+
+async function pollForToken(doneUrl: string, opts: Record<string, unknown>): Promise<string> {
+  while (true) {
+    const response = await fetch(doneUrl, {
+      ...opts,
+      method: 'GET',
+      // The challenge completion endpoint must never be served from cache.
+      cache: false,
+    } as fetch.FetchOptions);
+
+    if (response.status === 200) {
+      const content = (await response.json()) as { token?: unknown };
+
+      if (typeof content.token !== 'string' || !content.token) {
+        throw new Error(`Invalid response from ${doneUrl}: expected a token`);
+      }
+
+      return content.token;
+    }
+
+    if (response.status === 202) {
+      const retryAfter = Number(response.headers.get('retry-after'));
+      const delay = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : DEFAULT_RETRY_DELAY_MS;
+
+      log.silly('web-auth', `authentication pending, retrying in ${delay}ms`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      continue;
+    }
+
+    throw new Error(`Invalid response from ${doneUrl}: unexpected status ${response.status}`);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,9 @@ importers:
       npm-package-arg:
         specifier: 'catalog:'
         version: 13.0.2
+      npm-registry-fetch:
+        specifier: 'catalog:'
+        version: 19.1.1(supports-color@7.2.0)
       verkit:
         specifier: 'catalog:'
         version: 0.4.0


### PR DESCRIPTION
## Description

Add support for npm’s browser-based authentication flow during `lerna publish`.

- Add the `--auth-type web` publish option.
- Keep `legacy` authentication as the default for backward compatibility.
- Send the `npm-auth-type`, `npm-command`, and `user-agent` headers expected by npm.
- Detect web-auth challenges returned in `EOTP` responses.
- Print and open the authentication URL, respecting npm’s `browser=false` configuration.
- Poll the challenge completion URL and retry publishing with the returned OTP token.
- Cache the token across concurrent package publishes.
- Force legacy authentication when `--otp` is explicitly supplied.
- Update the CLI schema, command types, publish documentation, and dependencies.

This adapts the functionality proposed in https://github.com/lerna/lerna/pull/4417 while intentionally retaining Lerna-Lite’s existing `legacy` default.

## Motivation and Context

npm accounts secured with security keys or passkeys cannot provide a numeric OTP during publishing. These accounts require npm’s browser-based authentication challenge.

Without this support, `lerna publish` falls back to requesting an OTP that the user cannot provide. Users can now opt into the appropriate flow with:

```sh
lerna publish --auth-type web
```

The flow can also be configured with `authType: "web"` under `command.publish` in `lerna.json`, or with `auth-type=web` in `.npmrc`.

## How Has This Been Tested?

Tested locally on Windows with Node.js and pnpm.

- Package TypeScript build passed.
- Formatting checks passed.
- Standard and type-aware lint checks passed.
- Focused CLI, publish-command, `otplease`, and web-auth unit tests passed.
- Added end-to-end tests using a local fake npm registry.
- The end-to-end tests verify:
  - npm web-auth request headers.
  - Handling an npm-style `EOTP` web challenge.
  - Polling the completion endpoint.
  - Retrying publish with the returned OTP token.
  - Falling back to legacy authentication when `--otp` is supplied.
- Publish web-auth e2e tests passed: 2/2.
- Publish dry-run e2e tests passed: 2/2.

A local broad unit-suite run passed 1,745 tests. The remaining 18 failures were outside this change and involved unavailable registry access, pnpm command timeouts, Windows ANSI expectations, and a temporary fixture-file race. All new and focused authentication tests passed.

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
